### PR TITLE
Performance tests for AMD's Bolt library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(BOOST_COMPUTE_HAVE_QT "Have Qt" OFF)
 option(BOOST_COMPUTE_HAVE_VTK "Have VTK" OFF)
 option(BOOST_COMPUTE_HAVE_CUDA "Have CUDA" OFF)
 option(BOOST_COMPUTE_HAVE_TBB "Have TBB" OFF)
+option(BOOST_COMPUTE_HAVE_BOLT "Have BOLT" OFF)
 
 include_directories(include)
 

--- a/cmake/FindBolt.cmake
+++ b/cmake/FindBolt.cmake
@@ -1,0 +1,149 @@
+############################################################################                                                                                     
+#   © 2012,2014 Advanced Micro Devices, Inc. All rights reserved.                                     
+#                                                                                    
+#   Licensed under the Apache License, Version 2.0 (the "License");   
+#   you may not use this file except in compliance with the License.                 
+#   You may obtain a copy of the License at                                          
+#                                                                                    
+#       http://www.apache.org/licenses/LICENSE-2.0                      
+#                                                                                    
+#   Unless required by applicable law or agreed to in writing, software              
+#   distributed under the License is distributed on an "AS IS" BASIS,              
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.         
+#   See the License for the specific language governing permissions and              
+#   limitations under the License.                                                   
+
+############################################################################                                                                                     
+
+# Locate an BOLT implementation.
+#
+# Defines the following variables:
+#
+#   BOLT_FOUND - Found an Bolt imlementation
+#
+# Also defines the library variables below as normal
+# variables.
+#
+#   BOLT_LIBRARIES - These contain debug/optimized keywords when a debugging library is found
+#   BOLT_INCLUDE_DIRS - All relevant Bolt include directories
+#
+# Accepts the following variables as input:
+#
+#   BOLT_ROOT - (as a CMake or environment variable)
+#                The root directory of an BOLT installation
+#
+#   FIND_LIBRARY_USE_LIB64_PATHS - Global property that controls whether FindBOLT should search for 
+#                              64bit or 32bit libs
+#
+#-----------------------
+# Example Usage:
+#
+#    find_package(BOLT REQUIRED)
+#    include_directories(${BOLT_INCLUDE_DIRS})
+#
+#    add_executable(foo foo.cc)
+#    target_link_libraries(foo ${BOLT_LIBRARIES})
+#
+#-----------------------
+
+# This module helps to use BOLT_FIND_COMPONENTS, BOLT_FIND_REQUIRED, BOLT_FIND_QUIETLY
+include( FindPackageHandleStandardArgs )
+
+# Search for 64bit libs if FIND_LIBRARY_USE_LIB64_PATHS is set to true in the global environment, 32bit libs else
+get_property( LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS )
+
+# Debug print statements
+#message( "BOLT_LIBRARY_PATH_SUFFIXES: ${BOLT_LIBRARY_PATH_SUFFIXES}" )
+#message( "ENV{BOLT_ROOT}: $ENV{BOLT_ROOT}" )
+#message( "BOLT_FIND_COMPONENTS: ${BOLT_FIND_COMPONENTS}" )
+#message( "BOLT_FIND_REQUIRED: ${BOLT_FIND_REQUIRED}" )
+
+# Set the component to find if the user does not specify explicitely
+if( NOT BOLT_FIND_COMPONENTS )
+    set( BOLT_FIND_COMPONENTS CL )
+endif( )
+if(WIN32)
+if( MSVC_VERSION VERSION_LESS 1600 )
+    set( myMSVCVer "vc90" )
+elseif( MSVC_VERSION VERSION_LESS 1700 )
+    set( myMSVCVer "vc100" )
+elseif( MSVC_VERSION VERSION_LESS 1800 )
+    set( myMSVCVer "vc110" )
+else()
+    set( myMSVCVer "vc120" )
+endif( )
+else()
+    set( myMSVCVer "gcc" )
+endif()
+
+if(WIN32)
+ set( BoltLibName "clBolt.runtime.${myMSVCVer}") 
+ set( LIB_EXT "lib")    
+else()
+ set( BoltLibName "libclBolt.runtime.${myMSVCVer}")
+ set( LIB_EXT "a")  
+endif()
+
+# Eventually, Bolt may support multiple backends, but for now it only supports CL
+list( FIND BOLT_FIND_COMPONENTS CL find_CL )
+if( NOT find_CL EQUAL -1 )
+    set( BOLT_LIBNAME_BASE ${BoltLibName} )
+endif( )
+
+if( NOT find_CL EQUAL -1 )
+    # Find and set the location of main BOLT static lib file
+    find_library( BOLT_LIBRARY_STATIC_RELEASE
+        NAMES ${BOLT_LIBNAME_BASE}.${LIB_EXT}
+        HINTS
+            ${BOLT_ROOT}
+            ENV BOLT_ROOT
+        DOC "BOLT static library path"
+        PATH_SUFFIXES lib
+    )
+    mark_as_advanced( BOLT_LIBRARY_STATIC_RELEASE )
+
+    # Find and set the location of main BOLT static lib file
+    find_library( BOLT_LIBRARY_STATIC_DEBUG
+        NAMES ${BOLT_LIBNAME_BASE}.debug.${LIB_EXT}
+        HINTS
+            ${BOLT_ROOT}
+            ENV BOLT_ROOT
+        DOC "BOLT static library path"
+        PATH_SUFFIXES lib
+    )
+    mark_as_advanced( BOLT_LIBRARY_STATIC_DEBUG )
+    
+    if( BOLT_LIBRARY_STATIC_RELEASE )
+        set( BOLT_LIBRARY_STATIC optimized ${BOLT_LIBRARY_STATIC_RELEASE} )
+    else( )
+        set( BOLT_LIBRARY_STATIC "" )
+        message( "${BOLT_LIBNAME_BASE}.${LIB_EXT}: Release static bolt library not found" )
+    endif( )
+
+    if( BOLT_LIBRARY_STATIC_DEBUG )
+        set( BOLT_LIBRARY_STATIC ${BOLT_LIBRARY_STATIC} debug ${BOLT_LIBRARY_STATIC_DEBUG} )
+    else( )
+        message( "${BOLT_LIBNAME_BASE}.debug.${LIB_EXT}: Debug static bolt library not found" )
+    endif( )
+    
+    find_path( BOLT_INCLUDE_DIRS
+        NAMES bolt/cl/bolt.h
+        HINTS
+            ${BOLT_ROOT}
+            ENV BOLT_ROOT
+        DOC "BOLT header file path"
+        PATH_SUFFIXES include
+    )
+    mark_as_advanced( BOLT_INCLUDE_DIRS )
+
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS( BOLT DEFAULT_MSG BOLT_LIBRARY_STATIC BOLT_INCLUDE_DIRS )
+endif( )
+
+if( BOLT_FOUND )
+    list( APPEND BOLT_LIBRARIES ${BOLT_LIBRARY_STATIC} )
+else( )
+    if( NOT BOLT_FIND_QUIETLY )
+        message( WARNING "FindBOLT could not find the BOLT library" )
+        message( STATUS "Did you remember to set the BOLT_ROOT environment variable?" )
+    endif( )
+endif()

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -8,6 +8,12 @@ endif()
 
 if(${BOOST_COMPUTE_THREAD_SAFE} AND NOT ${BOOST_COMPUTE_USE_CPP11})
   set(PERF_BOOST_COMPONENTS ${PERF_BOOST_COMPONENTS} thread)
