### PR TITLE
Fix errors when using platforms with no devices

### DIFF
--- a/include/boost/compute/platform.hpp
+++ b/include/boost/compute/platform.hpp
@@ -118,6 +118,10 @@ public:
     std::vector<device> devices(cl_device_type type = CL_DEVICE_TYPE_ALL) const
     {
         size_t count = device_count(type);
+        if(count == 0){
+            // no devices for this platform
+            return std::vector<device>();
+        }
 
         std::vector<cl_device_id> device_ids(count);
         cl_int ret = clGetDeviceIDs(m_platform,
@@ -143,7 +147,14 @@ public:
         cl_uint count = 0;
         cl_int ret = clGetDeviceIDs(m_platform, type, 0, 0, &count);
         if(ret != CL_SUCCESS){
-            BOOST_THROW_EXCEPTION(opencl_error(ret));
+            if(ret == CL_DEVICE_NOT_FOUND){
+                // no devices for this platform
+                return 0;
+            }
+            else {
+                // something else went wrong
+                BOOST_THROW_EXCEPTION(opencl_error(ret));
+            }
         }
 
         return count;


### PR DESCRIPTION
This fixes errors caused when handling OpenCL platforms with
no devices. Now the platform::devices() method will properly
return an empty vector without throwing an exception when such
a platform is encountered.

Previously, default_device() would throw an exception when
confronted with a platform with no devices even if devices
from other platforms on the system were available.

Thanks to Godeffroy Valet for reporting this issue.
