### PR TITLE
Fixed OpenCL 2.0 Header compatibility

### DIFF
--- a/include/boost/compute/image2d.hpp
+++ b/include/boost/compute/image2d.hpp
@@ -62,7 +62,11 @@ public:
         desc.image_slice_pitch = 0;
         desc.num_mip_levels = 0;
         desc.num_samples = 0;
+        #ifdef CL_VERSION_2_0
+        desc.mem_object = 0;
+        #else
         desc.buffer = 0;
+        #endif
 
         m_mem = clCreateImage(context,
                               flags,

--- a/include/boost/compute/image3d.hpp
+++ b/include/boost/compute/image3d.hpp
@@ -61,7 +61,11 @@ public:
         desc.image_slice_pitch = image_slice_pitch;
         desc.num_mip_levels = 0;
         desc.num_samples = 0;
+        #ifdef CL_VERSION_2_0
+        desc.mem_object = 0;
+        #else
         desc.buffer = 0;
+        #endif
 
         m_mem = clCreateImage(context,
                               flags,


### PR DESCRIPTION
When compiling against OpenCL 2.0 Headers i had to modify image2d.hpp and image3d.hpp, because they renamed the "buffer" attribute to "mem_object" still being of type cl_mem.