+elseif(${BOOST_COMPUTE_HAVE_BOLT} AND ${BOOST_COMPUTE_USE_CPP11})
+  set(PERF_BOOST_COMPONENTS ${PERF_BOOST_COMPONENTS} thread)	
+endif()
+
+if(${BOOST_COMPUTE_HAVE_BOLT} AND ${BOOST_COMPUTE_USE_CPP11})
+  set(PERF_BOOST_COMPONENTS ${PERF_BOOST_COMPONENTS} date_time) 
 endif()
 
 find_package(Boost 1.48 REQUIRED COMPONENTS ${PERF_BOOST_COMPONENTS})
@@ -95,7 +101,7 @@ set(STL_BENCHMARKS
   stl_unique_copy
 )
 
-# stl benchmarks which rerquire c++11
+# stl benchmarks which require c++11
 if(${BOOST_COMPUTE_USE_CPP11})
   list(APPEND
     STL_BENCHMARKS
@@ -153,4 +159,31 @@ if(${BOOST_COMPUTE_HAVE_TBB})
     add_executable(${PERF_TARGET} perf_${BENCHMARK}.cpp)
     target_link_libraries(${PERF_TARGET} ${TBB_LIBRARIES} ${Boost_LIBRARIES})
   endforeach()
+endif()
+
+# bolt c++ template lib benchmarks (for comparison)
+if(${BOOST_COMPUTE_HAVE_BOLT} AND ${BOOST_COMPUTE_USE_CPP11})
+  find_package(Bolt REQUIRED)
+  include_directories(${BOLT_INCLUDE_DIRS})
+
+  set(BOLT_BENCHMARKS
+    bolt_accumulate
+    bolt_count
+    bolt_exclusive_scan
+    bolt_fill
+    bolt_inner_product
+    bolt_max_element
+    bolt_merge
+    bolt_partial_sum
+    bolt_saxpy
+    bolt_sort
+  )
+
+  foreach(BENCHMARK ${BOLT_BENCHMARKS})
+    set(PERF_TARGET perf_${BENCHMARK})
+    add_executable(${PERF_TARGET} perf_${BENCHMARK}.cpp)
+    target_link_libraries(${PERF_TARGET} ${OPENCL_LIBRARIES} ${BOLT_LIBRARIES} ${Boost_LIBRARIES})
+  endforeach()
+elseif(${BOOST_COMPUTE_HAVE_BOLT} AND NOT ${BOOST_COMPUTE_USE_CPP11})
+  message(WARNING "BOOST_COMPUTE_USE_CPP11 must be ON for building Bolt C++ Template Library performance tests.")
 endif()

--- a/perf/perf.py
+++ b/perf/perf.py
@@ -128,6 +128,18 @@ def run_benchmark(name, sizes, vs=[]):
             "sort",
             "unique"
         ],
