### PR TITLE
Add coveralls.io integration

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ compiler:
     - clang
 before_install:
     - sudo apt-get update -qq
-    - sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers libboost-chrono1.48-dev libboost-date-time1.48-dev libboost-test1.48-dev libboost-system1.48-dev libboost-filesystem1.48-dev libboost-timer1.48-dev
+    - sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers libboost-chrono1.48-dev libboost-date-time1.48-dev libboost-test1.48-dev libboost-system1.48-dev libboost-filesystem1.48-dev libboost-timer1.48-dev python-yaml
+    - sudo pip install cpp-coveralls --use-mirrors
 script:
-    - mkdir -p build && (cd build && cmake -DBOOST_COMPUTE_BUILD_TESTS=ON -DBOOST_COMPUTE_USE_OFFLINE_CACHE=ON .. && make)
+    - mkdir -p build && (cd build && cmake -DBOOST_COMPUTE_BUILD_TESTS=ON -DBOOST_COMPUTE_USE_OFFLINE_CACHE=ON -DBOOST_COMPUTE_ENABLE_COVERAGE=ON .. && make)
     - (cd build && ctest --output-on-failure && ctest --output-on-failure)
+after_success:
+  - coveralls -b build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ if(MSVC)
   add_definitions(-D_SCL_SECURE_NO_WARNINGS)
 endif()
 
+# compiler options
+option(BOOST_COMPUTE_ENABLE_COVERAGE "Enable code coverage generation" OFF)
+
 option(BOOST_COMPUTE_BUILD_EXAMPLES "Build the Boost.Compute examples" OFF)
 if(${BOOST_COMPUTE_BUILD_EXAMPLES})
   add_subdirectory(example)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/kylelutz/compute.png?branch=master)]
  (https://travis-ci.org/kylelutz/compute)
+ [![Coverage Status](https://coveralls.io/repos/kylelutz/compute/badge.png?branch=master)]
+ (https://coveralls.io/r/kylelutz/compute)
 
 Boost.Compute is a GPU/parallel-computing library for C++ based on OpenCL.
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,11 @@ add_definitions(-DBOOST_TEST_DYN_LINK)
 
 add_definitions(-DBOOST_COMPUTE_DEBUG_KERNEL_COMPILATION)
 
+# enable code coverage generation (only with GCC for now)
+if(${BOOST_COMPUTE_ENABLE_COVERAGE} AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  add_definitions(-fprofile-arcs -ftest-coverage)
+endif()
+
 function(add_compute_test TEST_NAME TEST_SOURCE)
   get_filename_component(TEST_TARGET ${TEST_SOURCE} NAME_WE)
   add_executable(${TEST_TARGET} ${TEST_SOURCE})
@@ -19,6 +24,12 @@ function(add_compute_test TEST_NAME TEST_SOURCE)
     ${OPENCL_LIBRARIES}
     ${Boost_LIBRARIES}
   )
+
+  # link with coverage library
+  if(${BOOST_COMPUTE_ENABLE_COVERAGE} AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    target_link_libraries(${TEST_TARGET} -fprofile-arcs -ftest-coverage)
+  endif()
+
   add_test(${TEST_NAME} ${TEST_TARGET})
 endfunction()
 
@@ -164,5 +175,9 @@ target_link_libraries(test_multiple_objects
     ${OPENCL_LIBRARIES}
     ${Boost_LIBRARIES}
     )
+# link with coverage library
+if(${BOOST_COMPUTE_ENABLE_COVERAGE} AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  target_link_libraries(test_multiple_objects -fprofile-arcs -ftest-coverage)
+endif()
 add_test("core.multiple_objects" test_multiple_objects)
 


### PR DESCRIPTION
This adds support for automatic code-coverage generation with
coveralls.io and Travis-CI.
