### PR TITLE
Move device_ptr to the detail namespace

### DIFF
--- a/include/boost/compute/container/allocator.hpp
+++ b/include/boost/compute/container/allocator.hpp
@@ -14,7 +14,7 @@
 #include <boost/compute/buffer.hpp>
 #include <boost/compute/config.hpp>
 #include <boost/compute/context.hpp>
-#include <boost/compute/device_ptr.hpp>
+#include <boost/compute/detail/device_ptr.hpp>
 
 namespace boost {
 namespace compute {
@@ -24,8 +24,8 @@ class allocator
 {
 public:
     typedef T value_type;
-    typedef device_ptr<T> pointer;
-    typedef const device_ptr<T> const_pointer;
+    typedef detail::device_ptr<T> pointer;
+    typedef const detail::device_ptr<T> const_pointer;
     typedef std::size_t size_type;
     typedef std::ptrdiff_t difference_type;
 
@@ -75,7 +75,7 @@ public:
     {
         buffer buf(m_context, n * sizeof(T), m_mem_flags);
         clRetainMemObject(buf.get());
-        return device_ptr<T>(buf);
+        return detail::device_ptr<T>(buf);
     }
 
     void deallocate(pointer p, size_type n)

--- a/include/boost/compute/detail/buffer_value.hpp
+++ b/include/boost/compute/detail/buffer_value.hpp
@@ -12,8 +12,8 @@
 #define BOOST_COMPUTE_DETAIL_BUFFER_VALUE_HPP
 
 #include <boost/compute/context.hpp>
-#include <boost/compute/device_ptr.hpp>
 #include <boost/compute/command_queue.hpp>
+#include <boost/compute/detail/device_ptr.hpp>
 #include <boost/compute/detail/read_write_single_value.hpp>
 
 namespace boost {
@@ -139,9 +139,9 @@ public:
         return operator=(T(value));
     }
 
-    device_ptr<T> operator&() const
+    detail::device_ptr<T> operator&() const
     {
-        return device_ptr<T>(m_buffer, m_index);
+        return detail::device_ptr<T>(m_buffer, m_index);
     }
 
     buffer_value<T>& operator++()

--- a/include/boost/compute/detail/device_ptr.hpp
+++ b/include/boost/compute/detail/device_ptr.hpp
@@ -57,8 +57,6 @@ struct device_ptr_index_expr
     IndexExpr m_expr;
 };
 
-} // end detail namespace
-
 template<class T>
 class device_ptr
 {
@@ -192,8 +190,6 @@ private:
     const buffer m_buffer;
     size_t m_index;
 };
-
-namespace detail {
 
 // is_buffer_iterator specialization for buffer_iterator
 template<class Iterator>

--- a/include/boost/compute/detail/meta_kernel.hpp
+++ b/include/boost/compute/detail/meta_kernel.hpp
@@ -30,12 +30,12 @@
 #include <boost/compute/image3d.hpp>
 #include <boost/compute/closure.hpp>
 #include <boost/compute/function.hpp>
-#include <boost/compute/device_ptr.hpp>
 #include <boost/compute/functional.hpp>
 #include <boost/compute/type_traits.hpp>
 #include <boost/compute/command_queue.hpp>
 #include <boost/compute/image_sampler.hpp>
 #include <boost/compute/memory_object.hpp>
+#include <boost/compute/detail/device_ptr.hpp>
 #include <boost/compute/detail/program_cache.hpp>
 #include <boost/compute/detail/sha1.hpp>
 
@@ -911,7 +911,7 @@ inline meta_kernel& operator<<(meta_kernel &kernel,
 
 template<class T, class IndexExpr>
 inline meta_kernel& operator<<(meta_kernel &kernel,
-                               const device_ptr_index_expr<T, IndexExpr> &expr)
+                               const detail::device_ptr_index_expr<T, IndexExpr> &expr)
 {
     if(expr.m_index == 0){
         return kernel <<
@@ -927,7 +927,7 @@ inline meta_kernel& operator<<(meta_kernel &kernel,
 
 template<class T1, class T2, class IndexExpr>
 inline meta_kernel& operator<<(meta_kernel &kernel,
-                               const device_ptr_index_expr<std::pair<T1, T2>, IndexExpr> &expr)
+                               const detail::device_ptr_index_expr<std::pair<T1, T2>, IndexExpr> &expr)
 {
     typedef std::pair<T1, T2> T;
 

--- a/include/boost/compute/experimental/malloc.hpp
+++ b/include/boost/compute/experimental/malloc.hpp
@@ -14,11 +14,14 @@
 #include <boost/compute/buffer.hpp>
 #include <boost/compute/system.hpp>
 #include <boost/compute/context.hpp>
-#include <boost/compute/device_ptr.hpp>
+#include <boost/compute/detail/device_ptr.hpp>
 
 namespace boost {
 namespace compute {
 namespace experimental {
+
+// bring device_ptr into the experimental namespace
+using detail::device_ptr;
 
 template<class T>
 inline device_ptr<T>

--- a/test/test_malloc.cpp
+++ b/test/test_malloc.cpp
@@ -20,7 +20,7 @@ namespace bc = boost::compute;
 
 BOOST_AUTO_TEST_CASE(malloc_int)
 {
-    bc::device_ptr<int> ptr = bc::experimental::malloc<int>(5);
+    bc::experimental::device_ptr<int> ptr = bc::experimental::malloc<int>(5);
 
     int input_data[] = { 2, 5, 8, 3, 6 };
     bc::copy(input_data, input_data + 5, ptr);

--- a/test/test_type_traits.cpp
+++ b/test/test_type_traits.cpp
@@ -20,7 +20,6 @@
 
 #include <boost/compute/types.hpp>
 #include <boost/compute/type_traits.hpp>
-#include <boost/compute/device_ptr.hpp>
 #include <boost/compute/iterator/buffer_iterator.hpp>
 #include <boost/compute/iterator/constant_iterator.hpp>
 #include <boost/compute/detail/is_buffer_iterator.hpp>
@@ -126,5 +125,4 @@ BOOST_AUTO_TEST_CASE(is_device_iterator)
     BOOST_STATIC_ASSERT(is_device_iterator<boost::compute::constant_iterator<int> >::value == true);
     BOOST_STATIC_ASSERT(is_device_iterator<std::vector<int>::iterator>::value == false);
     BOOST_STATIC_ASSERT(is_device_iterator<float *>::value == false);
-    BOOST_STATIC_ASSERT(is_device_iterator<boost::compute::device_ptr<float> >::value == true);
 }


### PR DESCRIPTION
This deprecates the device_ptr class and moves it to the detail
namespace. The buffer_iterator class should be used instead of
device_ptr for referencing a memory location on the device.
