### PR TITLE
Changes to FindOpenCL.cmake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_MODULE_PATH ${BoostCompute_SOURCE_DIR}/cmake)
 
 # find OpenCL
 find_package(OpenCL REQUIRED)
-include_directories(${OpenCL_INCLUDE_DIRS})
+include_directories(${OPENCL_INCLUDE_DIRS})
 
 # find Boost
 find_package(Boost 1.46 REQUIRED)

--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -1,17 +1,15 @@
 # - Try to find OpenCL
 # This module tries to find an OpenCL implementation on your system. It supports
-# AMD / ATI, Apple and NVIDIA implementations, but should work, too.
+# AMD / ATI, Apple and NVIDIA implementations.
 #
-# To set manually the paths, define these environment variables:
+# To set the paths manually, define these environment variables:
 # OpenCL_INCPATH    - Include path (e.g. OpenCL_INCPATH=/opt/cuda/4.0/cuda/include)
 # OpenCL_LIBPATH    - Library path (e.h. OpenCL_LIBPATH=/usr/lib64/nvidia)
 #
 # Once done this will define
-#  OPENCL_FOUND        - system has OpenCL
-#  OpenCL_INCLUDE_DIRS  - the OpenCL include directory
-#  OpenCL_LIBRARY    - link these to use OpenCL
-#
-# WIN32 should work, but is untested
+#  OPENCL_FOUND         - system has OpenCL
+#  OPENCL_INCLUDE_DIRS  - the OpenCL include directory
+#  OPENCL_LIBRARIES     - link these to use OpenCL
 
 FIND_PACKAGE(PackageHandleStandardArgs)
 
@@ -22,8 +20,8 @@ SET (OPENCL_VERSION_PATCH 0)
 
 IF (APPLE)
 
-    FIND_LIBRARY(OpenCL_LIBRARY OpenCL DOC "OpenCL lib for OSX")
-    FIND_PATH(OpenCL_INCLUDE_DIRS OpenCL/cl.h DOC "Include for OpenCL on OSX")
+    FIND_LIBRARY(OPENCL_LIBRARIES OpenCL DOC "OpenCL lib for OSX")
+    FIND_PATH(OPENCL_INCLUDE_DIRS OpenCL/cl.h DOC "Include for OpenCL on OSX")
     FIND_PATH(_OPENCL_CPP_INCLUDE_DIRS OpenCL/cl.hpp DOC "Include for OpenCL CPP bindings on OSX")
 
 ELSE (APPLE)
@@ -37,13 +35,13 @@ ELSE (APPLE)
 	    SET(OPENCL_LIB_DIR "$ENV{AMDAPPSDKROOT}/lib/x86")
 	ENDIF( CMAKE_SIZEOF_VOID_P EQUAL 8 )
 
