### PR TITLE
Fix core.system test

### DIFF
--- a/test/test_system.cpp
+++ b/test/test_system.cpp
@@ -34,5 +34,5 @@ BOOST_AUTO_TEST_CASE(find_device)
 {
     boost::compute::device device = boost::compute::system::default_device();
     const std::string &name = device.name();
-    BOOST_CHECK(boost::compute::system::find_device(name).id() == device.id());
+    BOOST_CHECK(boost::compute::system::find_device(name).name() == device.name());
 }


### PR DESCRIPTION
The find_device check in core.system is invalid. It could fail when same device is supported by several platforms. In my case this happens for Intel CPU when both AMD and Intel platforms are installed. The CPU returned by `boost::compute::system::default_device()` is served by the AMD platform, and the CPU returned by
`boost::compute::system::find_device(name)` is served by the Intel SDK. The only thing that could be safely asserted here is that both devices have the same name.
