### PR TITLE
Add bernoulli distribution

### DIFF
--- a/include/boost/compute/random.hpp
+++ b/include/boost/compute/random.hpp
@@ -15,6 +15,7 @@
 ///
 /// Meta-header to include all Boost.Compute random headers.
 
+#include <boost/compute/random/bernoulli_distribution.hpp>
 #include <boost/compute/random/default_random_engine.hpp>
 #include <boost/compute/random/mersenne_twister.hpp>
 #include <boost/compute/random/uniform_real_distribution.hpp>

--- a/include/boost/compute/random/bernoulli_distribution.hpp
+++ b/include/boost/compute/random/bernoulli_distribution.hpp
@@ -1,0 +1,91 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Roshan <thisisroshansmail@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#ifndef BOOST_COMPUTE_RANDOM_BERNOULLI_DISTRIBUTION_HPP
+#define BOOST_COMPUTE_RANDOM_BERNOULLI_DISTRIBUTION_HPP
+
+#include <boost/compute/command_queue.hpp>
+#include <boost/compute/function.hpp>
+#include <boost/compute/types/builtin.hpp>
+#include <boost/compute/detail/iterator_range_size.hpp>
+
+namespace boost {
+namespace compute {
+
+///
+/// \class bernoulli_distribution
+/// \brief Produces random boolean values according to the following
+/// discrete probability function with parameter p :
+/// P(true/p) = p and P(false/p) = (1 - p)
+///
+/// The following example shows how to setup a bernoulli distribution to
+/// produce random boolean values with parameter p = 0.25
+///
+/// \snippet test/test_bernoulli_distribution.cpp generate
+///
+template<class RealType = float>
+class bernoulli_distribution
+{
+public:
+
+    /// Creates a new bernoulli distribution
+    bernoulli_distribution(RealType p = 0.25f)
+        : m_p(p)
+    {
+    }
+
+    /// Destroys the bernoulli_distribution object
+    ~bernoulli_distribution()
+    {
+    }
+
+    /// Returns the value of the parameter p
+    RealType p() const
+    {
+        return m_p;
+    }
+
+    /// Generates bernoulli distributed booleans and stores
+    /// them in the range [\p first, \p last).
+    template<class OutputIterator, class Generator>
+    void generate(OutputIterator first,
+                  OutputIterator last,
+                  Generator &generator,
+                  command_queue &queue)
+    {
+        size_t count = detail::iterator_range_size(first, last);
+
+        vector<uint_> tmp(count, queue.get_context());
+        generator.generate(tmp.begin(), tmp.end(), queue);
+
+        BOOST_COMPUTE_FUNCTION(bool, scale_random, (const uint_ x),
+        {
+            return (convert_RealType(x) / MAX_RANDOM) < PARAM;
+        });
+
+        scale_random.define("PARAM", boost::lexical_cast<std::string>(m_p));
+        scale_random.define("MAX_RANDOM", "UINT_MAX");
+        scale_random.define(
+            "convert_RealType", std::string("convert_") + type_name<RealType>()
+        );
+
+        transform(
+            tmp.begin(), tmp.end(), first, scale_random, queue
+        );
+    }
+
+private:
+    RealType m_p;
+};
+
+} // end compute namespace
+} // end boost namespace
+
+#endif // BOOST_COMPUTE_RANDOM_BERNOULLI_DISTRIBUTION_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -134,6 +134,7 @@ add_compute_test("iterator.permutation_iterator" test_permutation_iterator.cpp)
 add_compute_test("iterator.transform_iterator" test_transform_iterator.cpp)
 add_compute_test("iterator.zip_iterator" test_zip_iterator.cpp)
 
+add_compute_test("random.bernoulli_distribution" test_bernoulli_distribution.cpp)
 add_compute_test("random.mersenne_twister" test_mersenne_twister.cpp)
 add_compute_test("random.normal_distribution" test_normal_distribution.cpp)
 add_compute_test("random.uniform_real_distribution" test_uniform_real_distribution.cpp)

--- a/test/test_bernoulli_distribution.cpp
+++ b/test/test_bernoulli_distribution.cpp
@@ -1,0 +1,39 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Roshan <thisisroshansmail@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE TestBernoulliDistribution
+#include <boost/test/unit_test.hpp>
+
+#include <boost/compute/system.hpp>
+#include <boost/compute/command_queue.hpp>
+#include <boost/compute/container/vector.hpp>
+#include <boost/compute/random/default_random_engine.hpp>
+#include <boost/compute/random/bernoulli_distribution.hpp>
+
+#include "context_setup.hpp"
+
+BOOST_AUTO_TEST_CASE(bernoulli_distribution_doctest)
+{
+    boost::compute::vector<bool> vec(10, context);
+
+//! [generate]
+// initialize the default random engine
+boost::compute::default_random_engine engine(queue);
+
+// setup the bernoulli distribution to produce booleans
+// with parameter p = 0.25
+boost::compute::bernoulli_distribution<float> distribution(0.25f);
+
+// generate the random values and store them to 'vec'
+distribution.generate(vec.begin(), vec.end(), engine, queue);
+//! [generate]
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I added `bernoulli_distribution`. And one small thing, any reason why `normal_distribution` isn't in the `random.hpp` header? I'll add it in my next pull if it should be there...
