### PR TITLE
Fixing several warnings given by pedantic g++-4.8.2

### DIFF
--- a/include/boost/compute/algorithm/detail/copy_to_host.hpp
+++ b/include/boost/compute/algorithm/detail/copy_to_host.hpp
@@ -59,9 +59,6 @@ inline future<HostIterator> copy_to_host_async(DeviceIterator first,
     typedef typename
         std::iterator_traits<DeviceIterator>::value_type
         value_type;
-    typedef typename
-        std::iterator_traits<HostIterator>::difference_type
-        difference_type;
 
     size_t count = iterator_range_size(first, last);
     if(count == 0){

--- a/include/boost/compute/algorithm/detail/find_extrema_with_atomics.hpp
+++ b/include/boost/compute/algorithm/detail/find_extrema_with_atomics.hpp
@@ -28,7 +28,6 @@ inline InputIterator find_extrema_with_atomics(InputIterator first,
                                                char sign,
                                                command_queue &queue)
 {
-    typedef typename std::iterator_traits<InputIterator>::value_type value_type;
     typedef typename std::iterator_traits<InputIterator>::difference_type difference_type;
 
     const context &context = queue.get_context();

--- a/include/boost/compute/algorithm/detail/inplace_reduce.hpp
+++ b/include/boost/compute/algorithm/detail/inplace_reduce.hpp
@@ -32,9 +32,6 @@ inline void inplace_reduce(Iterator first,
     typedef typename
         std::iterator_traits<Iterator>::value_type
         value_type;
-    typedef typename
-        boost::tr1_result_of<BinaryFunction(value_type, value_type)>::type
-        result_type;
 
     size_t input_size = iterator_range_size(first, last);
     if(input_size < 2){

--- a/include/boost/compute/algorithm/detail/scan_on_cpu.hpp
+++ b/include/boost/compute/algorithm/detail/scan_on_cpu.hpp
@@ -36,8 +36,6 @@ inline OutputIterator scan_on_cpu(InputIterator first,
 
     typedef typename
         std::iterator_traits<InputIterator>::value_type input_type;
-    typedef typename
-        std::iterator_traits<OutputIterator>::value_type output_type;
 
     const context &context = queue.get_context();
 

--- a/include/boost/compute/algorithm/detail/serial_count_if.hpp
+++ b/include/boost/compute/algorithm/detail/serial_count_if.hpp
@@ -29,7 +29,6 @@ inline size_t serial_count_if(InputIterator first,
                               command_queue &queue)
 {
     typedef typename std::iterator_traits<InputIterator>::value_type value_type;
-    typedef typename std::iterator_traits<InputIterator>::difference_type difference_type;
 
     const context &context = queue.get_context();
     size_t size = iterator_range_size(first, last);

--- a/include/boost/compute/algorithm/inner_product.hpp
+++ b/include/boost/compute/algorithm/inner_product.hpp
@@ -34,7 +34,6 @@ inline T inner_product(InputIterator1 first1,
                        command_queue &queue = system::default_queue())
 {
     typedef typename std::iterator_traits<InputIterator1>::value_type input_type;
-    typedef typename multiplies<input_type>::result_type product_type;
 
     ptrdiff_t n = std::distance(first1, last1);
 

--- a/include/boost/compute/algorithm/sort.hpp
+++ b/include/boost/compute/algorithm/sort.hpp
@@ -96,8 +96,6 @@ inline void sort(Iterator first,
                  Compare compare,
                  command_queue &queue = system::default_queue())
 {
-    typedef typename std::iterator_traits<Iterator>::value_type T;
-
     size_t count = detail::iterator_range_size(first, last);
     if(count < 2){
         return;

--- a/include/boost/compute/algorithm/swap_ranges.hpp
+++ b/include/boost/compute/algorithm/swap_ranges.hpp
@@ -28,7 +28,6 @@ inline Iterator2 swap_ranges(Iterator1 first1,
                              command_queue &queue = system::default_queue())
 {
     typedef typename std::iterator_traits<Iterator1>::value_type value_type;
-    typedef typename std::iterator_traits<Iterator1>::difference_type difference_type;
 
     Iterator2 last2 = first2 + std::distance(first1, last1);
 

--- a/include/boost/compute/iterator/transform_iterator.hpp
+++ b/include/boost/compute/iterator/transform_iterator.hpp
@@ -174,7 +174,6 @@ private:
 
         kernel kernel = k.compile(context);
 
-        typedef typename std::iterator_traits<InputIterator>::value_type input_type;
         buffer output_buffer(context, sizeof(value_type));
 
         kernel.set_arg(output_arg, output_buffer);

--- a/include/boost/compute/wait_list.hpp
+++ b/include/boost/compute/wait_list.hpp
@@ -33,7 +33,7 @@ public:
     }
 
     /// Creates a new wait-list as a copy of \p other.
-    wait_list(const wait_list &other)
+    wait_list(const wait_list &/*other*/)
     {
     }
 


### PR DESCRIPTION
This fixes several warnings (mostly unused local typedefs, and one unused parameter) given by g++-4.8.2 with `-pedantic` flag. The one with unused parameter is interesting, because it is in a copy constructor, and the [comment says](https://github.com/ddemidov/compute/blob/6c8f158c004238d261bab9b6494c60cb900f61da/include/boost/compute/wait_list.hpp#L35-L38) the parameter would be copied, but the constructor is empty.

I've seen the warnings when compiling Boost.Compute wrapping code for VexCL, which only uses scan and sort algorithms, so there could be more.
