### PR TITLE
Change vector<T> to use the system-wide default queue

### DIFF
--- a/include/boost/compute/container/flat_map.hpp
+++ b/include/boost/compute/container/flat_map.hpp
@@ -55,8 +55,9 @@ public:
     {
     }
 
-    flat_map(const flat_map<Key, T> &other)
-        : m_vector(other.m_vector)
+    flat_map(const flat_map<Key, T> &other,
+             command_queue &queue = system::default_queue())
+        : m_vector(other.m_vector, queue)
     {
     }
 
@@ -153,16 +154,10 @@ public:
         return m_vector.capacity();
     }
 
-    void reserve(size_type size, command_queue &queue)
+    void reserve(size_type size,
+                 command_queue &queue = system::default_queue())
     {
         m_vector.reserve(size, queue);
-    }
-
-    void reserve(size_type size)
-    {
-        command_queue queue = m_vector.default_queue();
-        reserve(size, queue);
-        queue.finish();
     }
 
     void shrink_to_fit()
@@ -176,7 +171,8 @@ public:
     }
 
     std::pair<iterator, bool>
-    insert(const value_type &value, command_queue &queue)
+    insert(const value_type &value,
+           command_queue &queue = system::default_queue())
     {
         iterator location = upper_bound(value.first, queue);
 
@@ -192,43 +188,21 @@ public:
         return std::make_pair(location, true);
     }
 
-    std::pair<iterator, bool> insert(const value_type &value)
-    {
-        command_queue queue = m_vector.default_queue();
-        std::pair<iterator, bool> result = insert(value, queue);
-        queue.finish();
-        return result;
-    }
-
-    iterator erase(const const_iterator &position, command_queue &queue)
+    iterator erase(const const_iterator &position,
+                   command_queue &queue = system::default_queue())
     {
         return erase(position, position + 1, queue);
     }
 
-    iterator erase(const const_iterator &position)
-    {
-        command_queue queue = m_vector.default_queue();
-        iterator iter = erase(position, queue);
-        queue.finish();
-        return iter;
-    }
-
     iterator erase(const const_iterator &first,
                    const const_iterator &last,
-                   command_queue &queue)
+                   command_queue &queue = system::default_queue())
     {
         return m_vector.erase(first, last, queue);
     }
 
-    iterator erase(const const_iterator &first, const const_iterator &last)
-    {
-        command_queue queue = m_vector.default_queue();
-        iterator iter = erase(first, last, queue);
-        queue.finish();
-        return iter;
-    }
-
-    size_type erase(const key_type &value, command_queue &queue)
+    size_type erase(const key_type &value,
+                    command_queue &queue = system::default_queue())
     {
         iterator position = find(value, queue);
 
@@ -241,7 +215,8 @@ public:
         }
     }
 
-    iterator find(const key_type &value, command_queue &queue)
+    iterator find(const key_type &value,
+                  command_queue &queue = system::default_queue())
     {
         ::boost::compute::get<0> get_key;
 
@@ -253,15 +228,8 @@ public:
                ).base();
     }
 
-    iterator find(const key_type &value)
-    {
-        command_queue queue = m_vector.default_queue();
-        iterator iter = find(value, queue);
-        queue.finish();
-        return iter;
-    }
-
-    const_iterator find(const key_type &value, command_queue &queue) const
+    const_iterator find(const key_type &value,
+                        command_queue &queue = system::default_queue()) const
     {
         ::boost::compute::get<0> get_key;
 
@@ -273,28 +241,14 @@ public:
                ).base();
     }
 
-    const_iterator find(const key_type &value) const
-    {
-        command_queue queue = m_vector.default_queue();
-        const_iterator iter = find(value, queue);
-        queue.finish();
-        return iter;
-    }
-
-    size_type count(const key_type &value, command_queue &queue) const
+    size_type count(const key_type &value,
+                    command_queue &queue = system::default_queue()) const
     {
         return find(value, queue) != end() ? 1 : 0;
     }
 
-    size_type count(const key_type &value) const
-    {
-        command_queue queue = m_vector.default_queue();
-        size_type result = count(value, queue);
-        queue.finish();
-        return result;
-    }
-
-    iterator lower_bound(const key_type &value, command_queue &queue)
+    iterator lower_bound(const key_type &value,
+                         command_queue &queue = system::default_queue())
     {
         ::boost::compute::get<0> get_key;
 
@@ -306,15 +260,8 @@ public:
                ).base();
     }
 
