### PR TITLE
Removing unused variables that cause warnings

### DIFF
--- a/include/boost/compute/algorithm/detail/merge_path.hpp
+++ b/include/boost/compute/algorithm/detail/merge_path.hpp
@@ -49,8 +49,6 @@ public:
                    OutputIterator1 result_a,
                    OutputIterator2 result_b)
     {
-        typedef typename std::iterator_traits<InputIterator1>::value_type value_type;
-
         m_a_count = iterator_range_size(first1, last1);
         m_a_count_arg = add_arg<uint_>("a_count");
 

--- a/include/boost/compute/algorithm/detail/merge_with_merge_path.hpp
+++ b/include/boost/compute/algorithm/detail/merge_with_merge_path.hpp
@@ -129,8 +129,6 @@ merge_with_merge_path(InputIterator1 first1,
                         OutputIterator result,
                         command_queue &queue = system::default_queue())
 {
-    typedef typename std::iterator_traits<InputIterator1>::value_type value_type;
-
     int tile_size = 1024;
 
     int count1 = iterator_range_size(first1, last1);

--- a/include/boost/compute/algorithm/includes.hpp
+++ b/include/boost/compute/algorithm/includes.hpp
@@ -116,8 +116,6 @@ inline bool includes(InputIterator1 first1,
                     InputIterator2 last2,
                     command_queue &queue = system::default_queue())
 {
-    typedef typename std::iterator_traits<InputIterator1>::value_type value_type;
-
     int tile_size = 1024;
 
     int count1 = detail::iterator_range_size(first1, last1);

--- a/include/boost/compute/random/discrete_distribution.hpp
+++ b/include/boost/compute/random/discrete_distribution.hpp
@@ -44,9 +44,6 @@ public:
         : m_n(std::distance(first, last)),
           m_probabilities(std::distance(first, last))
     {
-        typedef typename
-            std::iterator_traits<InputIterator>::value_type value_type;
-
         double sum = 0;
 
         for(InputIterator iter = first; iter!=last; iter++)


### PR DESCRIPTION
Removed unused value_type typedefs that are causing warnings when -Wunused is used.
