### PR TITLE
Get rid of clang-3.3 -Wconstexpr-not-const warning

### DIFF
--- a/include/boost/compute/container/vector.hpp
+++ b/include/boost/compute/container/vector.hpp
@@ -451,8 +451,8 @@ public:
     }
 
 private:
-    BOOST_CONSTEXPR size_type _minimum_capacity() { return 4; }
-    BOOST_CONSTEXPR float _growth_factor() { return 1.5; }
+    BOOST_CONSTEXPR size_type _minimum_capacity() const { return 4; }
+    BOOST_CONSTEXPR float _growth_factor() const { return 1.5; }
 
 private:
     pointer m_data;


### PR DESCRIPTION
Without the patch, clang-3.3 shows the following warning:

```
.../compute/include/boost/compute/container/vector.hpp:454:31: warning: 'constexpr' non-static member function will not be
      implicitly 'const' in C++1y; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
    BOOST_CONSTEXPR size_type _minimum_capacity() { return 4; }
                              ^
                                                  const
.../compute/include/boost/compute/container/vector.hpp:455:27: warning: 'constexpr' non-static member function will not be
      implicitly 'const' in C++1y; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
    BOOST_CONSTEXPR float _growth_factor() { return 1.5; }
                          ^
                                           const

```
