### PR TITLE
Skip fill_char_pair_vector test on AMD

### DIFF
--- a/test/test_pair.cpp
+++ b/test/test_pair.cpp
@@ -72,6 +72,11 @@ BOOST_AUTO_TEST_CASE(fill_pair_vector)
 
 BOOST_AUTO_TEST_CASE(fill_char_pair_vector)
 {
+    if(bug_in_struct_assignment(device)){
+        std::cerr << "skipping fill_char_pair_vector test" << std::endl;
+        return;
+    }
+
     std::pair<char, unsigned char> value('c', static_cast<unsigned char>(127));
     boost::compute::vector<std::pair<char, unsigned char> > vector(5);
     boost::compute::fill(vector.begin(), vector.end(), value);


### PR DESCRIPTION
The test fails for the same reason that fill_pair_vector does.

See: c085d64a46b315bf9e884283d6b980b2191b72bc
See: http://devgurus.amd.com/thread/166622

closes: #2
