### PR TITLE
explicitly look for Qt4 and not for Qt in general

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -77,7 +77,7 @@ endif()
 
 # qt examples
 if(${BOOST_COMPUTE_HAVE_QT})
-  find_package(Qt REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
+  find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
   set(CMAKE_AUTOMOC TRUE)
   set(QT_USE_QTOPENGL TRUE)
   include(${QT_USE_FILE})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -179,7 +179,7 @@ endif()
 
 # qt interop tests
 if(${BOOST_COMPUTE_HAVE_QT})
-  find_package(Qt REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
+  find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
   include(${QT_USE_FILE})
   add_compute_test("interop.qt" test_interop_qt.cpp)
   target_link_libraries(test_interop_qt ${QT_LIBRARIES})


### PR DESCRIPTION
I had a problem building the Qt examples, so I looked into the CMakeLists.

I use CMake 3.0.0 and have both Qt4 and Qt5 installed. QT_USE_FILE is defined by the FindQt4.cmake module that comes shipped with CMake. In versions older than 3.0.0 the FindQt.cmake module uses FindQt4.cmake to find Qt. In newer versions CMake will look for Qt5 so that QT_USE_FILE is not defined. By directly looking for Qt4 by calling find_package(Qt REQUIRED COMPONENTS QtCore QtGui QtOpenGL) everything works fine, even when using CMake 2.8.8.
