### PR TITLE
Use SHA1 for online cache keys

### DIFF
--- a/include/boost/compute/detail/meta_kernel.hpp
+++ b/include/boost/compute/detail/meta_kernel.hpp
@@ -23,7 +23,6 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/algorithm/string/find.hpp>
-#include <boost/functional/hash.hpp>
 
 #include <boost/compute/kernel.hpp>
 #include <boost/compute/image2d.hpp>
@@ -36,6 +35,7 @@
 #include <boost/compute/image_sampler.hpp>
 #include <boost/compute/memory_object.hpp>
 #include <boost/compute/detail/program_cache.hpp>
+#include <boost/compute/detail/sha1.hpp>
 
 namespace boost {
 namespace compute {
@@ -332,17 +332,14 @@ public:
         std::string source = this->source();
 
         // generate cache key
-        size_t hash = boost::hash<std::string>()(source);
-        std::string cache_key =
-            std::string("meta_kernel_") +
-            boost::lexical_cast<std::string>(hash);
+        std::string cache_key = detail::sha1(source);
 
         // try to look the program up in the cache
         boost::shared_ptr<program_cache> cache = get_program_cache(context);
         ::boost::compute::program program = cache->get(cache_key);
 
         // build the program if it was not in the cache
-        if(!program.get()/* || program.source() != source*/){
+        if(!program.get()){
             program =
                 ::boost::compute::program::build_with_source(source, context);
 

--- a/include/boost/compute/detail/sha1.hpp
+++ b/include/boost/compute/detail/sha1.hpp
@@ -1,0 +1,42 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2013-2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#ifndef BOOST_COMPUTE_DETAIL_SHA1_HPP
+#define BOOST_COMPUTE_DETAIL_SHA1_HPP
+
+#include <sstream>
+#include <iomanip>
+#include <boost/uuid/sha1.hpp>
+
+namespace boost {
+namespace compute {
+namespace detail {
+
+// Returns SHA1 hash of the string parameter.
+inline std::string sha1(const std::string &src) {
+    boost::uuids::detail::sha1 sha1;
+    sha1.process_bytes(src.c_str(), src.size());
+
+    unsigned int hash[5];
+    sha1.get_digest(hash);
+
+    std::ostringstream buf;
+    for(int i = 0; i < 5; ++i)
+        buf << std::hex << std::setfill('0') << std::setw(8) << hash[i];
+
+    return buf.str();
+}
+
+} // end detail namespace
+} // end compute namespace
+} // end boost namespace
+
+
+#endif // BOOST_COMPUTE_DETAIL_SHA1_HPP

--- a/include/boost/compute/program.hpp
+++ b/include/boost/compute/program.hpp
@@ -30,12 +30,11 @@
 
 #ifdef BOOST_COMPUTE_USE_OFFLINE_CACHE
 #include <sstream>
-#include <iomanip>
-#include <boost/uuid/sha1.hpp>
 #include <boost/optional.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/compute/platform.hpp>
 #include <boost/compute/detail/getenv.hpp>
+#include <boost/compute/detail/sha1.hpp>
 #endif
 
 namespace boost {
@@ -388,9 +387,8 @@ public:
                 << "// " << options << "\n\n"
                 << source;
 
-            hash = sha1(src.str());
+            hash = detail::sha1(src.str());
         }
-
 
         // Try to get cached program binaries:
         try {
@@ -464,21 +462,6 @@ private:
         if (create) boost::filesystem::create_directories(dir);
 
         return dir + path_delim();
-    }
-
-    // Returns SHA1 hash of the string parameter.
-    static std::string sha1(const std::string &src) {
-        boost::uuids::detail::sha1 sha1;
-        sha1.process_bytes(src.c_str(), src.size());
-
-        unsigned int hash[5];
-        sha1.get_digest(hash);
-
-        std::ostringstream buf;
-        for(int i = 0; i < 5; ++i)
-            buf << std::hex << std::setfill('0') << std::setw(8) << hash[i];
-
-        return buf.str();
     }
 
     // Saves program binaries for future reuse.


### PR DESCRIPTION
This makes online cache use SHA1 of the program source as key. Introduces `compute::detail::sha1()` function, which is moved from `compute::program` into its own header file.

This does not change the total test time on my Intel CPU. What really should be tested though is a sequence of kernels launched in a loop.