+        "bolt" : [
+            "accumulate",
+            "count",
+            "exclusive_scan",
+            "fill",
+            "inner_product",
+            "max_element",
+            "merge",
+            "partial_sum",
+            "saxpy",
+            "sort"
+        ],
         "tbb": [
             "accumulate",
             "merge",
@@ -187,7 +199,7 @@ if __name__ == '__main__':
 
     sizes = sorted(sizes)
 
-    competitors = ["tbb", "thrust", "stl"]
+    competitors = ["bolt", "tbb", "thrust", "stl"]
 
     report = run_benchmark(test, sizes, competitors)
 

--- a/perf/perf_bolt_accumulate.cpp
+++ b/perf/perf_bolt_accumulate.cpp
@@ -1,0 +1,51 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+#include <bolt/cl/copy.h>
+#include <bolt/cl/device_vector.h>
+#include <bolt/cl/reduce.h>
+
+#include "perf.hpp"
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+
+    std::cout << "size: " << PERF_N << std::endl;
+
+    bolt::cl::control ctrl = bolt::cl::control::getDefault();
+    ::cl::Device device = ctrl.getDevice();
+    std::cout << "device: " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
+
+    // create host vector
+    std::vector<int> host_vec = generate_random_vector<int>(PERF_N);
+
+    // create device vectors
+    bolt::cl::device_vector<int> device_vec(PERF_N);
+
+    // transfer data to the device
+    bolt::cl::copy(host_vec.begin(), host_vec.end(), device_vec.begin());
+
+    int sum = 0;
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        t.start();
+        sum = bolt::cl::reduce(device_vec.begin(), device_vec.end());
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+    std::cout << "sum: " << sum << std::endl;
+
+    return 0;
+}

--- a/perf/perf_bolt_count.cpp
+++ b/perf/perf_bolt_count.cpp
@@ -1,0 +1,57 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+#include <bolt/cl/count.h>
+#include <bolt/cl/copy.h>
+#include <bolt/cl/device_vector.h>
+
+#include "perf.hpp"
+
+int rand_int()
+{
+    return static_cast<int>((rand() / double(RAND_MAX)) * 25.0);
+}
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+
+    std::cout << "size: " << PERF_N << std::endl;
+
+    bolt::cl::control ctrl = bolt::cl::control::getDefault();
+    ::cl::Device device = ctrl.getDevice();
+    std::cout << "device: " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
+
+    // create vector of random numbers on the host
+    std::vector<int> h_vec(PERF_N);
+    std::generate(h_vec.begin(), h_vec.end(), rand_int);
+
+    // create device vector
+    bolt::cl::device_vector<int> d_vec(PERF_N);
+
+    // transfer data to the device
+    bolt::cl::copy(h_vec.begin(), h_vec.end(), d_vec.begin());
+
+    size_t count = 0;
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        t.start();
+        count = bolt::cl::count(ctrl, d_vec.begin(), d_vec.end(), 4);
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+    std::cout << "count: " << count << std::endl;
+
+    return 0;
+}