-    iterator lower_bound(const key_type &value)
-    {
-        command_queue queue = m_vector.default_queue();
-        iterator iter = lower_bound(value, queue);
-        queue.finish();
-        return iter;
-    }
-
-    const_iterator lower_bound(const key_type &value, command_queue &queue) const
+    const_iterator lower_bound(const key_type &value,
+                               command_queue &queue = system::default_queue()) const
     {
         ::boost::compute::get<0> get_key;
 
@@ -326,15 +273,8 @@ public:
                ).base();
     }
 
-    const_iterator lower_bound(const key_type &value) const
-    {
-        command_queue queue = m_vector.default_queue();
-        const_iterator iter = lower_bound(value, queue);
-        queue.finish();
-        return iter;
-    }
-
-    iterator upper_bound(const key_type &value, command_queue &queue)
+    iterator upper_bound(const key_type &value,
+                         command_queue &queue = system::default_queue())
     {
         ::boost::compute::get<0> get_key;
 
@@ -346,15 +286,8 @@ public:
                ).base();
     }
 
-    iterator upper_bound(const key_type &value)
-    {
-        command_queue queue = m_vector.default_queue();
-        iterator iter = upper_bound(value, queue);
-        queue.finish();
-        return iter;
-    }
-
-    const_iterator upper_bound(const key_type &value, command_queue &queue) const
+    const_iterator upper_bound(const key_type &value,
+                               command_queue &queue = system::default_queue()) const
     {
         ::boost::compute::get<0> get_key;
 
@@ -364,14 +297,6 @@ public:
                    value,
                    queue
                ).base();
-    }
-
-    const_iterator upper_bound(const key_type &value) const
-    {
-        command_queue queue = m_vector.default_queue();
-        const_iterator iter = upper_bound(value, queue);
-        queue.finish();
-        return iter;
     }
 
     const mapped_type at(const key_type &key) const
@@ -390,6 +315,9 @@ public:
         if(iter == end()){
             iter = insert(std::make_pair(key, mapped_type())).first;
         }
+
+        // ensure insert() is finished before returning value
+        system::finish();
 
         size_t index = iter.get_index() * sizeof(value_type) + sizeof(key_type);
 

--- a/include/boost/compute/container/flat_set.hpp
+++ b/include/boost/compute/container/flat_set.hpp
@@ -44,8 +44,9 @@ public:
     {
     }
 
-    flat_set(const flat_set<T> &other)
-        : m_vector(other.m_vector)
+    flat_set(const flat_set<T> &other,
+             command_queue &queue = system::default_queue())
+        : m_vector(other.m_vector, queue)
     {
     }
 
@@ -142,16 +143,10 @@ public:
         return m_vector.capacity();
     }
 
-    void reserve(size_type size, command_queue &queue)
+    void reserve(size_type size,
+                 command_queue &queue = system::default_queue())
     {
         m_vector.reserve(size, queue);
-    }
-
-    void reserve(size_type size)
-    {
-        command_queue queue = m_vector.default_queue();
-        reserve(size, queue);
-        queue.finish();
     }
 
     void shrink_to_fit()
@@ -165,7 +160,8 @@ public:
     }
 
     std::pair<iterator, bool>
-    insert(const value_type &value, command_queue &queue)
+    insert(const value_type &value,
+           command_queue &queue = system::default_queue())
     {
         iterator location = upper_bound(value, queue);
 
@@ -181,43 +177,21 @@ public:
         return std::make_pair(location, true);
     }
 
-    std::pair<iterator, bool> insert(const value_type &value)
-    {
-        command_queue queue = m_vector.default_queue();
-        std::pair<iterator, bool> result = insert(value, queue);
-        queue.finish();
-        return result;
-    }
-
-    iterator erase(const const_iterator &position, command_queue &queue)
+    iterator erase(const const_iterator &position,
+                   command_queue &queue = system::default_queue())
     {
         return erase(position, position + 1, queue);
     }
 
-    iterator erase(const const_iterator &position)
-    {
-        command_queue queue = m_vector.default_queue();
-        iterator iter = erase(position, queue);
-        queue.finish();
-        return iter;
-    }
-
     iterator erase(const const_iterator &first,
                    const const_iterator &last,
-                   command_queue &queue)
+                   command_queue &queue = system::default_queue())
     {
         return m_vector.erase(first, last, queue);
     }
 
-    iterator erase(const const_iterator &first, const const_iterator &last)
-    {
-        command_queue queue = m_vector.default_queue();
-        iterator iter = erase(first, last, queue);
-        queue.finish();
-        return iter;
-    }
-
-    size_type erase(const key_type &value, command_queue &queue)
+    size_type erase(const key_type &value,
+                    command_queue queue = system::default_queue())
     {
         iterator position = find(value, queue);
 
@@ -230,103 +204,46 @@ public:
         }
     }
 