-	FIND_LIBRARY(OpenCL_LIBRARY OpenCL.lib PATHS
+	FIND_LIBRARY(OPENCL_LIBRARIES OpenCL.lib PATHS
 	    ${OPENCL_LIB_DIR} $ENV{OpenCL_LIBPATH} $ENV{CUDA_LIB_PATH})
 
 	GET_FILENAME_COMPONENT(_OPENCL_INC_CAND ${OPENCL_LIB_DIR}/../../include ABSOLUTE)
 
 	# On Win32 search relative to the library
-	FIND_PATH(OpenCL_INCLUDE_DIRS CL/cl.h PATHS
+	FIND_PATH(OPENCL_INCLUDE_DIRS CL/cl.h PATHS
 	    ${_OPENCL_INC_CAND} $ENV{OpenCL_INCPATH} $ENV{CUDA_INC_PATH})
 	FIND_PATH(_OPENCL_CPP_INCLUDE_DIRS CL/cl.hpp PATHS
 	    ${_OPENCL_INC_CAND} $ENV{OpenCL_INCPATH} $ENV{CUDA_INC_PATH})
@@ -51,43 +49,31 @@ ELSE (APPLE)
     ELSE (WIN32)
 
 	# Unix style platforms
-	FIND_LIBRARY(OpenCL_LIBRARY OpenCL
+	FIND_LIBRARY(OPENCL_LIBRARIES OpenCL
 	    PATHS ENV LD_LIBRARY_PATH ENV OpenCL_LIBPATH
 	    )
 
-	GET_FILENAME_COMPONENT(OPENCL_LIB_DIR ${OpenCL_LIBRARY} PATH)
+	GET_FILENAME_COMPONENT(OPENCL_LIB_DIR ${OPENCL_LIBRARIES} PATH)
 	GET_FILENAME_COMPONENT(_OPENCL_INC_CAND ${OPENCL_LIB_DIR}/../../include ABSOLUTE)
 
 	# The AMD SDK currently does not place its headers
 	# in /usr/include, therefore also search relative
 	# to the library
-	FIND_PATH(OpenCL_INCLUDE_DIRS
-      CL/cl.h
-      PATHS ${_OPENCL_INC_CAND} "/usr/local/cuda/include" "/opt/AMDAPP/include" $ENV{OpenCL_INCPATH})
-	FIND_PATH(_OPENCL_CPP_INCLUDE_DIRS CL/cl.hpp PATHS ${_OPENCL_INC_CAND} "/usr/local/cuda/include" "/opt/AMDAPP/include" ENV OpenCL_INCPATH)
+	FIND_PATH(OPENCL_INCLUDE_DIRS CL/cl.h PATHS ${_OPENCL_INC_CAND} "/usr/local/cuda/include" "/opt/cuda/include" "/opt/AMDAPP/include" ENV OpenCL_INCPATH)
+	FIND_PATH(_OPENCL_CPP_INCLUDE_DIRS CL/cl.hpp PATHS ${_OPENCL_INC_CAND} "/usr/local/cuda/include" "/opt/cuda/include" "/opt/AMDAPP/include" ENV OpenCL_INCPATH)
 
     ENDIF (WIN32)
 
 ENDIF (APPLE)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(OpenCL DEFAULT_MSG OpenCL_LIBRARY
-    OpenCL_INCLUDE_DIRS)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(OpenCL DEFAULT_MSG OPENCL_LIBRARIES OPENCL_INCLUDE_DIRS)
 
 IF(_OPENCL_CPP_INCLUDE_DIRS)
     SET( OPENCL_HAS_CPP_BINDINGS TRUE )
-    LIST( APPEND OpenCL_INCLUDE_DIRS ${_OPENCL_CPP_INCLUDE_DIRS} )
+    LIST( APPEND OPENCL_INCLUDE_DIRS ${_OPENCL_CPP_INCLUDE_DIRS} )
     # This is often the same, so clean up
-    LIST( REMOVE_DUPLICATES OpenCL_INCLUDE_DIRS )
+    LIST( REMOVE_DUPLICATES OPENCL_INCLUDE_DIRS )
 ENDIF(_OPENCL_CPP_INCLUDE_DIRS)
 
-MARK_AS_ADVANCED(
-    OpenCL_INCLUDE_DIRS
-    )
+MARK_AS_ADVANCED( OPENCL_INCLUDE_DIRS )
 
-if (OPENCL_FOUND)
-  message(STATUS "OpenCL found")
-  message(STATUS "  OpenCL_INCLUDE_DIRS = ${OpenCL_INCLUDE_DIRS}")
-  message(STATUS "  OpenCL_LIBRARY = ${OpenCL_LIBRARY}")
-else ()
-  message(STATUS "OpenCL not found")
-endif()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -16,5 +16,5 @@ set(EXAMPLES
 
 foreach(EXAMPLE ${EXAMPLES})
   add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
-  target_link_libraries(${EXAMPLE} ${OpenCL_LIBRARY})
+  target_link_libraries(${EXAMPLE} ${OPENCL_LIBRARIES})
 endforeach()

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -13,5 +13,5 @@ set(BENCHMARKS
 foreach(BENCHMARK ${BENCHMARKS})
   set(PERF_TARGET perf_${BENCHMARK})
   add_executable(${PERF_TARGET} perf_${BENCHMARK}.cpp)
-  target_link_libraries(${PERF_TARGET} ${OpenCL_LIBRARY})
+  target_link_libraries(${PERF_TARGET} ${OPENCL_LIBRARIES})
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@ function(add_compute_test TEST_NAME TEST_SOURCE)
   get_filename_component(TEST_TARGET ${TEST_SOURCE} NAME_WE)
   add_executable(${TEST_TARGET} ${TEST_SOURCE})
   target_link_libraries(${TEST_TARGET}
-    ${OpenCL_LIBRARY}
+    ${OPENCL_LIBRARIES}
     ${Boost_LIBRARIES}
   )
   add_test(${TEST_NAME} ${TEST_TARGET})


### PR DESCRIPTION
Hey Kyle,

I made a few changes to the FindOpenCL module that make this work better on my machine. I think this may be generally useful. The strategy is to search in the following locations
- A user specified OpenCL_ROOT_DIR (e.g. cmake -DOpenCL_ROOT_DIR=/opt/AMDAPP source_dir)
- If none is given the $CUDA_TOOLKIT_ROOT_DIR is searched
- If that can't be found search in $AMDAPPSDKROOT
  In addition the normal system path is search (e.g. /usr/lib64 etc.)

Cheers,
Dominic
