### PR TITLE
Add benchmarks for partitioning algorithms

### DIFF
--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -20,6 +20,8 @@ set(BENCHMARKS
   merge
   mersenne_twister
   partial_sum
+  partition
+  partition_point
   reverse
   rotate
   rotate_copy
@@ -32,6 +34,7 @@ set(BENCHMARKS
   sort
   sort_by_key
   sort_float
+  stable_partition
   unique
   unique_copy
   exclusive_scan
@@ -51,6 +54,7 @@ set(STL_BENCHMARKS
   stl_inner_product
   stl_merge
   stl_partial_sum
+  stl_partition
   stl_reverse
   stl_rotate
   stl_rotate_copy
@@ -60,9 +64,18 @@ set(STL_BENCHMARKS
   stl_set_symmetric_difference
   stl_set_union
   stl_sort
+  stl_stable_partition
   stl_unique
   stl_unique_copy
 )
+
+# stl benchmarks which rerquire c++11
+if(${BOOST_COMPUTE_USE_CPP11})
+  list(APPEND
+    STL_BENCHMARKS
+    stl_partition_point
+  )
+endif()
 
 foreach(BENCHMARK ${STL_BENCHMARKS})
   set(PERF_TARGET perf_${BENCHMARK})

--- a/perf/perf.py
+++ b/perf/perf.py
@@ -110,11 +110,34 @@ def run_benchmark(name, sizes, vs=[]):
         report.add_sample("compute", size, time)
 
     competitors = {
-        "thrust" : ["accumulate", "count", "inner_product", "partial_sum", "sort", "saxpy"],
-        "tbb": ["accumulate", "merge", "sort"],
-        "stl": ["accumulate", "count", "includes", "inner_product", "merge",  "partial_sum",
-                "reverse", "rotate", "rotate_copy", "set_difference", "set_intersection",
-                "set_symmetric_difference", "set_union", "sort", "unique", "unique_copy"]
+        "thrust" : ["accumulate",
+                    "count",
+                    "inner_product",
+                    "partial_sum",
+                    "sort",
+                    "saxpy"],
+        "tbb": ["accumulate",
+                "merge",
+                "sort"],
+        "stl": ["accumulate",
+                "count",
+                "includes",
+                "inner_product",
+                "merge",
+                "partial_sum",
+                "partition",
+                "partition_point",
+                "reverse",
+                "rotate",
+                "rotate_copy",
+                "set_difference",
+                "set_intersection",
+                "set_symmetric_difference",
+                "set_union",
+                "sort",
+                "stable_partition",
+                "unique",
+                "unique_copy"]
     }
 
     for other in vs:

--- a/perf/perf_partition.cpp
+++ b/perf/perf_partition.cpp
@@ -1,0 +1,62 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Roshan <thisisroshansmail@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+#include <boost/compute/system.hpp>
+#include <boost/compute/algorithm/partition.hpp>
+#include <boost/compute/container/vector.hpp>
+
+#include "perf.hpp"
+
+int rand_int()
+{
+    return static_cast<int>((rand() / double(RAND_MAX)) * 25.0);
+}
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+    std::cout << "size: " << PERF_N << std::endl;
+
+    // setup context and queue for the default device
+    boost::compute::device device = boost::compute::system::default_device();
+    boost::compute::context context(device);
+    boost::compute::command_queue queue(context, device);
+    std::cout << "device: " << device.name() << std::endl;
+
+    // create vector of random numbers on the host
+    std::vector<int> host_vector(PERF_N);
+    std::generate(host_vector.begin(), host_vector.end(), rand_int);
+
+    // create vector on the device and copy the data
+    boost::compute::vector<int> device_vector(PERF_N, context);
+    boost::compute::copy(
+        host_vector.begin(), host_vector.end(), device_vector.begin(), queue
+    );
+
+    using boost::compute::_1;
+
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        t.start();
+        boost::compute::partition(
+            device_vector.begin(), device_vector.end(), _1 < 10, queue
+        );
+        queue.finish();
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+
+    return 0;
+}

--- a/perf/perf_partition_point.cpp
+++ b/perf/perf_partition_point.cpp
@@ -1,0 +1,68 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Roshan <thisisroshansmail@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+#include <boost/compute/system.hpp>
+#include <boost/compute/lambda.hpp>
+#include <boost/compute/algorithm/partition.hpp>
+#include <boost/compute/algorithm/partition_point.hpp>
+#include <boost/compute/container/vector.hpp>
+
+#include "perf.hpp"
+
+int rand_int()
+{
+    return static_cast<int>((rand() / double(RAND_MAX)) * 25.0);
+}
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+    std::cout << "size: " << PERF_N << std::endl;
+
+    // setup context and queue for the default device
+    boost::compute::device device = boost::compute::system::default_device();
+    boost::compute::context context(device);
+    boost::compute::command_queue queue(context, device);
+    std::cout << "device: " << device.name() << std::endl;
+
+    // create vector of random numbers on the host
+    std::vector<int> host_vector(PERF_N);
+    std::generate(host_vector.begin(), host_vector.end(), rand_int);
+
+    // create vector on the device and copy the data
+    boost::compute::vector<int> device_vector(PERF_N, context);
+    boost::compute::copy(
+        host_vector.begin(), host_vector.end(), device_vector.begin(), queue
+    );
+
+    using boost::compute::_1;
+    boost::compute::partition(
+        device_vector.begin(), device_vector.end(), _1 < 20, queue
+    );
+
+
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        t.start();
+        boost::compute::partition_point(
+            device_vector.begin(), device_vector.end(), _1 < 20, queue
+        );
+        queue.finish();
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+
+    return 0;
+}

--- a/perf/perf_stable_partition.cpp
+++ b/perf/perf_stable_partition.cpp
@@ -1,0 +1,62 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Roshan <thisisroshansmail@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+#include <boost/compute/system.hpp>
+#include <boost/compute/algorithm/stable_partition.hpp>
+#include <boost/compute/container/vector.hpp>
+
+#include "perf.hpp"
+
+int rand_int()
+{
+    return static_cast<int>((rand() / double(RAND_MAX)) * 25.0);
+}
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+    std::cout << "size: " << PERF_N << std::endl;
+
+    // setup context and queue for the default device
+    boost::compute::device device = boost::compute::system::default_device();
+    boost::compute::context context(device);
+    boost::compute::command_queue queue(context, device);
+    std::cout << "device: " << device.name() << std::endl;
+
+    // create vector of random numbers on the host
+    std::vector<int> host_vector(PERF_N);
+    std::generate(host_vector.begin(), host_vector.end(), rand_int);
+
+    // create vector on the device and copy the data
+    boost::compute::vector<int> device_vector(PERF_N, context);
+    boost::compute::copy(
+        host_vector.begin(), host_vector.end(), device_vector.begin(), queue
+    );
+
+    using boost::compute::_1;
+
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        t.start();
+        boost::compute::stable_partition(
+            device_vector.begin(), device_vector.end(), _1 < 10, queue
+        );
+        queue.finish();
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+
+    return 0;
+}