-    size_type erase(const key_type &value)
-    {
-        command_queue queue = m_vector.default_queue();
-        size_type result = erase(value, queue);
-        queue.finish();
-        return result;
-    }
-
-    iterator find(const key_type &value, command_queue &queue)
+    iterator find(const key_type &value,
+                  command_queue queue = system::default_queue())
     {
         return ::boost::compute::find(begin(), end(), value, queue);
     }
 
-    iterator find(const key_type &value)
-    {
-        command_queue queue = m_vector.default_queue();
-        iterator iter = find(value, queue);
-        queue.finish();
-        return iter;
-    }
-
-    const_iterator find(const key_type &value, command_queue &queue) const
+    const_iterator find(const key_type &value,
+                        command_queue &queue = system::default_queue()) const
     {
         return ::boost::compute::find(begin(), end(), value, queue);
     }
 
-    const_iterator find(const key_type &value) const
-    {
-        command_queue queue = m_vector.default_queue();
-        const_iterator iter = find(value, queue);
-        queue.finish();
-        return iter;
-    }
-
-    size_type count(const key_type &value, command_queue &queue) const
+    size_type count(const key_type &value,
+                    command_queue &queue = system::default_queue()) const
     {
         return find(value, queue) != end() ? 1 : 0;
     }
 
-    size_type count(const key_type &value) const
-    {
-        command_queue queue = m_vector.default_queue();
-        size_type result = count(value, queue);
-        queue.finish();
-        return result;
-    }
-
-    iterator lower_bound(const key_type &value, command_queue &queue)
+    iterator lower_bound(const key_type &value,
+                         command_queue &queue = system::default_queue())
     {
         return ::boost::compute::lower_bound(begin(), end(), value, queue);
     }
 
-    iterator lower_bound(const key_type &value)
-    {
-        command_queue queue = m_vector.default_queue();
-        iterator iter = lower_bound(value, queue);
-        queue.finish();
-        return iter;
-    }
-
-    const_iterator lower_bound(const key_type &value, command_queue &queue) const
+    const_iterator lower_bound(const key_type &value,
+                               command_queue &queue = system::default_queue()) const
     {
         return ::boost::compute::lower_bound(begin(), end(), value, queue);
     }
 
-    const_iterator lower_bound(const key_type &value) const
-    {
-        command_queue queue = m_vector.default_queue();
-        const_iterator iter = lower_bound(value, queue);
-        queue.finish();
-        return iter;
-    }
-
-    iterator upper_bound(const key_type &value, command_queue &queue)
+    iterator upper_bound(const key_type &value,
+                         command_queue &queue = system::default_queue())
     {
         return ::boost::compute::upper_bound(begin(), end(), value, queue);
     }
 
-    iterator upper_bound(const key_type &value)
-    {
-        command_queue queue = m_vector.default_queue();
-        iterator iter = upper_bound(value, queue);
-        queue.finish();
-        return iter;
-    }
-
-    const_iterator upper_bound(const key_type &value, command_queue &queue) const
+    const_iterator upper_bound(const key_type &value,
+                               command_queue &queue = system::default_queue()) const
     {
         return ::boost::compute::upper_bound(begin(), end(), value, queue);
-    }
-
-    const_iterator upper_bound(const key_type &value) const
-    {
-        command_queue queue = m_vector.default_queue();
-        const_iterator iter = upper_bound(value, queue);
-        queue.finish();
-        return iter;
     }
 
 private:

--- a/include/boost/compute/container/vector.hpp
+++ b/include/boost/compute/container/vector.hpp
@@ -194,7 +194,7 @@ public:
         m_data = m_allocator.allocate((std::max)(m_size, _minimum_capacity()));
 
         if(!other.empty()){
-            command_queue queue = default_queue();
+            command_queue queue = system::default_queue();
             ::boost::compute::copy(other.begin(), other.end(), begin(), queue);
             queue.finish();
         }
