### PR TITLE
fixing CHECK_RANGE_EQUAL

### DIFF
--- a/test/check_macros.hpp
+++ b/test/check_macros.hpp
@@ -20,7 +20,7 @@
     { \
         type _actual[size]; \
         boost::compute::copy( \
-            actual.begin(), actual.end(), _actual, queue \
+            actual.begin(), actual.begin()+size, _actual, queue \
         ); \
         const type _expected[size] = { \
             BOOST_PP_REPEAT(size, LIST_ARRAY_VALUES, (size, expected)) \


### PR DESCRIPTION
if the container passed to CHECK_RANGE_EQUAL is larger than the expected range, the copy writes over the boundaries of the created buffer _actual.

This fixes unit tests 27 - algorithm.copy_if and 46 - algorithm.merge on ARM plattform but should be an error on all plattforms.
