### PR TITLE
oveloaded find() for string and char pointer

### DIFF
--- a/include/boost/compute/container/basic_string.hpp
+++ b/include/boost/compute/container/basic_string.hpp
@@ -16,6 +16,7 @@
 
 #include <boost/compute/cl.hpp>
 #include <boost/compute/algorithm/find.hpp>
+#include <boost/compute/algorithm/search.hpp>
 #include <boost/compute/container/vector.hpp>
 #include <boost/compute/system.hpp>
 #include <boost/compute/command_queue.hpp>
@@ -247,9 +248,44 @@ public:
         return basic_string<CharT, Traits>(*this, pos, count);
     }
 
+    /// Finds the first character \p ch
     size_type find(CharT ch, size_type pos = 0) const
     {
         const_iterator iter = ::boost::compute::find(begin() + pos, end(), ch);
+        if(iter == end()){
+            return npos;
+        }
+        else {
+            return static_cast<size_type>(std::distance(begin(), iter));
+        }
+    }
+
+    /// Finds the first substring equal to \p str
+    size_type find(basic_string& str, size_type pos = 0) const
+    {
+        const_iterator iter = ::boost::compute::search(begin() + pos, end(),
+                                                       str.begin(), str.end());
+        if(iter == end()){
+            return npos;
+        }
+        else {
+            return static_cast<size_type>(std::distance(begin(), iter));
+        }
+    }
+
+    /// Finds the first substring equal to the character string
+    /// pointed to by \p s.
+    /// The length of the string is determined by the first null character.
+    ///
+    /// For example, the following code
+    /// \snippet test/test_string.cpp string_find
+    ///
+    /// will return 5 as position.
+    size_type find(const char* s, size_type pos = 0) const
+    {
+        basic_string str(s);
+        const_iterator iter = ::boost::compute::search(begin() + pos, end(),
+                                                       str.begin(), str.end());
         if(iter == end()){
             return npos;
         }

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -54,12 +54,19 @@ BOOST_AUTO_TEST_CASE(size)
     BOOST_CHECK_EQUAL(str.length(), size_t(6));
 }
 
-BOOST_AUTO_TEST_CASE(find)
+BOOST_AUTO_TEST_CASE(find_doctest)
 {
-    boost::compute::string str = "string";
+//! [string_find]
+boost::compute::string str = "boost::compute::string";
+int pos = str.find("::");
+//! [string_find]
+    boost::compute::string pattern = "string";
     BOOST_VERIFY(!str.empty());
-    BOOST_CHECK_EQUAL(str.find('r'), 2);
-    BOOST_CHECK_NE(str.find('r'), 3);
+    BOOST_CHECK_EQUAL(str.find('o'), 1);
+    BOOST_CHECK_NE(str.find('o'), 2);
+    BOOST_CHECK_EQUAL(str.find(pattern), 16);
+    BOOST_CHECK_EQUAL(pos, 5);
+    BOOST_CHECK_EQUAL(str.find("@#$"), size_t(-1));
 }
 
 BOOST_AUTO_TEST_CASE(outStream)


### PR DESCRIPTION
Added support for searching string in bc::string find().

Tried adding doctest.

Please review.