@@ -228,7 +228,7 @@ public:
     vector<T>& operator=(const vector<T> &other)
     {
         if(this != &other){
-            command_queue queue = default_queue();
+            command_queue queue = system::default_queue();
             resize(other.size(), queue);
             ::boost::compute::copy(other.begin(), other.end(), begin(), queue);
             queue.finish();
@@ -240,7 +240,7 @@ public:
     template<class OtherAlloc>
     vector<T>& operator=(const std::vector<T, OtherAlloc> &vector)
     {
-        command_queue queue = default_queue();
+        command_queue queue = system::default_queue();
         resize(vector.size(), queue);
         ::boost::compute::copy(vector.begin(), vector.end(), begin(), queue);
         queue.finish();
@@ -354,7 +354,7 @@ public:
     }
 
     /// Resizes the vector to \p size.
-    void resize(size_type size, command_queue &queue)
+    void resize(size_type size, command_queue &queue = system::default_queue())
     {
         if(size < capacity()){
             m_size = size;
@@ -380,14 +380,6 @@ public:
         }
     }
 
-    /// \overload
-    void resize(size_type size)
-    {
-        command_queue queue = default_queue();
-        resize(size, queue);
-        queue.finish();
-    }
-
     /// Returns \c true if the vector is empty.
     bool empty() const
     {
@@ -400,29 +392,15 @@ public:
         return m_data.get_buffer().size() / sizeof(T);
     }
 
-    void reserve(size_type size, command_queue &queue)
+    void reserve(size_type size, command_queue &queue = system::default_queue())
     {
         (void) size;
         (void) queue;
     }
 
-    void reserve(size_type size)
-    {
-        command_queue queue = default_queue();
-        reserve(size, queue);
-        queue.finish();
-    }
-
-    void shrink_to_fit(command_queue &queue)
+    void shrink_to_fit(command_queue &queue = system::default_queue())
     {
         (void) queue;
-    }
-
-    void shrink_to_fit()
-    {
-        command_queue queue = default_queue();
-        shrink_to_fit(queue);
-        queue.finish();
     }
 
     reference operator[](size_type index)
@@ -476,7 +454,7 @@ public:
     template<class InputIterator>
     void assign(InputIterator first,
                 InputIterator last,
-                command_queue &queue)
+                command_queue &queue = system::default_queue())
     {
         // resize vector for new contents
         resize(detail::iterator_range_size(first, last), queue);
@@ -485,28 +463,13 @@ public:
         ::boost::compute::copy(first, last, begin(), queue);
     }
 
-    template<class InputIterator>
-    void assign(InputIterator first, InputIterator last)
-    {
-        command_queue queue = default_queue();
-        assign(first, last, queue);
-        queue.finish();
-    }
-
-    void assign(size_type n, const T &value, command_queue &queue)
+    void assign(size_type n, const T &value, command_queue &queue = system::default_queue())
     {
         // resize vector for new contents
         resize(n, queue);
 
         // fill vector with value
         ::boost::compute::fill_n(begin(), n, value, queue);
-    }
-
-    void assign(size_type n, const T &value)
-    {
-        command_queue queue = default_queue();
-        assign(n, value, queue);
-        queue.finish();
     }
 
     /// Inserts \p value at the end of the vector (resizing if neccessary).
@@ -516,32 +479,19 @@ public:
     /// transfer to the device. It is usually better to store a set of values
     /// on the host (for example, in a \c std::vector) and then transfer them
     /// in bulk using the \c insert() method or the copy() algorithm.
-    void push_back(const T &value, command_queue &queue)
+    void push_back(const T &value, command_queue &queue = system::default_queue())
     {
         insert(end(), value, queue);
     }
 
-    /// \overload
-    void push_back(const T &value)
-    {
-        command_queue queue = default_queue();
-        push_back(value, queue);
-        queue.finish();
-    }
-
-    void pop_back(command_queue &queue)
+    void pop_back(command_queue &queue = system::default_queue())
     {
         resize(size() - 1, queue);
     }
 
-    void pop_back()
-    {
-        command_queue queue = default_queue();
-        pop_back(queue);
-        queue.finish();
-    }
-
-    iterator insert(iterator position, const T &value, command_queue &queue)
+    iterator insert(iterator position,
+                    const T &value,
+                    command_queue &queue = system::default_queue())
     {
         if(position == end()){
             resize(m_size + 1, queue);
@@ -557,14 +507,6 @@ public:
         }
 
         return position + 1;
-    }
-
-    iterator insert(iterator position, const T &value)
-    {
-        command_queue queue = default_queue();
-        iterator iter = insert(position, value, queue);
-        queue.finish();
-        return iter;
     }
 
     void insert(iterator position,
@@ -586,20 +528,13 @@ public:
         );
     }
 
