### PR TITLE
Add binary_find algorithm

### DIFF
--- a/include/boost/compute/algorithm/binary_search.hpp
+++ b/include/boost/compute/algorithm/binary_search.hpp
@@ -13,7 +13,7 @@
 
 #include <boost/compute/system.hpp>
 #include <boost/compute/command_queue.hpp>
-#include <boost/compute/algorithm/find.hpp>
+#include <boost/compute/algorithm/lower_bound.hpp>
 
 namespace boost {
 namespace compute {
@@ -26,7 +26,9 @@ inline bool binary_search(InputIterator first,
                           const T &value,
                           command_queue &queue = system::default_queue())
 {
-    return ::boost::compute::find(first, last, value, queue) != last;
+    InputIterator position = lower_bound(first, last, value, queue);
+
+    return position != last && *position == value;
 }
 
 } // end compute namespace

--- a/include/boost/compute/algorithm/detail/binary_find.hpp
+++ b/include/boost/compute/algorithm/detail/binary_find.hpp
@@ -1,0 +1,46 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Roshan <thisisroshansmail@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#ifndef BOOST_COMPUTE_ALGORITHM_DETAIL_BINARY_FIND_HPP
+#define BOOST_COMPUTE_ALGORITHM_DETAIL_BINARY_FIND_HPP
+
+#include <boost/compute/algorithm/find_if.hpp>
+#include <boost/compute/algorithm/transform.hpp>
+#include <boost/compute/command_queue.hpp>
+
+namespace boost {
+namespace compute {
+namespace detail{
+
+///
+/// \brief Binary find algorithm
+///
+/// Finds the end of true values in the partitioned range [first, last).
+/// \return Iterator pointing to end of true values
+///
+/// \param first Iterator pointing to start of range
+/// \param last Iterator pointing to end of range
+/// \param value Value to be found
+/// \param queue Queue on which to execute
+///
+template<class InputIterator, class UnaryPredicate>
+inline InputIterator binary_find(InputIterator first,
+                                 InputIterator last,
+                                 UnaryPredicate predicate,
+                                 command_queue &queue = system::default_queue())
+{
+    return find_if(first, last, predicate, queue);
+}
+
+} // end detail namespace
+} // end compute namespace
+} // end boost namespace
+
+#endif // BOOST_COMPUTE_ALGORITHM_DETAIL_BINARY_FIND_HPP

--- a/include/boost/compute/algorithm/lower_bound.hpp
+++ b/include/boost/compute/algorithm/lower_bound.hpp
@@ -14,7 +14,7 @@
 #include <boost/compute/lambda.hpp>
 #include <boost/compute/system.hpp>
 #include <boost/compute/command_queue.hpp>
-#include <boost/compute/algorithm/find_if.hpp>
+#include <boost/compute/algorithm/detail/binary_find.hpp>
 
 namespace boost {
 namespace compute {
@@ -33,7 +33,7 @@ lower_bound(InputIterator first,
     using ::boost::compute::_1;
 
     InputIterator position =
-        ::boost::compute::find_if(first, last, _1 >= value, queue);
+        detail::binary_find(first, last, _1 >= value, queue);
 
     return position;
 }

--- a/include/boost/compute/algorithm/upper_bound.hpp
+++ b/include/boost/compute/algorithm/upper_bound.hpp
@@ -14,7 +14,7 @@
 #include <boost/compute/lambda.hpp>
 #include <boost/compute/system.hpp>
 #include <boost/compute/command_queue.hpp>
-#include <boost/compute/algorithm/find_if.hpp>
+#include <boost/compute/algorithm/detail/binary_find.hpp>
 
 namespace boost {
 namespace compute {
@@ -32,7 +32,7 @@ upper_bound(InputIterator first,
     using ::boost::compute::_1;
 
     InputIterator position =
-        ::boost::compute::find_if(first, last, _1 > value, queue);
+        detail::binary_find(first, last, _1 > value, queue);
 
     return position;
 }


### PR DESCRIPTION
Added `binary_find` algorithm and changed `upper_bound`, `lower_bound`, `binary_search` to use it as its core. This will also be useful in `partition_point` as well.

This also calls for a small change in my proposal. During the week I have allocated to improve `binary_search`, I will instead improve `binary_find` to take advantage of the partitioned input(Currently it simply uses `find_if`)
