### PR TITLE
Use BOOST_NOEXCEPT

### DIFF
--- a/include/boost/compute/buffer.hpp
+++ b/include/boost/compute/buffer.hpp
@@ -105,13 +105,13 @@ public:
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
     /// Move-constructs a new buffer object from \p other.
-    buffer(buffer&& other) noexcept
+    buffer(buffer&& other) BOOST_NOEXCEPT
         : memory_object(std::move(other))
     {
     }
 
     /// Move-assigns the buffer from \p other to \c *this.
-    buffer& operator=(buffer&& other) noexcept
+    buffer& operator=(buffer&& other) BOOST_NOEXCEPT
     {
         memory_object::operator=(std::move(other));
 

--- a/include/boost/compute/command_queue.hpp
+++ b/include/boost/compute/command_queue.hpp
@@ -146,14 +146,14 @@ public:
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
     /// Move-constructs a new command queue object from \p other.
-    command_queue(command_queue&& other) noexcept
+    command_queue(command_queue&& other) BOOST_NOEXCEPT
         : m_queue(other.m_queue)
     {
         other.m_queue = 0;
     }
 
     /// Move-assigns the command queue from \p other to \c *this.
-    command_queue& operator=(command_queue&& other) noexcept
+    command_queue& operator=(command_queue&& other) BOOST_NOEXCEPT
     {
         if(m_queue){
             clReleaseCommandQueue(m_queue);

--- a/include/boost/compute/container/allocator.hpp
+++ b/include/boost/compute/container/allocator.hpp
@@ -52,13 +52,13 @@ public:
     }
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
-    allocator(allocator<T>&& other) noexcept
+    allocator(allocator<T>&& other) BOOST_NOEXCEPT
         : m_context(std::move(other.m_context)),
           m_mem_flags(other.m_mem_flags)
     {
     }
 
-    allocator<T>& operator=(allocator<T>&& other) noexcept
+    allocator<T>& operator=(allocator<T>&& other) BOOST_NOEXCEPT
     {
         m_context = std::move(other.m_context);
         m_mem_flags = other.m_mem_flags;

--- a/include/boost/compute/context.hpp
+++ b/include/boost/compute/context.hpp
@@ -112,14 +112,14 @@ public:
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
     /// Move-constructs a new context object from \p other.
-    context(context&& other) noexcept
+    context(context&& other) BOOST_NOEXCEPT
         : m_context(other.m_context)
     {
         other.m_context = 0;
     }
 
     /// Move-assigns the context from \p other to \c *this.
-    context& operator=(context&& other) noexcept
+    context& operator=(context&& other) BOOST_NOEXCEPT
     {
         if(m_context){
             clReleaseContext(m_context);

--- a/include/boost/compute/device.hpp
+++ b/include/boost/compute/device.hpp
@@ -103,14 +103,14 @@ public:
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
     /// Move-constructs a new device object from \p other.
-    device(device&& other) noexcept
+    device(device&& other) BOOST_NOEXCEPT
         : m_id(other.m_id)
     {
         other.m_id = 0;
     }
 
     /// Move-assigns the device from \p other to \c *this.
-    device& operator=(device&& other) noexcept
+    device& operator=(device&& other) BOOST_NOEXCEPT
     {
         #ifdef CL_VERSION_1_2
         if(m_id && is_subdevice()){

--- a/include/boost/compute/device_ptr.hpp
+++ b/include/boost/compute/device_ptr.hpp
@@ -98,14 +98,14 @@ public:
     }
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
-    device_ptr(device_ptr<T>&& other) noexcept
+    device_ptr(device_ptr<T>&& other) BOOST_NOEXCEPT
         : m_buffer(other.m_buffer.get(), false),
           m_index(other.m_index)
     {
         other.m_buffer.get() = 0;
     }
 
-    device_ptr<T>& operator=(device_ptr<T>&& other) noexcept
+    device_ptr<T>& operator=(device_ptr<T>&& other) BOOST_NOEXCEPT
     {
         m_buffer.get() = other.m_buffer.get();
         m_index = other.m_index;

--- a/include/boost/compute/event.hpp
+++ b/include/boost/compute/event.hpp
@@ -114,14 +114,14 @@ public:
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
     /// Move-constructs a new event object from \p other.
-    event(event&& other) noexcept
+    event(event&& other) BOOST_NOEXCEPT
         : m_event(other.m_event)
     {
         other.m_event = 0;
     }
 
     /// Move-assigns the event from \p other to \c *this.
-    event& operator=(event&& other) noexcept
+    event& operator=(event&& other) BOOST_NOEXCEPT
     {
         if(m_event){
             clReleaseEvent(m_event);

--- a/include/boost/compute/image2d.hpp
+++ b/include/boost/compute/image2d.hpp
@@ -102,13 +102,13 @@ public:
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
     /// Move-constructs a new image object from \p other.
-    image2d(image2d&& other) noexcept
+    image2d(image2d&& other) BOOST_NOEXCEPT
         : memory_object(std::move(other))
     {
     }
 
     /// Move-assigns the image from \p other to \c *this.
-    image2d& operator=(image2d&& other) noexcept
+    image2d& operator=(image2d&& other) BOOST_NOEXCEPT
     {
         memory_object::operator=(std::move(other));
 

--- a/include/boost/compute/image3d.hpp
+++ b/include/boost/compute/image3d.hpp
@@ -103,13 +103,13 @@ public:
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
     /// Move-constructs a new image object from \p other.
-    image3d(image3d&& other) noexcept
+    image3d(image3d&& other) BOOST_NOEXCEPT
         : memory_object(std::move(other))
     {
     }
 
     /// Move-assigns the image from \p other to \c *this.
-    image3d& operator=(image3d&& other) noexcept
+    image3d& operator=(image3d&& other) BOOST_NOEXCEPT
     {
         memory_object::operator=(std::move(other));
 

--- a/include/boost/compute/image_sampler.hpp
+++ b/include/boost/compute/image_sampler.hpp
@@ -94,13 +94,13 @@ public:
     }
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
-    image_sampler(image_sampler&& other) noexcept
+    image_sampler(image_sampler&& other) BOOST_NOEXCEPT
         : m_sampler(other.m_sampler)
     {
         other.m_sampler = 0;
     }
 
-    image_sampler& operator=(image_sampler&& other) noexcept
+    image_sampler& operator=(image_sampler&& other) BOOST_NOEXCEPT
     {
         if(m_sampler){
             clReleaseSampler(m_sampler);

--- a/include/boost/compute/kernel.hpp
+++ b/include/boost/compute/kernel.hpp
@@ -94,14 +94,14 @@ public:
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
     /// Move-constructs a new kernel object from \p other.
-    kernel(kernel&& other) noexcept
+    kernel(kernel&& other) BOOST_NOEXCEPT
         : m_kernel(other.m_kernel)
     {
         other.m_kernel = 0;
     }
 
     /// Move-assigns the kernel from \p other to \c *this.
-    kernel& operator=(kernel&& other) noexcept
+    kernel& operator=(kernel&& other) BOOST_NOEXCEPT
     {
         if(m_kernel){
             clReleaseKernel(m_kernel);

--- a/include/boost/compute/memory_object.hpp
+++ b/include/boost/compute/memory_object.hpp
@@ -167,14 +167,14 @@ protected:
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
     /// \internal_
-    memory_object(memory_object&& other) noexcept
+    memory_object(memory_object&& other) BOOST_NOEXCEPT
         : m_mem(other.m_mem)
     {
         other.m_mem = 0;
     }
 
     /// \internal_
-    memory_object& operator=(memory_object&& other) noexcept
+    memory_object& operator=(memory_object&& other) BOOST_NOEXCEPT
     {
         if(m_mem){
             clReleaseMemObject(m_mem);

--- a/include/boost/compute/program.hpp
+++ b/include/boost/compute/program.hpp
@@ -118,14 +118,14 @@ public:
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
     /// Move-constructs a new program object from \p other.
-    program(program&& other) noexcept
+    program(program&& other) BOOST_NOEXCEPT
         : m_program(other.m_program)
     {
         other.m_program = 0;
     }
 
     /// Move-assigns the program from \p other to \c *this.
-    program& operator=(program&& other) noexcept
+    program& operator=(program&& other) BOOST_NOEXCEPT
     {
         if(m_program){
             clReleaseProgram(m_program);

--- a/include/boost/compute/user_event.hpp
+++ b/include/boost/compute/user_event.hpp
@@ -55,13 +55,13 @@ public:
 
     #ifndef BOOST_COMPUTE_NO_RVALUE_REFERENCES
     /// Move-constructs a new user event object from \p other.
-    user_event(user_event&& other) noexcept
+    user_event(user_event&& other) BOOST_NOEXCEPT
         : event(std::move(other))
     {
     }
 
     /// Move-assigns the user event from \p other to \c *this.
-    user_event& operator=(user_event&& other) noexcept
+    user_event& operator=(user_event&& other) BOOST_NOEXCEPT
     {
         event::operator=(std::move(other));
 


### PR DESCRIPTION
Replace `noexcept` with `BOOST_NOEXCEPT` to support pre-c++11 compilers.