-    void insert(iterator position, size_type count, const T &value)
-    {
-        command_queue queue = default_queue();
-        insert(position, count, value, queue);
-        queue.finish();
-    }
-
     /// Inserts the values in the range [\p first, \p last) into the vector at
     /// \p position using \p queue.
     template<class InputIterator>
     void insert(iterator position,
                 InputIterator first,
                 InputIterator last,
-                command_queue &queue)
+                command_queue &queue = system::default_queue())
     {
         ::boost::compute::vector<T> tmp(position, end(), queue);
 
@@ -617,29 +552,12 @@ public:
         );
     }
 
-    /// \overload
-    template<class InputIterator>
-    void insert(iterator position, InputIterator first, InputIterator last)
-    {
-        command_queue queue = default_queue();
-        insert(position, first, last, queue);
-        queue.finish();
-    }
-
-    iterator erase(iterator position, command_queue &queue)
+    iterator erase(iterator position, command_queue &queue = system::default_queue())
     {
         return erase(position, position + 1, queue);
     }
 
-    iterator erase(iterator position)
-    {
-        command_queue queue = default_queue();
-        iterator iter = erase(position, queue);
-        queue.finish();
-        return iter;
-    }
-
-    iterator erase(iterator first, iterator last, command_queue &queue)
+    iterator erase(iterator first, iterator last, command_queue &queue = system::default_queue())
     {
         if(last != end()){
             ::boost::compute::vector<T> tmp(last, end(), queue);
@@ -650,14 +568,6 @@ public:
         resize(size() - static_cast<size_type>(count), queue);
 
         return begin() + first.get_index() + count;
-    }
-
-    iterator erase(iterator first, iterator last)
-    {
-        command_queue queue = default_queue();
-        iterator iter = erase(first, last, queue);
-        queue.finish();
-        return iter;
     }
 
     /// Swaps the contents of \c *this with \p other.
@@ -683,18 +593,6 @@ public:
     const buffer& get_buffer() const
     {
         return m_data.get_buffer();
-    }
-
-    /// \internal_
-    ///
-    /// Returns a command queue usable to issue commands for the vector's
-    /// memory buffer. This is used when a member function is called without
-    /// speicifying an existing command queue to use.
-    command_queue default_queue() const
-    {
-        const context &context = m_allocator.get_context();
-        command_queue queue(context, context.get_device());
-        return queue;
     }
 
 private:

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -69,6 +69,7 @@ BOOST_AUTO_TEST_CASE(array_operator)
     CHECK_RANGE_EQUAL(int, 10, vector, (42, 42, 42, 42, 42, 42, 42, 42, 42, 42));
 
     vector[0] = 9;
+    bc::system::finish();
     CHECK_RANGE_EQUAL(int, 10, vector, (9, 42, 42, 42, 42, 42, 42, 42, 42, 42));
 }
 
@@ -150,6 +151,7 @@ BOOST_AUTO_TEST_CASE(at)
     vector.push_back(1);
     vector.push_back(2);
     vector.push_back(3);
+    bc::system::finish();
     BOOST_CHECK_EQUAL(vector.at(0), 1);
     BOOST_CHECK_EQUAL(vector.at(1), 2);
     BOOST_CHECK_EQUAL(vector.at(2), 3);
@@ -230,6 +232,7 @@ BOOST_AUTO_TEST_CASE(vector_iterator)
     vector.push_back(4);
     vector.push_back(6);
     vector.push_back(8);
+    bc::system::finish();
     BOOST_CHECK_EQUAL(vector.size(), size_t(4));
     BOOST_CHECK_EQUAL(vector[0], 2);
     BOOST_CHECK_EQUAL(*vector.begin(), 2);
@@ -276,6 +279,9 @@ BOOST_AUTO_TEST_CASE(swap_between_contexts)
     compute::context ctx1(device);
     compute::context ctx2(device);
 
+    compute::command_queue queue1(ctx1, device);
+    compute::command_queue queue2(ctx2, device);
+
     compute::vector<int> vec1(32, ctx1);
     compute::vector<int> vec2(32, ctx2);
 
@@ -287,8 +293,8 @@ BOOST_AUTO_TEST_CASE(swap_between_contexts)
     BOOST_CHECK(vec1.get_allocator().get_context() == ctx2);
     BOOST_CHECK(vec2.get_allocator().get_context() == ctx1);
 
-    vec1.resize(64);
-    vec2.resize(64);
+    vec1.resize(64, queue2);
+    vec2.resize(64, queue1);
 }
 
 BOOST_AUTO_TEST_CASE(assign_from_std_vector)


### PR DESCRIPTION
This changes the vector<T> container class to use the
system-wide default queue instead of creating temporary
queue objects.
