### PR TITLE
Fix linkage problem with detail::getenv()

### DIFF
--- a/include/boost/compute/detail/getenv.hpp
+++ b/include/boost/compute/detail/getenv.hpp
@@ -17,7 +17,7 @@ namespace boost {
 namespace compute {
 namespace detail {
 
-const char* getenv(const char *env_var)
+inline const char* getenv(const char *env_var)
 {
 #ifdef _MSC_VER
 #  pragma warning(push)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -148,3 +148,15 @@ if(${BOOST_COMPUTE_HAVE_VTK})
   add_compute_test("interop.vtk" test_interop_vtk.cpp)
   target_link_libraries(test_interop_vtk ${VTK_LIBRARIES})
 endif()
+
+# Check for linkage problems
+add_executable(test_multiple_objects
+    test_multiple_objects1.cpp
+    test_multiple_objects2.cpp
+    )
+target_link_libraries(test_multiple_objects
+    ${OPENCL_LIBRARIES}
+    ${Boost_LIBRARIES}
+    )
+add_test("core.multiple_objects" test_multiple_objects)
+

--- a/test/test_multiple_objects1.cpp
+++ b/test/test_multiple_objects1.cpp
@@ -1,0 +1,21 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2013 Kyle Lutz <kyle.r.lutz@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE TestMultipleObjects
+#include <boost/test/unit_test.hpp>
+#include <boost/compute.hpp>
+
+bool dummy_function();
+
+BOOST_AUTO_TEST_CASE(multiple_objects)
+{
+    // It is enough if the test compiles.
+    BOOST_CHECK( dummy_function() );
+}

--- a/test/test_multiple_objects2.cpp
+++ b/test/test_multiple_objects2.cpp
@@ -1,0 +1,15 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2013 Kyle Lutz <kyle.r.lutz@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <boost/compute.hpp>
+
+bool dummy_function() {
+    return true;
+}


### PR DESCRIPTION
`detail::getenv()` function was not declared `inline`, which led to `multiple definition` errors at link time when a program consisted of multiple objects that included Boost.Compute headers.

Fixed the problem and added `core.multiple_objects` test.
