### PR TITLE
Declare cnd() function static in black_scholes example

### DIFF
--- a/example/black_scholes.cpp
+++ b/example/black_scholes.cpp
@@ -70,7 +70,7 @@ int main()
     // source code for black-scholes program
     const char source[] = BOOST_COMPUTE_STRINGIZE_SOURCE(
         // approximation of the cumulative normal distribution function
-        float cnd(float d)
+        static float cnd(float d)
         {
             const float A1 =  0.319381530f;
             const float A2 = -0.356563782f;


### PR DESCRIPTION
This fixes an issue (#276) when compiling the black_scholes
program on Mac OS X.
