### PR TITLE
Rename tile_sets kernel, add support for comparator

### DIFF
--- a/include/boost/compute/algorithm/includes.hpp
+++ b/include/boost/compute/algorithm/includes.hpp
@@ -13,7 +13,7 @@
 
 #include <iterator>
 
-#include <boost/compute/algorithm/detail/tile_sets.hpp>
+#include <boost/compute/algorithm/detail/balanced_path.hpp>
 #include <boost/compute/algorithm/fill_n.hpp>
 #include <boost/compute/algorithm/find.hpp>
 #include <boost/compute/container/vector.hpp>
@@ -127,7 +127,7 @@ inline bool includes(InputIterator1 first1,
     vector<uint_> tile_b((count1+count2+tile_size-1)/tile_size+1, queue.get_context());
 
     // Tile the sets
-    detail::tile_sets_kernel tiling_kernel;
+    detail::balanced_path_kernel tiling_kernel;
     tiling_kernel.tile_size = tile_size;
     tiling_kernel.set_range(first1, last1, first2, last2,
                             tile_a.begin()+1, tile_b.begin()+1);

--- a/include/boost/compute/algorithm/set_difference.hpp
+++ b/include/boost/compute/algorithm/set_difference.hpp
@@ -14,7 +14,7 @@
 #include <iterator>
 
 #include <boost/compute/algorithm/detail/compact.hpp>
-#include <boost/compute/algorithm/detail/tile_sets.hpp>
+#include <boost/compute/algorithm/detail/balanced_path.hpp>
 #include <boost/compute/algorithm/exclusive_scan.hpp>
 #include <boost/compute/algorithm/fill_n.hpp>
 #include <boost/compute/container/vector.hpp>
@@ -142,7 +142,7 @@ inline OutputIterator set_difference(InputIterator1 first1,
     vector<uint_> tile_b((count1+count2+tile_size-1)/tile_size+1, queue.get_context());
 
     // Tile the sets
-    detail::tile_sets_kernel tiling_kernel;
+    detail::balanced_path_kernel tiling_kernel;
     tiling_kernel.tile_size = tile_size;
     tiling_kernel.set_range(first1, last1, first2, last2,
                             tile_a.begin()+1, tile_b.begin()+1);

--- a/include/boost/compute/algorithm/set_intersection.hpp
+++ b/include/boost/compute/algorithm/set_intersection.hpp
@@ -14,7 +14,7 @@
 #include <iterator>
 
 #include <boost/compute/algorithm/detail/compact.hpp>
-#include <boost/compute/algorithm/detail/tile_sets.hpp>
+#include <boost/compute/algorithm/detail/balanced_path.hpp>
 #include <boost/compute/algorithm/exclusive_scan.hpp>
 #include <boost/compute/algorithm/fill_n.hpp>
 #include <boost/compute/container/vector.hpp>
@@ -130,7 +130,7 @@ inline OutputIterator set_intersection(InputIterator1 first1,
     vector<uint_> tile_b((count1+count2+tile_size-1)/tile_size+1, queue.get_context());
 
     // Tile the sets
-    detail::tile_sets_kernel tiling_kernel;
+    detail::balanced_path_kernel tiling_kernel;
     tiling_kernel.tile_size = tile_size;
     tiling_kernel.set_range(first1, last1, first2, last2,
                             tile_a.begin()+1, tile_b.begin()+1);

--- a/include/boost/compute/algorithm/set_symmetric_difference.hpp
+++ b/include/boost/compute/algorithm/set_symmetric_difference.hpp
@@ -14,7 +14,7 @@
 #include <iterator>
 
 #include <boost/compute/algorithm/detail/compact.hpp>
-#include <boost/compute/algorithm/detail/tile_sets.hpp>
+#include <boost/compute/algorithm/detail/balanced_path.hpp>
 #include <boost/compute/algorithm/exclusive_scan.hpp>
 #include <boost/compute/algorithm/fill_n.hpp>
 #include <boost/compute/container/vector.hpp>
@@ -153,7 +153,7 @@ inline OutputIterator set_symmetric_difference(InputIterator1 first1,
     vector<uint_> tile_b((count1+count2+tile_size-1)/tile_size+1, queue.get_context());
 
     // Tile the sets
-    detail::tile_sets_kernel tiling_kernel;
+    detail::balanced_path_kernel tiling_kernel;
     tiling_kernel.tile_size = tile_size;
     tiling_kernel.set_range(first1, last1, first2, last2,
                             tile_a.begin()+1, tile_b.begin()+1);

--- a/include/boost/compute/algorithm/set_union.hpp
+++ b/include/boost/compute/algorithm/set_union.hpp
@@ -13,8 +13,8 @@
 
 #include <iterator>
 
+#include <boost/compute/algorithm/detail/balanced_path.hpp>
 #include <boost/compute/algorithm/detail/compact.hpp>
-#include <boost/compute/algorithm/detail/tile_sets.hpp>
 #include <boost/compute/algorithm/exclusive_scan.hpp>
 #include <boost/compute/algorithm/fill_n.hpp>
 #include <boost/compute/container/vector.hpp>
@@ -155,7 +155,7 @@ inline OutputIterator set_union(InputIterator1 first1,
     vector<uint_> tile_b((count1+count2+tile_size-1)/tile_size+1, queue.get_context());
 
     // Tile the sets
-    detail::tile_sets_kernel tiling_kernel;
+    detail::balanced_path_kernel tiling_kernel;
     tiling_kernel.tile_size = tile_size;
     tiling_kernel.set_range(first1, last1, first2, last2,
                             tile_a.begin()+1, tile_b.begin()+1);


### PR DESCRIPTION
Renamed the tile_sets kernel to balanced_path for consistency with
merge_path. Also added support for giving a custom comparator.
