### PR TITLE
Better perf fail warning

### DIFF
--- a/perf/perf.py
+++ b/perf/perf.py
@@ -22,7 +22,6 @@ def run_perf_process(name, size, backend = ""):
 
     filename = "./perf/" + proc
 
-    
     if not os.path.isfile(filename):
         print "Error: failed to find ", filename, " for running"
         return 0


### PR DESCRIPTION
I blindly ran `perf.py` and it then silently fails and gives you outputs of zero for all tests.

This will at least print a warning if the executable has not been compiled for running the test.
