### PR TITLE
Fix resize bug with vector::assign()

### DIFF
--- a/include/boost/compute/container/vector.hpp
+++ b/include/boost/compute/container/vector.hpp
@@ -472,6 +472,10 @@ public:
                 InputIterator last,
                 command_queue &queue)
     {
+        // resize vector for new contents
+        resize(detail::iterator_range_size(first, last), queue);
+
+        // copy values into the vector
         ::boost::compute::copy(first, last, begin(), queue);
     }
 
@@ -485,6 +489,10 @@ public:
 
     void assign(size_type n, const T &value, command_queue &queue)
     {
+        // resize vector for new contents
+        resize(n, queue);
+
+        // fill vector with value
         ::boost::compute::fill_n(begin(), n, value, queue);
     }
 

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -291,4 +291,26 @@ BOOST_AUTO_TEST_CASE(swap_between_contexts)
     vec2.resize(64);
 }
 
+BOOST_AUTO_TEST_CASE(assign_from_std_vector)
+{
+    std::vector<int> host_vector;
+    host_vector.push_back(1);
+    host_vector.push_back(9);
+    host_vector.push_back(7);
+    host_vector.push_back(9);
+
+    compute::vector<int> device_vector(context);
+    device_vector.assign(host_vector.begin(), host_vector.end(), queue);
+    BOOST_CHECK_EQUAL(device_vector.size(), size_t(4));
+    CHECK_RANGE_EQUAL(int, 4, device_vector, (1, 9, 7, 9));
+}
+
+BOOST_AUTO_TEST_CASE(assign_constant_value)
+{
+    compute::vector<float> device_vector(10, context);
+    device_vector.assign(3, 6.28f, queue);
+    BOOST_CHECK_EQUAL(device_vector.size(), size_t(3));
+    CHECK_RANGE_EQUAL(float, 3, device_vector, (6.28f, 6.28f, 6.28f));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This fixes a bug in which vector::assign() would not resize
itself to accommodate the assigned values. Now the behavior
matches that of std::vector.