--- a/perf/perf_bolt_exclusive_scan.cpp
+++ b/perf/perf_bolt_exclusive_scan.cpp
@@ -1,0 +1,52 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+#include <bolt/cl/scan.h>
+#include <bolt/cl/copy.h>
+#include <bolt/cl/device_vector.h>
+
+#include "perf.hpp"
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+
+    std::cout << "size: " << PERF_N << std::endl;
+
+    bolt::cl::control ctrl = bolt::cl::control::getDefault();
+    ::cl::Device device = ctrl.getDevice();
+    std::cout << "device: " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
+
+    // create vector of random numbers on the host
+    std::vector<int> h_vec = generate_random_vector<int>(PERF_N);
+
+    // create device vector
+    bolt::cl::device_vector<int> d_vec(PERF_N);
+
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        // transfer data to the device
+        bolt::cl::copy(h_vec.begin(), h_vec.end(), d_vec.begin());
+
+        t.start();
+        bolt::cl::exclusive_scan(d_vec.begin(), d_vec.end(), d_vec.begin());
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+
+    // transfer data back to host
+    bolt::cl::copy(d_vec.begin(), d_vec.end(), h_vec.begin());
+
+    return 0;
+}

--- a/perf/perf_bolt_fill.cpp
+++ b/perf/perf_bolt_fill.cpp
@@ -1,0 +1,43 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+#include <bolt/cl/fill.h>
+#include <bolt/cl/copy.h>
+#include <bolt/cl/device_vector.h>
+
+#include "perf.hpp"
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+
+    std::cout << "size: " << PERF_N << std::endl;
+
+    bolt::cl::control ctrl = bolt::cl::control::getDefault();
+    ::cl::Device device = ctrl.getDevice();
+    std::cout << "device: " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
+
+    // create device vector (filled with zeros)
+    bolt::cl::device_vector<int> d_vec(PERF_N, 0);
+
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        t.start();
+        bolt::cl::fill(d_vec.begin(), d_vec.end(), int(trial));
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+
+    return 0;
+}

--- a/perf/perf_bolt_inner_product.cpp
+++ b/perf/perf_bolt_inner_product.cpp
@@ -1,0 +1,56 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+#include <bolt/cl/inner_product.h>
+#include <bolt/cl/copy.h>
+#include <bolt/cl/device_vector.h>
+
+#include "perf.hpp"
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+
+    std::cout << "size: " << PERF_N << std::endl;
+
+    bolt::cl::control ctrl = bolt::cl::control::getDefault();
+    ::cl::Device device = ctrl.getDevice();
+    std::cout << "device: " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
+
+    // create host vectors
+    std::vector<int> host_x = generate_random_vector<int>(PERF_N);
+    std::vector<int> host_y = generate_random_vector<int>(PERF_N);
+
+    // create device vectors
+    bolt::cl::device_vector<int> device_x(PERF_N);
+    bolt::cl::device_vector<int> device_y(PERF_N);
+
+    // transfer data to the device
+    bolt::cl::copy(host_x.begin(), host_x.end(), device_x.begin());
+    bolt::cl::copy(host_y.begin(), host_y.end(), device_y.begin());
+
+    int product = 0;
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        t.start();
+        product = bolt::cl::inner_product(
+            device_x.begin(), device_x.end(), device_y.begin(), 0
+        );
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+    std::cout << "product: " << product << std::endl;
+
+    return 0;
+}

--- a/perf/perf_bolt_max_element.cpp
+++ b/perf/perf_bolt_max_element.cpp
@@ -1,0 +1,56 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+#include <bolt/cl/copy.h>
+#include <bolt/cl/device_vector.h>
+#include <bolt/cl/max_element.h>
+
+#include "perf.hpp"
+
+int rand_int()
+{
+    return static_cast<int>(rand() % 10000000);
+}
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+
+    std::cout << "size: " << PERF_N << std::endl;
+
+    bolt::cl::control ctrl = bolt::cl::control::getDefault();
+    ::cl::Device device = ctrl.getDevice();
+    std::cout << "device: " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
+
+    // create host vector
+    std::vector<int> host_vec = generate_random_vector<int>(PERF_N);
+
+    // create device vectors
+    bolt::cl::device_vector<int> device_vec(PERF_N);
+
+    // transfer data to the device
+    bolt::cl::copy(host_vec.begin(), host_vec.end(), device_vec.begin());
+
+    size_t max = 0;
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        t.start();
+        max = *bolt::cl::max_element(device_vec.begin(), device_vec.end());
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+    std::cout << "max: " << max << std::endl;
+
+    return 0;
+}

