### PR TITLE
Use the original program source for program creation/compilation

### DIFF
--- a/include/boost/compute/program.hpp
+++ b/include/boost/compute/program.hpp
@@ -370,12 +370,14 @@ public:
      * on Windows.
      */
     static program build_with_source(
-            std::string source,
-            const context &context,
+            const std::string &source,
+            const context     &context,
             const std::string &options = std::string()
             )
     {
 #ifdef BOOST_COMPUTE_USE_OFFLINE_CACHE
+        // Get hash string for the kernel.
+        std::string hash;
         {
             device   d(context.get_device());
             platform p(d.get_info<cl_platform_id>(CL_DEVICE_PLATFORM));
@@ -386,11 +388,9 @@ public:
                 << "// " << options << "\n\n"
                 << source;
 
-            source = src.str();
+            hash = sha1(src.str());
         }
 
-        // Get hash string for the kernel.
-        std::string hash = sha1(source);
 
         // Try to get cached program binaries:
         try {


### PR DESCRIPTION
Instead of building the program from source with the added comment block (used for distinction between different platforms and devices when offline cache is in use), only use the altered source for the hash computation. This way users will not get unexpected results from `program.source()`.
