### PR TITLE
Check OpenCL version before calling enqueue_fill_buffer()

### DIFF
--- a/include/boost/compute/algorithm/fill.hpp
+++ b/include/boost/compute/algorithm/fill.hpp
@@ -112,6 +112,11 @@ dispatch_fill(BufferIterator first,
         return;
     }
 
+    // check if the device supports OpenCL 1.2 (required for enqueue_fill_buffer)
+    if(!queue.check_device_version(1, 2)){
+        return fill_with_copy(first, count, value, queue);
+    }
+
     value_type pattern = static_cast<value_type>(value);
     size_t offset = static_cast<size_t>(first.get_index());
 
@@ -148,6 +153,11 @@ dispatch_fill_async(BufferIterator first,
                     >::type* = 0)
 {
     typedef typename std::iterator_traits<BufferIterator>::value_type value_type;
+
+    // check if the device supports OpenCL 1.2 (required for enqueue_fill_buffer)
+    if(!queue.check_device_version(1, 2)){
+        return fill_async_with_copy(first, count, value, queue);
+    }
 
     value_type pattern = static_cast<value_type>(value);
     size_t offset = static_cast<size_t>(first.get_index());

--- a/include/boost/compute/command_queue.hpp
+++ b/include/boost/compute/command_queue.hpp
@@ -1421,6 +1421,12 @@ public:
         return m_queue;
     }
 
+    /// \internal_
+    bool check_device_version(int major, int minor) const
+    {
+        return get_device().check_version(major, minor);
+    }
+
 private:
     cl_command_queue m_queue;
 };

--- a/include/boost/compute/device.hpp
+++ b/include/boost/compute/device.hpp
@@ -396,6 +396,22 @@ public:
         return m_id != other.m_id;
     }
 
+    /// \internal_
+    bool check_version(int major, int minor) const
+    {
+        std::stringstream stream;
+        stream << version();
+
+        int actual_major, actual_minor;
+        stream.ignore(7); // 'OpenCL '
+        stream >> actual_major;
+        stream.ignore(1); // '.'
+        stream >> actual_minor;
+
+        return actual_major > major ||
+               (actual_major == major && actual_minor >= minor);
+    }
+
 private:
     cl_device_id m_id;
 };


### PR DESCRIPTION
This adds a check for OpenCL version 1.2 before calling the
enqueue_fill_buffer() function in the fill() algorithm.
