### PR TITLE
Allow buffer and queue initialization from lowlevel types

### DIFF
--- a/include/boost/compute/buffer.hpp
+++ b/include/boost/compute/buffer.hpp
@@ -32,6 +32,11 @@ public:
     {
     }
 
+    buffer(const cl_mem &mem)
+        : memory_object(mem)
+    {
+    }
+
     buffer(const context &context,
            size_t size,
            cl_mem_flags flags = read_write,
@@ -105,12 +110,6 @@ public:
         return buf;
     }
     #endif // BOOST_COMPUTE_HAVE_GL
-
-protected:
-    buffer(const cl_mem &mem)
-        : memory_object(mem)
-    {
-    }
 };
 
 } // end compute namespace

--- a/include/boost/compute/command_queue.hpp
+++ b/include/boost/compute/command_queue.hpp
@@ -51,6 +51,14 @@ public:
     {
     }
 
+    command_queue(cl_command_queue queue)
+        : m_queue(queue)
+    {
+        if(m_queue){
+            clRetainCommandQueue(m_queue);
+        }
+    }
+
     command_queue(const context &context,
                   const device &device,
                   cl_command_queue_properties properties = 0)


### PR DESCRIPTION
This commit adds compute::command_queue constructor from cl_command_queue and makes compute::buffer(cl_mem) constructor public.

This would allow to use Boost.Compute algorithms from externally initialized OpenCL contexts.
