### PR TITLE
Show Thrust results on performance plots

### DIFF
--- a/doc/performance.qbk
+++ b/doc/performance.qbk
@@ -1,7 +1,7 @@
 [section:performance Performance]
 
-The following tests were run with an AMD HD 7970 "Tahiti" GPU on a system
-with an Intel i7-4771 3.50GHz CPU.
+The following tests were run with an NVIDIA Tesla K40c GPU on a system
+with an Intel Core i7 920 2.67GHz CPU.
 
 Source code for the benchmarks can be found under the
 [@https://github.com/kylelutz/compute/tree/master/perf perf] directory. All

--- a/perf/perfdoc.py
+++ b/perf/perfdoc.py
@@ -15,10 +15,11 @@ def plot_to_file(report, filename):
 
     run_to_label = {
         "stl" : "C++ STL",
+        "thrust" : "Thrust",
         "compute" : "Boost.Compute"
     }
 
-    for run in report.samples.keys():
+    for run in sorted(report.samples.keys()):
         x = []
         y = []
 
@@ -57,6 +58,6 @@ if __name__ == '__main__':
 
     for algorithm in algorithms:
         print("running '%s'" % (algorithm))
-        report = run_benchmark(algorithm, sizes, ["stl"])
+        report = run_benchmark(algorithm, sizes, ["stl", "thrust"])
         plot_to_file(report, "perf_plots/%s_time_plot.png" % algorithm)
 


### PR DESCRIPTION
Update perf/perfdoc.py to generate Thrust results along with Boost.Compute and STL, update performance.qbk with the hardware informantion used in tests. The images are part of #346 and are also available at https://gist.github.com/ddemidov/192740d6e0d4871b9d40.

See #342 
