### PR TITLE
Add algorithm and test for stable_partition

### DIFF
--- a/include/boost/compute/algorithm.hpp
+++ b/include/boost/compute/algorithm.hpp
@@ -74,6 +74,7 @@
 #include <boost/compute/algorithm/set_union.hpp>
 #include <boost/compute/algorithm/sort.hpp>
 #include <boost/compute/algorithm/sort_by_key.hpp>
+#include <boost/compute/algorithm/stable_partition.hpp>
 #include <boost/compute/algorithm/stable_sort.hpp>
 #include <boost/compute/algorithm/swap_ranges.hpp>
 #include <boost/compute/algorithm/transform.hpp>

--- a/include/boost/compute/algorithm/partition.hpp
+++ b/include/boost/compute/algorithm/partition.hpp
@@ -12,48 +12,25 @@
 #define BOOST_COMPUTE_ALGORITHM_PARTITION_HPP
 
 #include <boost/compute/system.hpp>
-#include <boost/compute/context.hpp>
-#include <boost/compute/functional.hpp>
 #include <boost/compute/command_queue.hpp>
-#include <boost/compute/algorithm/copy_if.hpp>
-#include <boost/compute/container/vector.hpp>
+#include <boost/compute/algorithm/stable_partition.hpp>
 
 namespace boost {
 namespace compute {
 
-/// Partitions the elements in the range [\p first, \p last) according to
-/// \p predicate.
 ///
-/// \see is_partitioned()
+/// Partitions the elements in the range [\p first, \p last) according to
+/// \p predicate. Order of the elements need not be preserved.
+///
+/// \see is_partitioned() and stable_partition()
+///
 template<class Iterator, class UnaryPredicate>
 inline Iterator partition(Iterator first,
                           Iterator last,
                           UnaryPredicate predicate,
                           command_queue &queue = system::default_queue())
 {
-    typedef typename std::iterator_traits<Iterator>::value_type value_type;
-
-    // make temporary copy of the input
-    ::boost::compute::vector<value_type> tmp(first, last, queue);
-
-    // copy true values
-    Iterator last_true =
-        ::boost::compute::copy_if(tmp.begin(),
-                                  tmp.end(),
-                                  first,
-                                  predicate,
-                                  queue);
-
-    // copy false values
-    Iterator last_false =
-        ::boost::compute::copy_if(tmp.begin(),
-                                  tmp.end(),
-                                  last_true,
-                                  not1(predicate),
-                                  queue);
-
-    // return iterator pointing to the last true value
-    return last_true;
+    return stable_partition(first, last, predicate, queue);
 }
 
 } // end compute namespace

--- a/include/boost/compute/algorithm/stable_partition.hpp
+++ b/include/boost/compute/algorithm/stable_partition.hpp
@@ -1,0 +1,72 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Roshan <thisisroshansmail@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#ifndef BOOST_COMPUTE_ALGORITHM_STABLE_PARTITION_HPP
+#define BOOST_COMPUTE_ALGORITHM_STABLE_PARTITION_HPP
+
+#include <boost/compute/system.hpp>
+#include <boost/compute/context.hpp>
+#include <boost/compute/functional.hpp>
+#include <boost/compute/command_queue.hpp>
+#include <boost/compute/algorithm/copy_if.hpp>
+#include <boost/compute/container/vector.hpp>
+
+namespace boost {
+namespace compute {
+
+///
+/// \brief Partitioning algorithm
+///
+/// Partitions the elements in the range [\p first, \p last) according to
+/// \p predicate. The order of the elements is preserved.
+/// \return Iterator pointing to end of true values
+///
+/// \param first Iterator pointing to start of range
+/// \param last Iterator pointing to end of range
+/// \param predicate Unary predicate to be applied on each element
+/// \param queue Queue on which to execute
+///
+/// \see is_partitioned() and partition()
+///
+template<class Iterator, class UnaryPredicate>
+inline Iterator stable_partition(Iterator first,
+                                 Iterator last,
+                                 UnaryPredicate predicate,
+                                 command_queue &queue = system::default_queue())
+{
+    typedef typename std::iterator_traits<Iterator>::value_type value_type;
+
+    // make temporary copy of the input
+    ::boost::compute::vector<value_type> tmp(first, last, queue);
+
+    // copy true values
+    Iterator last_true =
+        ::boost::compute::copy_if(tmp.begin(),
+                                  tmp.end(),
+                                  first,
+                                  predicate,
+                                  queue);
+
+    // copy false values
+    Iterator last_false =
+        ::boost::compute::copy_if(tmp.begin(),
+                                  tmp.end(),
+                                  last_true,
+                                  not1(predicate),
+                                  queue);
+
+    // return iterator pointing to the last true value
+    return last_true;
+}
+
+} // end compute namespace
+} // end boost namespace
+
+#endif // BOOST_COMPUTE_ALGORITHM_STABLE_PARTITION_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,6 +98,7 @@ add_compute_test("algorithm.set_symmetric_difference" test_set_symmetric_differe
 add_compute_test("algorithm.set_union" test_set_union.cpp)
 add_compute_test("algorithm.sort" test_sort.cpp)
 add_compute_test("algorithm.sort_by_key" test_sort_by_key.cpp)
+add_compute_test("algorithm.stable_partition" test_stable_partition.cpp)
 add_compute_test("algorithm.stable_sort" test_stable_sort.cpp)
 add_compute_test("algorithm.transform" test_transform.cpp)
 add_compute_test("algorithm.transform_reduce" test_transform_reduce.cpp)

--- a/test/test_stable_partition.cpp
+++ b/test/test_stable_partition.cpp
@@ -1,0 +1,38 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Roshan <thisisroshansmail@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE TestStablePartition
+#include <boost/test/unit_test.hpp>
+
+#include <boost/compute/system.hpp>
+#include <boost/compute/functional.hpp>
+#include <boost/compute/command_queue.hpp>
+#include <boost/compute/algorithm/stable_partition.hpp>
+#include <boost/compute/container/vector.hpp>
+
+#include "check_macros.hpp"
+#include "context_setup.hpp"
+
+namespace bc = boost::compute;
+
+BOOST_AUTO_TEST_CASE(partition_int)
+{
+    int dataset[] = {1, 1, -2, 0, 5, -1, 2, 4, 0, -1};
+    bc::vector<bc::int_> vector(dataset, dataset + 10, queue);
+
+    bc::vector<bc::int_>::iterator iter =
+        bc::stable_partition(vector.begin(), vector.begin() + 10,
+                             bc::_1 > 0, queue);
+
+    CHECK_RANGE_EQUAL(int, 10, vector, (1, 1, 5, 2, 4, -2, 0, -1, 0, -1));
+    BOOST_VERIFY(iter == vector.begin()+5);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Added algorithm and test for `stable_partition` and changed `partition` to use it for now. I am searching for a good implementation(swaps based?) for `partition` to take advantage of the fact that order of elements need not be preserved.