--- a/perf/perf_bolt_merge.cpp
+++ b/perf/perf_bolt_merge.cpp
@@ -1,0 +1,60 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+#include <bolt/cl/merge.h>
+#include <bolt/cl/copy.h>
+#include <bolt/cl/device_vector.h>
+
+#include "perf.hpp"
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+
+    std::cout << "size: " << PERF_N << std::endl;
+
+    bolt::cl::control ctrl = bolt::cl::control::getDefault();
+    ::cl::Device device = ctrl.getDevice();
+    std::cout << "device: " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
+    
+    // create vector of random numbers on the host
+    std::vector<int> host_vec1 = generate_random_vector<int>(std::floor(PERF_N / 2.0));
+    std::vector<int> host_vec2 = generate_random_vector<int>(std::ceil(PERF_N / 2.0));
+    // sort them
+    std::sort(host_vec1.begin(), host_vec1.end());
+    std::sort(host_vec2.begin(), host_vec2.end());
+
+    // create device vectors
+    bolt::cl::device_vector<int> device_vec1(PERF_N);
+    bolt::cl::device_vector<int> device_vec2(PERF_N);
+    bolt::cl::device_vector<int> device_vec3(PERF_N);
+    
+    // transfer data to the device
+    bolt::cl::copy(host_vec1.begin(), host_vec1.end(), device_vec1.begin());
+    bolt::cl::copy(host_vec2.begin(), host_vec2.end(), device_vec2.begin());
+
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        t.start();
+        bolt::cl::merge(
+            device_vec1.begin(), device_vec1.end(),
+            device_vec2.begin(), device_vec2.end(),
+            device_vec3.begin()
+        );
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+
+    return 0;
+}

--- a/perf/perf_bolt_partial_sum.cpp
+++ b/perf/perf_bolt_partial_sum.cpp
@@ -1,0 +1,53 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+#include <bolt/cl/scan.h>
+#include <bolt/cl/copy.h>
+#include <bolt/cl/device_vector.h>
+
+#include "perf.hpp"
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+
+    std::cout << "size: " << PERF_N << std::endl;
+
+    bolt::cl::control ctrl = bolt::cl::control::getDefault();
+    ::cl::Device device = ctrl.getDevice();
+    std::cout << "device: " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
+
+    // create vector of random numbers on the host
+    std::vector<int> h_vec = generate_random_vector<int>(PERF_N);
+
+    // create device vector
+    bolt::cl::device_vector<int> d_vec(PERF_N);
+
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        // transfer data to the device
+        bolt::cl::copy(h_vec.begin(), h_vec.end(), d_vec.begin());
+
+        t.start();
+        bolt::cl::inclusive_scan(d_vec.begin(), d_vec.end(), d_vec.begin());
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+
+    // transfer data back to host
+    bolt::cl::copy(d_vec.begin(), d_vec.end(), h_vec.begin());
+
+    return 0;
+}
+

--- a/perf/perf_bolt_saxpy.cpp
+++ b/perf/perf_bolt_saxpy.cpp
@@ -1,0 +1,76 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+#include <bolt/cl/copy.h>
+#include <bolt/cl/device_vector.h>
+#include <bolt/cl/transform.h>
+
+#include "perf.hpp"
+
+BOLT_FUNCTOR(saxpy_functor,
+    struct saxpy_functor
+    {
+        float _a;
+        saxpy_functor(float a) : _a(a) {};
+
+        float operator() (const float &x, const float &y) const
+        {
+            return _a * x + y;
+        };
+    };
+);
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+
+    std::cout << "size: " << PERF_N << std::endl;
+
+    bolt::cl::control ctrl = bolt::cl::control::getDefault();
+    ::cl::Device device = ctrl.getDevice();
+    std::cout << "device: " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
+
+    // create host vectors
+    std::vector<float> host_x(PERF_N);
+    std::vector<float> host_y(PERF_N);
+    std::generate(host_x.begin(), host_x.end(), rand);
+    std::generate(host_y.begin(), host_y.end(), rand);
+
+    // create device vectors
+    bolt::cl::device_vector<float> device_x(PERF_N);
+    bolt::cl::device_vector<float> device_y(PERF_N);
+
+    // transfer data to the device
+    bolt::cl::copy(host_x.begin(), host_x.end(), device_x.begin());
+    bolt::cl::copy(host_y.begin(), host_y.end(), device_y.begin());
+
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        t.start();
+        bolt::cl::transform(
+            device_x.begin(), device_x.end(),
+            device_y.begin(),
+            device_y.begin(),
+            saxpy_functor(2.5f)
+        );
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+
+    // transfer data back to host
+    bolt::cl::copy(device_x.begin(), device_x.end(), host_x.begin());
+    bolt::cl::copy(device_y.begin(), device_y.end(), host_y.begin());
+
+    return 0;
+}

