### PR TITLE
use qt5 and fall back to qt4

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -77,20 +77,48 @@ endif()
 
 # qt examples
 if(${BOOST_COMPUTE_HAVE_QT})
-  find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
-  set(CMAKE_AUTOMOC TRUE)
-  set(QT_USE_QTOPENGL TRUE)
-  include(${QT_USE_FILE})
-  include_directories(${CMAKE_CURRENT_BINARY_DIR})
-  add_executable(qimage_blur qimage_blur.cpp)
-  target_link_libraries(qimage_blur ${OPENCL_LIBRARIES} ${Boost_LIBRARIES} ${QT_LIBRARIES})
+  find_package(Qt REQUIRED)
+  string(SUBSTRING ${QTVERSION} 0 1 QT_MAJOR_VERSION)
 
-  set(QT_OPENGL_EXAMPLES
-    mandelbrot
-    resize_image
-  )
-  foreach(EXAMPLE ${QT_OPENGL_EXAMPLES})
-    add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
-    target_link_libraries(${EXAMPLE} ${OPENCL_LIBRARIES} ${Boost_LIBRARIES} ${QT_LIBRARIES} GL)
-  endforeach()
+  if(QT_MAJOR_VERSION STREQUAL "5")
+    # use qt5
+    find_package(Qt5Core REQUIRED)
+    find_package(Qt5Widgets REQUIRED)
+    find_package(Qt5OpenGL REQUIRED)
+    set(CMAKE_AUTOMOC TRUE)
+    include_directories(${CMAKE_CURRENT_BINARY_DIR})
+    include_directories(${Qt5OpenGL_INCLUDE_DIRS})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt5OpenGL_EXECUTABLE_COMPILE_FLAGS}")
+
+    add_executable(qimage_blur qimage_blur.cpp)
+    target_link_libraries(qimage_blur ${OPENCL_LIBRARIES} ${Boost_LIBRARIES} ${Qt5Widgets_LIBRARIES})
+
+    set(QT_OPENGL_EXAMPLES
+      mandelbrot
+      resize_image
+    )
+    foreach(EXAMPLE ${QT_OPENGL_EXAMPLES})
+      add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+      target_link_libraries(${EXAMPLE} ${OPENCL_LIBRARIES} ${Boost_LIBRARIES} ${Qt5OpenGL_LIBRARIES} GL)
+    endforeach()
+  else()
+    # use qt4
+    find_package(Qt REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
+    set(CMAKE_AUTOMOC TRUE)
+    set(QT_USE_QTOPENGL TRUE)
+    include(${QT_USE_FILE})
+    include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+    add_executable(qimage_blur qimage_blur.cpp)
+    target_link_libraries(qimage_blur ${OPENCL_LIBRARIES} ${Boost_LIBRARIES} ${QT_LIBRARIES})
+
+    set(QT_OPENGL_EXAMPLES
+      mandelbrot
+      resize_image
+    )
+    foreach(EXAMPLE ${QT_OPENGL_EXAMPLES})
+      add_executable(${EXAMPLE} ${EXAMPLE}.cpp)
+      target_link_libraries(${EXAMPLE} ${OPENCL_LIBRARIES} ${Boost_LIBRARIES} ${QT_LIBRARIES} GL)
+    endforeach()
+  endif()
 endif()

--- a/example/mandelbrot.cpp
+++ b/example/mandelbrot.cpp
@@ -11,7 +11,12 @@
 #include <iostream>
 #include <algorithm>
 
+#include <QtGlobal>
+#if QT_VERSION >= 0x050000
+#include <QtWidgets>
+#else
 #include <QtGui>
+#endif
 #include <QtOpenGL>
 
 #include <boost/compute/command_queue.hpp>

--- a/example/qimage_blur.cpp
+++ b/example/qimage_blur.cpp
@@ -1,7 +1,12 @@
 #include <iostream>
 #include <algorithm>
 
+#include <QtGlobal>
+#if QT_VERSION >= 0x050000
+#include <QtWidgets>
+#else
 #include <QtGui>
+#endif
 
 #include <boost/compute/source.hpp>
 #include <boost/compute/system.hpp>

--- a/example/resize_image.cpp
+++ b/example/resize_image.cpp
@@ -11,7 +11,12 @@
 #include <iostream>
 #include <algorithm>
 
+#include <QtGlobal>
+#if QT_VERSION >= 0x050000
+#include <QtWidgets>
+#else
 #include <QtGui>
+#endif
 #include <QtOpenGL>
 
 #include <boost/program_options.hpp>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -179,14 +179,37 @@ endif()
 
 # qt interop tests
 if(${BOOST_COMPUTE_HAVE_QT})
-  find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
-  include(${QT_USE_FILE})
-  add_compute_test("interop.qt" test_interop_qt.cpp)
-  target_link_libraries(test_interop_qt ${QT_LIBRARIES})
+  find_package(Qt REQUIRED)
+  string(SUBSTRING ${QTVERSION} 0 1 QT_MAJOR_VERSION)
 
-  # the opengl interop test depends on qt to create the opengl context
-  add_compute_test("interop.opengl" test_interop_opengl.cpp)
-  target_link_libraries(test_interop_opengl ${QT_LIBRARIES})
+  if(QT_MAJOR_VERSION)
+    # use qt5
+    find_package(Qt5Core REQUIRED)
+    find_package(Qt5Widgets REQUIRED)
+    find_package(Qt5OpenGL REQUIRED)
+    set(CMAKE_AUTOMOC TRUE)
+    include_directories(${CMAKE_CURRENT_BINARY_DIR})
+    include_directories(${Qt5OpenGL_INCLUDE_DIRS})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt5OpenGL_EXECUTABLE_COMPILE_FLAGS}")
+
+    add_compute_test("interop.qt" test_interop_qt.cpp)
+    target_link_libraries(test_interop_qt ${Qt5Widgets_LIBRARIES})
+
+    # the opengl interop test depends on qt to create the opengl context
+    add_compute_test("interop.opengl" test_interop_opengl.cpp)
+    target_link_libraries(test_interop_opengl ${Qt5OpenGL_LIBRARIES} GL)
+  else()
+    # use qt4
+    find_package(Qt REQUIRED COMPONENTS QtCore QtGui QtOpenGL)
+    include(${QT_USE_FILE})
+
+    add_compute_test("interop.qt" test_interop_qt.cpp)
+    target_link_libraries(test_interop_qt ${QT_LIBRARIES})
+
+    # the opengl interop test depends on qt to create the opengl context
+    add_compute_test("interop.opengl" test_interop_opengl.cpp)
+    target_link_libraries(test_interop_opengl ${QT_LIBRARIES} GL)
+  endif()
 endif()
 
 # vtk interop tests


### PR DESCRIPTION
This my idea about the Qt5 issue [#204](https://github.com/kylelutz/compute/issues/204). These CMakeLists look for Qt. Qt4 or Qt5 will be used depending on which version is found.