--- a/perf/perf_stl_partition.cpp
+++ b/perf/perf_stl_partition.cpp
@@ -1,0 +1,46 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Roshan <thisisroshansmail@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+#include "perf.hpp"
+
+int rand_int()
+{
+    return static_cast<int>((rand() / double(RAND_MAX)) * 25.0);
+}
+
+bool less_than_10(int value)
+{
+    return value < 10;
+}
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+    std::cout << "size: " << PERF_N << std::endl;
+
+    // create vector of random numbers on the host
+    std::vector<int> host_vector(PERF_N);
+    std::generate(host_vector.begin(), host_vector.end(), rand_int);
+
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        t.start();
+        std::partition(host_vector.begin(), host_vector.end(), less_than_10);
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+
+    return 0;
+}

--- a/perf/perf_stl_partition_point.cpp
+++ b/perf/perf_stl_partition_point.cpp
@@ -1,0 +1,48 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Roshan <thisisroshansmail@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+#include "perf.hpp"
+
+int rand_int()
+{
+    return static_cast<int>((rand() / double(RAND_MAX)) * 25.0);
+}
+
+bool less_than_20(int value)
+{
+    return value < 20;
+}
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+    std::cout << "size: " << PERF_N << std::endl;
+
+    // create vector of random numbers on the host
+    std::vector<int> host_vector(PERF_N);
+    std::generate(host_vector.begin(), host_vector.end(), rand_int);
+    std::partition(host_vector.begin(), host_vector.end(),
+                    less_than_20);
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        t.start();
+        std::partition_point(host_vector.begin(), host_vector.end(),
+                             less_than_20);
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+
+    return 0;
+}

--- a/perf/perf_stl_stable_partition.cpp
+++ b/perf/perf_stl_stable_partition.cpp
@@ -1,0 +1,47 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Roshan <thisisroshansmail@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+#include "perf.hpp"
+
+int rand_int()
+{
+    return static_cast<int>((rand() / double(RAND_MAX)) * 25.0);
+}
+
+bool less_than_10(int value)
+{
+    return value < 10;
+}
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+    std::cout << "size: " << PERF_N << std::endl;
+
+    // create vector of random numbers on the host
+    std::vector<int> host_vector(PERF_N);
+    std::generate(host_vector.begin(), host_vector.end(), rand_int);
+
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        t.start();
+        std::stable_partition(host_vector.begin(), host_vector.end(),
+                                less_than_10);
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
Added benchmarks for the partitioning algorithms. Also, changed `competitiors` in `perf.py` to have a vertical layout to make it look better as more benchmarks are added...
