### PR TITLE
Use loglog scale for plotting performance data

### DIFF
--- a/perf/perf.py
+++ b/perf/perf.py
@@ -75,7 +75,7 @@ class Report:
         if not any_valid_samples:
             return
 
-        pylab.plot(x, y, marker='o', label=name)
+        pylab.loglog(x, y, marker='o', label=name)
         pylab.xlabel("Size")
         pylab.ylabel("Time (ms)")
         pylab.title(self.name)
@@ -100,7 +100,7 @@ class Report:
         if not any_valid_samples:
             return
 
-        pylab.plot(x, y, marker='o', label=name)
+        pylab.loglog(x, y, marker='o', label=name)
         pylab.xlabel("Size")
         pylab.ylabel("Rate (values/s)")
         pylab.title(self.name)
@@ -195,7 +195,7 @@ if __name__ == '__main__':
             report.plot_rate(competitor)
 
     if plot:
-        pylab.legend()
+        pylab.legend(loc='upper left')
         pylab.show()
     else:
         report.display()

--- a/perf/perfdoc.py
+++ b/perf/perfdoc.py
@@ -26,7 +26,7 @@ def plot_to_file(report, filename):
             x.append(sample[0])
             y.append(sample[1])
 
-        pylab.plot(x, y, marker='o', label=run_to_label[run])
+        pylab.loglog(x, y, marker='o', label=run_to_label[run])
 
     pylab.xlabel("Size")
     pylab.ylabel("Time (ms)")


### PR DESCRIPTION
This makes performance comparison easier, especially for smaller sizes.

An example:

![sort_perf](https://cloud.githubusercontent.com/assets/270503/5436349/24795482-8476-11e4-90be-c5faac6b68b3.png)

Here one may clearly see that there is no point in using GPUs when there are less than 1e5 elements to sort. It is also clear that all backends have similar algorithmic complexity for larger problems.

Compare it to the current plot:
![sort_time_plot](https://cloud.githubusercontent.com/assets/270503/5436421/17aa7fa0-8477-11e4-8d35-ad311b5f2e5d.png)
