### PR TITLE
min, max macro conflicts on windows platform

### DIFF
--- a/include/boost/compute/functional/detail/macros.hpp
+++ b/include/boost/compute/functional/detail/macros.hpp
@@ -21,7 +21,7 @@
     class name : public function<signature> \
     { \
     public: \
-        name() : function<signature>(BOOST_PP_STRINGIZE(name)) { } \
+        (name)() : function<signature>(BOOST_PP_STRINGIZE(name)) { } \
     };
 
 #define BOOST_COMPUTE_DECLARE_BUILTIN_FUNCTION_UNDERSCORE(name, signature, template_args) \


### PR DESCRIPTION
min, max functions declarations in functional/integer header were causing compilation issues on windows. This could be related to min, max macros being used in other projects that use compute. The temporary fix i did in our project was to undef min, max before every boost/compute header inclusion which was causing the issue. Windows Development Environment i used is Visual Studio 2013.