--- a/perf/perf_bolt_sort.cpp
+++ b/perf/perf_bolt_sort.cpp
@@ -1,0 +1,50 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <algorithm>
+#include <cstdlib>
+#include <vector>
+
+#include <bolt/cl/sort.h>
+#include <bolt/cl/copy.h>
+#include <bolt/cl/device_vector.h>
+
+#include "perf.hpp"
+
+int main(int argc, char *argv[])
+{
+    perf_parse_args(argc, argv);
+
+    std::cout << "size: " << PERF_N << std::endl;
+
+    ::cl::Device device = bolt::cl::control::getDefault().getDevice();
+    std::cout << "device: " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
+
+    // create host vector
+    std::vector<int> h_vec = generate_random_vector<int>(PERF_N);
+    // create device vector
+    bolt::cl::device_vector<int> d_vec(PERF_N);
+
+    perf_timer t;
+    for(size_t trial = 0; trial < PERF_TRIALS; trial++){
+        // transfer data to the device
+        bolt::cl::copy(h_vec.begin(), h_vec.end(), d_vec.begin());
+
+        t.start();
+        bolt::cl::sort(d_vec.begin(), d_vec.end());
+        t.stop();
+    }
+    std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+
+    // transfer data back to host
+    bolt::cl::copy(d_vec.begin(), d_vec.end(), h_vec.begin());
+
+    return 0;
+}

--- a/perf/perf_thrust_exclusive_scan.cu
+++ b/perf/perf_thrust_exclusive_scan.cu
@@ -1,3 +1,13 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2013-2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://kylelutz.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
 #include <algorithm>
 #include <cstdlib>
 

--- a/perf/perfdoc.py
+++ b/perf/perfdoc.py
@@ -16,7 +16,8 @@ def plot_to_file(report, filename):
     run_to_label = {
         "stl" : "C++ STL",
         "thrust" : "Thrust",
-        "compute" : "Boost.Compute"
+        "compute" : "Boost.Compute",
+        "bolt" : "Bolt"
     }
 
     for run in sorted(report.samples.keys()):
@@ -57,6 +58,6 @@ if __name__ == '__main__':
 
     for algorithm in algorithms:
         print("running '%s'" % (algorithm))
-        report = run_benchmark(algorithm, sizes, ["stl", "thrust"])
+        report = run_benchmark(algorithm, sizes, ["stl", "thrust", "bolt"])
         plot_to_file(report, "perf_plots/%s_time_plot.png" % algorithm)
 


### PR DESCRIPTION
This addresses issue https://github.com/kylelutz/compute/issues/220.

I've added:
* BOOST_COMPUTE_HAVE_BOLT option
* FindBolt.cmake cmake module from https://github.com/HSA-Libraries/Bolt
* Bolt perf tests (10):
 * bolt_accumulate (reduce)
 * bolt_count
 * bolt_exclusive_scan
 * bolt_fill
 * bolt_inner_product
 * bolt_max_element
 * bolt_merge
 * bolt_partial_sum (inclusive scan)
 * bolt_saxpy (transform)
 * bolt_sort
* Bolt perf tests in python benchmarking script perf.py
* Missing copyright and license info in one perf test

Bolt requires C++11, so performance tests for Bolt are build only if BOOST_COMPUTE_USE_CPP11 option is enabled. if BOOST_COMPUTE_HAVE_BOLT option is on and BOOST_COMPUTE_USE_CPP11 is off, warning message is printed.

If you're trying to test this PR and have problems with building Bolt on 64-bit Linux, contact me. I had the same problem.