### PR TITLE
Install specific version of fglrx on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
     - clang
 before_install:
     - sudo apt-get update -qq
-    - sudo apt-get install -qq fglrx opencl-headers libboost-chrono1.48-dev libboost-date-time1.48-dev libboost-test1.48-dev libboost-system1.48-dev libboost-filesystem1.48-dev libboost-timer1.48-dev
+    - sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers libboost-chrono1.48-dev libboost-date-time1.48-dev libboost-test1.48-dev libboost-system1.48-dev libboost-filesystem1.48-dev libboost-timer1.48-dev
 script:
     - mkdir -p build && (cd build && cmake -DBOOST_COMPUTE_BUILD_TESTS=ON -DBOOST_COMPUTE_USE_OFFLINE_CACHE=ON .. && make)
     - (cd build && ctest --output-on-failure && ctest --output-on-failure)


### PR DESCRIPTION
The current version that gets installed automatically is broken in the
sense that it does not work on a CPU in the absence of a GPU (e.g. see
https://travis-ci.org/ddemidov/vexcl/jobs/18265418#L276).

This installs version 2:8.960-0ubuntu1 which does work.
