### PR TITLE
Reimplemented unit tests for unsupported extension and context error

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -129,6 +129,8 @@ add_compute_test("container.valarray" test_valarray.cpp)
 add_compute_test("container.vector" test_vector.cpp)
 
 add_compute_test("exception.opencl_error" test_opencl_error.cpp)
+add_compute_test("exception.context_error" test_context_error.cpp)
+add_compute_test("exception.unsupported_extension" test_unsupported_extension.cpp)
 
 add_compute_test("functional.as" test_functional_as.cpp)
 add_compute_test("functional.bind" test_functional_bind.cpp)

--- a/test/test_context_error.cpp
+++ b/test/test_context_error.cpp
@@ -1,0 +1,20 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Fabian Köhler <fabian2804@googlemail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+#define BOOST_TEST_MODULE TestContextError
+#include <boost/test/unit_test.hpp>
+#include <boost/compute/system.hpp>
+#include <boost/compute/exception/context_error.hpp>
+
+BOOST_AUTO_TEST_CASE(what)
+{
+    boost::compute::context context = boost::compute::system::default_context();
+    boost::compute::context_error error(&context, "Test", 0, 0);
+    BOOST_CHECK_EQUAL(std::string(error.what()), std::string("Test"));
+}

--- a/test/test_unsupported_extension.cpp
+++ b/test/test_unsupported_extension.cpp
@@ -1,0 +1,18 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Fabian Köhler <fabian2804@googlemail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+#define BOOST_TEST_MODULE TestUnsupportedExtension
+#include <boost/test/unit_test.hpp>
+#include <boost/compute/exception/unsupported_extension_error.hpp>
+
+BOOST_AUTO_TEST_CASE(unsupported_extension_error_what)
+{
+    boost::compute::unsupported_extension_error error("CL_DUMMY_EXTENSION");
+    BOOST_CHECK_EQUAL(std::string(error.what()), std::string("OpenCL extension CL_DUMMY_EXTENSION not supported"));
+}


### PR DESCRIPTION
Added unit tests for unsupported extension and context error.
See [PR 229](https://github.com/kylelutz/compute/pull/229)
