### PR TITLE
Missing valarray operators

### DIFF
--- a/include/boost/compute/container/valarray.hpp
+++ b/include/boost/compute/container/valarray.hpp
@@ -15,6 +15,7 @@
 #include <valarray>
 
 #include <boost/static_assert.hpp>
+#include <boost/type_traits.hpp>
 
 #include <boost/compute/buffer.hpp>
 #include <boost/compute/algorithm/copy.hpp>
@@ -126,7 +127,8 @@ public:
     valarray<T> operator~() const
     {
         BOOST_STATIC_ASSERT_MSG(
-            (is_fundamental<T>::value && !is_floating_point<T>::value),
+            is_fundamental<T>::value &&
+                !is_floating_point<typename scalar_type<T>::type>::value,
             "This operator can be used with all OpenCL built-in scalar"
             " and vector types except the built-in scalar and vector float types"
         );
@@ -299,7 +301,8 @@ private:
 #define BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(op, op_name) \
     BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT(op, op_name, \
         BOOST_STATIC_ASSERT_MSG( \
-            (is_fundamental<T>::value && !is_floating_point<T>::value), \
+            is_fundamental<T>::value && \
+                !is_floating_point<typename scalar_type<T>::type>::value, \
             "This operator can be used with all OpenCL built-in scalar" \
             " and vector types except the built-in scalar and vector float types" \
         ); \
@@ -321,7 +324,7 @@ BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(>>, shift_right)
 // See OpenCL specification.
 BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT(%, modulus,
     BOOST_STATIC_ASSERT_MSG(
-        is_integral<T>::value,
+        is_integral<typename scalar_type<T>::type>::value,
         "This operator can be used only with OpenCL built-in integer types"
     );
 )
@@ -380,7 +383,8 @@ BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT(%, modulus,
 #define BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_NO_FP(op, op_name) \
     BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR(op, op_name, \
         BOOST_STATIC_ASSERT_MSG( \
-            is_fundamental<T>::value && !is_floating_point<T>::value, \
+            is_fundamental<T>::value && \
+                !is_floating_point<typename scalar_type<T>::type>::value, \
             "This operator can be used with all OpenCL built-in scalar" \
             " and vector types except the built-in scalar and vector float types" \
         ); \

--- a/include/boost/compute/container/valarray.hpp
+++ b/include/boost/compute/container/valarray.hpp
@@ -14,6 +14,8 @@
 #include <cstddef>
 #include <valarray>
 
+#include <boost/static_assert.hpp>
+
 #include <boost/compute/buffer.hpp>
 #include <boost/compute/functional.hpp>
 #include <boost/compute/algorithm/copy.hpp>
@@ -22,6 +24,8 @@
 #include <boost/compute/algorithm/min_element.hpp>
 #include <boost/compute/algorithm/transform.hpp>
 #include <boost/compute/algorithm/accumulate.hpp>
+#include <boost/compute/functional.hpp>
+#include <boost/compute/functional/bind.hpp>
 #include <boost/compute/detail/buffer_value.hpp>
 #include <boost/compute/iterator/buffer_iterator.hpp>
 
@@ -85,10 +89,97 @@ public:
     {
         resize(valarray.size());
         copy(&valarray[0], &valarray[valarray.size()], begin());
+
+        return *this;
     }
+
+    valarray<T>& operator*=(const T&);
+
+    valarray<T>& operator/=(const T&);
+
+    valarray<T>& operator%=(const T& val);
+
+    valarray<T> operator+() const
+    {
+        valarray<T> result(size());
+        copy(begin(), end(), result.begin());
+        return result;
+    }
+
+    valarray<T> operator-() const
+    {
+        valarray<T> result(size());
+        transform(begin(), end(), result.begin(),
+            bind(minus<T>(), T(0), placeholders::_1));
+        return result;
+    }
+
+    valarray<T> operator~() const
+    {
+        BOOST_STATIC_ASSERT_MSG(
+            !is_floating_point<T>::value,
+            "This operator can't be used with floating point types"
+        );
+        valarray<T> result(size());
+        BOOST_COMPUTE_FUNCTION(T, bitwise_not, (T x),
+        {
+            return ~x;
+        });
+        transform(begin(), end(), result.begin(), bitwise_not);
+        return result;
+    }
+
+    /// In OpenCL there cannot be memory buffer with bool type, for
+    /// this reason return type is valarray<char> instead of valarray<bool>.
+    /// 1 means true, 0 means false.
+    valarray<char> operator!() const
+    {
+        valarray<char> result(size());
+        BOOST_COMPUTE_FUNCTION(char, logical_not, (T x),
+        {
+            return !x;
+        });
+        transform(begin(), end(), &result[0], logical_not);
+        return result;
+    }
+
+    valarray<T>& operator+=(const T&);
+
+    valarray<T>& operator-=(const T&);
+
+    valarray<T>& operator^=(const T&);
+
+    valarray<T>& operator&=(const T&);
+
+    valarray<T>& operator|=(const T&);
+
+    valarray<T>& operator<<=(const T&);
+
+    valarray<T>& operator>>=(const T&);
+
+    valarray<T>& operator*=(const valarray<T>&);
+
+    valarray<T>& operator/=(const valarray<T>&);
+
+    valarray<T>& operator%=(const valarray<T>&);
+
+    valarray<T>& operator+=(const valarray<T>&);
+
+    valarray<T>& operator-=(const valarray<T>&);
+
+    valarray<T>& operator^=(const valarray<T>&);
+
+    valarray<T>& operator&=(const valarray<T>&);
+
+    valarray<T>& operator|=(const valarray<T>&);
+
+    valarray<T>& operator<<=(const valarray<T>&);
+
+    valarray<T>& operator>>=(const valarray<T>&);
 
     ~valarray()
     {
+
     }
 
     size_t size() const
@@ -140,6 +231,7 @@ public:
         return m_buffer;
     }
 
+
 private:
     buffer_iterator<T> begin() const
     {
@@ -154,6 +246,189 @@ private:
 private:
     buffer m_buffer;
 };
+
+/// \internal_
+#define BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT(op, op_name, assert) \
+    template<class T> \
+    inline valarray<T>& \
+    valarray<T>::operator op##=(const T& val) \
+    { \
+        assert \
+        transform(begin(), end(), begin(), \
+            bind(op_name<T>(), placeholders::_1, val)); \
+        return *this; \
+    } \
+    \
+    template<class T> \
+    inline valarray<T>& \
+    valarray<T>::operator op##=(const valarray<T> &rhs) \
+    { \
+        assert \
+        transform(begin(), end(), rhs.begin(), begin(), op_name<T>()); \
+        return *this; \
+    }
+
+/// \internal_
+#define BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_ANY(op, op_name) \
+    BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT(op, op_name, ) \
+
+/// \internal_
+/// For some operators class T can't be floating point type.
+/// See OpenCL specification, operators chapter.
+#define BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(op, op_name) \
+    BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT(op, op_name, \
+        BOOST_STATIC_ASSERT_MSG( \
+            !is_floating_point<T>::value, \
+            "This operator can't be used with floating point types" \
+        ); \
+    )
+
+// defining operators
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_ANY(+, plus)
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_ANY(-, minus)
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_ANY(*, multiplies)
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_ANY(/, divides)
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(^, bit_xor)
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(&, bit_and)
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(|, bit_or)
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(<<, shift_left)
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(>>, shift_right)
+
+// The remainder (%) operates on
+// integer scalar and integer vector data types only.
+// See OpenCL specification.
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT(%, modulus,
+    BOOST_STATIC_ASSERT_MSG(
+        is_integral<T>::value,
+        "This operator can be used only with integer types"
+    );
+)
+
+#undef BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_ANY
+#undef BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP
+
+#undef BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT
+
+/// \internal_
+/// Macro for defining binary operators for valarray
+#define BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR(op, op_name, assert) \
+    template<class T> \
+    valarray<T> operator op (const valarray<T>& lhs, const valarray<T>& rhs) \
+    { \
+        assert \
+        valarray<T> result(lhs.size()); \
+        transform(&lhs[0], &lhs[lhs.size()], &rhs[0], \
+            &result[0], op_name<T>()); \
+        return result; \
+    } \
+    \
+    template<class T> \
+    valarray<T> operator op (const T& val, const valarray<T>& rhs) \
+    { \
+        assert \
+        valarray<T> result(rhs.size()); \
+        transform(&rhs[0], &rhs[rhs.size()], &result[0], \
+            bind(op_name<T>(), val, placeholders::_1)); \
+        return result; \
+    } \
+    \
+    template<class T> \
+    valarray<T> operator op (const valarray<T>& lhs, const T& val) \
+    { \
+        assert \
+        valarray<T> result(lhs.size()); \
+        transform(&lhs[0], &lhs[lhs.size()], &result[0], \
+            bind(op_name<T>(), placeholders::_1, val)); \
+        return result; \
+    }
+
+/// \internal_
+/// For some operators class T can't be floating point type.
+/// See OpenCL specification, operators chapter.
+#define BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_NO_FP(op, op_name) \
+    BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR(op, op_name, \
+        BOOST_STATIC_ASSERT_MSG( \
+            !is_floating_point<T>::value, \
+            "This operator can't be used with floating point types" \
+        ); \
+    )
+
+/// \internal_
+#define BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_ANY(op, op_name) \
+    BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR(op, op_name, ) \
+
+// defining binary operators for valarray
+BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_ANY(+, plus)
+BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_ANY(-, minus)
+BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_ANY(*, multiplies)
+BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_ANY(/, divides)
+BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_NO_FP(^, bit_xor)
+BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_NO_FP(&, bit_and)
+BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_NO_FP(|, bit_or)
+BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_NO_FP(<<, shift_left)
+BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_NO_FP(>>, shift_right)
+
+#undef BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_ANY
+#undef BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_NO_FP
+
+#undef BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR
+
+/// \internal_
+/// Macro for defining valarray comparison operators.
+/// For return type valarray<char> is used instead of valarray<bool> because
+/// in OpenCL there cannot be memory buffer with bool type.
+///
+/// Note it's also used for defining binary logical operators (==, &&)
+#define BOOST_COMPUTE_DEFINE_VALARRAY_COMPARISON_OPERATOR(op, op_name) \
+    template<class T> \
+    valarray<char> operator op (const valarray<T>& lhs, const valarray<T>& rhs) \
+    { \
+        valarray<char> result(lhs.size()); \
+        transform(&lhs[0], &lhs[lhs.size()], &rhs[0], \
+            &result[0], op_name<T>()); \
+        return result; \
+    } \
+    \
+    template<class T> \
+    valarray<char> operator op (const T& val, const valarray<T>& rhs) \
+    { \
+        valarray<char> result(rhs.size()); \
+        transform(&rhs[0], &rhs[rhs.size()], &result[0], \
+            bind(op_name<T>(), val, placeholders::_1)); \
+        return result; \
+    } \
+    \
+    template<class T> \
+    valarray<char> operator op (const valarray<T>& lhs, const T& val) \
+    { \
+        valarray<char> result(lhs.size()); \
+        transform(&lhs[0], &lhs[lhs.size()], &result[0], \
+            bind(op_name<T>(), placeholders::_1, val)); \
+        return result; \
+    }
+
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPARISON_OPERATOR(==, equal_to)
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPARISON_OPERATOR(!=, not_equal_to)
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPARISON_OPERATOR(>, greater)
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPARISON_OPERATOR(<, less)
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPARISON_OPERATOR(>=, greater_equal)
+BOOST_COMPUTE_DEFINE_VALARRAY_COMPARISON_OPERATOR(<=, less_equal)
+
+/// \internal_
+/// Macro for defining binary logical operators for valarray.
+///
+/// For return type valarray<char> is used instead of valarray<bool> because
+/// in OpenCL there cannot be memory buffer with bool type.
+/// 1 means true, 0 means false.
+#define BOOST_COMPUTE_DEFINE_VALARRAY_LOGICAL_OPERATOR(op, op_name) \
+    BOOST_COMPUTE_DEFINE_VALARRAY_COMPARISON_OPERATOR(op, op_name)
+
+BOOST_COMPUTE_DEFINE_VALARRAY_LOGICAL_OPERATOR(&&, logical_and)
+BOOST_COMPUTE_DEFINE_VALARRAY_LOGICAL_OPERATOR(||, logical_or)
+
+#undef BOOST_COMPUTE_DEFINE_VALARRAY_LOGICAL_OPERATOR
+
+#undef BOOST_COMPUTE_DEFINE_VALARRAY_COMPARISON_OPERATOR
 
 } // end compute namespace
 } // end boost namespace

--- a/include/boost/compute/functional/operator.hpp
+++ b/include/boost/compute/functional/operator.hpp
@@ -92,6 +92,8 @@ BOOST_COMPUTE_DECLARE_BINARY_OPERATOR(logical_or, "||", T, T)
 BOOST_COMPUTE_DECLARE_BINARY_OPERATOR(bit_and, "&", T, T)
 BOOST_COMPUTE_DECLARE_BINARY_OPERATOR(bit_or, "|", T, T)
 BOOST_COMPUTE_DECLARE_BINARY_OPERATOR(bit_xor, "^", T, T)
+BOOST_COMPUTE_DECLARE_BINARY_OPERATOR(shift_left, "<<", T, T)
+BOOST_COMPUTE_DECLARE_BINARY_OPERATOR(shift_right, ">>", T, T)
 
 } // end compute namespace
 } // end boost namespace

--- a/test/test_valarray.cpp
+++ b/test/test_valarray.cpp
@@ -15,6 +15,7 @@
 #include <boost/compute/command_queue.hpp>
 #include <boost/compute/container/valarray.hpp>
 
+#include "check_macros.hpp"
 #include "context_setup.hpp"
 
 BOOST_AUTO_TEST_CASE(size)
@@ -54,9 +55,307 @@ BOOST_AUTO_TEST_CASE(sum)
 {
     int data[] = { 1, 2, 3, 4 };
     boost::compute::valarray<int> array(data, 4);
-    BOOST_CHECK_EQUAL(array.size(), size_t(4));
+    boost::compute::system::finish();
 
+    BOOST_CHECK_EQUAL(array.size(), size_t(4));
     BOOST_CHECK_EQUAL(array.sum(), int(10));
 }
+
+BOOST_AUTO_TEST_CASE(apply)
+{
+    int data[] = { -1, 2, -3, 4 };
+    boost::compute::valarray<int> array(data, 4);
+
+    boost::compute::abs<int> abs;
+    boost::compute::valarray<int> result = array.apply(abs);
+    boost::compute::system::finish();
+    BOOST_CHECK_EQUAL(int(result[0]), int(1));
+    BOOST_CHECK_EQUAL(int(result[1]), int(2));
+    BOOST_CHECK_EQUAL(int(result[2]), int(3));
+    BOOST_CHECK_EQUAL(int(result[3]), int(4));
+}
+
+/// \internal_
+/// Tests for compound assignment operators that works for floating
+/// point types.
+#define BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT(op, op_name) \
+BOOST_AUTO_TEST_CASE(op_name##_ca_operator_no_fp) \
+{ \
+    float data[] = { 1, 2, 3, 4 }; \
+    boost::compute::valarray<float> array1(data, 4); \
+    boost::compute::valarray<float> array2(data, 4); \
+    boost::compute::system::finish(); \
+    \
+    array1 op##= 1; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_CLOSE(float(array1[0]), float(1.0f op 1.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(array1[1]), float(2.0f op 1.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(array1[2]), float(3.0f op 1.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(array1[3]), float(4.0f op 1.0f), 1e-4f); \
+    \
+    array1 = boost::compute::valarray<float>(data, 4); \
+    boost::compute::system::finish(); \
+    \
+    array1 op##= array2; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_CLOSE(float(array1[0]), float(1.0f op 1.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(array1[1]), float(2.0f op 2.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(array1[2]), float(3.0f op 3.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(array1[3]), float(4.0f op 4.0f), 1e-4f); \
+    \
+    array2 op##= array2; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_CLOSE(float(array2[0]), float(1.0f op 1.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(array2[1]), float(2.0f op 2.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(array2[2]), float(3.0f op 3.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(array2[3]), float(4.0f op 4.0f), 1e-4f); \
+    \
+}
+
+BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT(+, plus)
+BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT(-, minus)
+BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT(*, multiplies)
+BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT(/, divides)
+
+#undef BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT
+
+/// \internal_
+/// Tests for compound assignment operators that does NOT work for floating
+/// point types.
+/// Note: modulo operator works only for integer types.
+#define BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(op, op_name) \
+BOOST_AUTO_TEST_CASE(op_name##_ca_operator) \
+{ \
+    int data[] = { 1, 2, 3, 4 }; \
+    boost::compute::valarray<int> array1(data, 4); \
+    boost::compute::valarray<int> array2(data, 4); \
+    boost::compute::system::finish(); \
+    \
+    array1 op##= 1; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_EQUAL(int(array1[0]), int(1 op 1)); \
+    BOOST_CHECK_EQUAL(int(array1[1]), int(2 op 1)); \
+    BOOST_CHECK_EQUAL(int(array1[2]), int(3 op 1)); \
+    BOOST_CHECK_EQUAL(int(array1[3]), int(4 op 1)); \
+    \
+    array1 = boost::compute::valarray<int>(data, 4); \
+    boost::compute::system::finish(); \
+    \
+    array1 op##= array2; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_EQUAL(int(array1[0]), int(1 op 1)); \
+    BOOST_CHECK_EQUAL(int(array1[1]), int(2 op 2)); \
+    BOOST_CHECK_EQUAL(int(array1[2]), int(3 op 3)); \
+    BOOST_CHECK_EQUAL(int(array1[3]), int(4 op 4)); \
+    \
+    array2 op##= array2; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_EQUAL(int(array2[0]), int(1 op 1)); \
+    BOOST_CHECK_EQUAL(int(array2[1]), int(2 op 2)); \
+    BOOST_CHECK_EQUAL(int(array2[2]), int(3 op 3)); \
+    BOOST_CHECK_EQUAL(int(array2[3]), int(4 op 4)); \
+    \
+}
+
+BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(%, modulus)
+BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(^, bit_xor)
+BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(&, bit_and)
+BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(|, bit_or)
+BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(<<, shift_left)
+BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP(>>, shift_right)
+
+#undef BOOST_COMPUTE_TEST_VALARRAY_COMPOUND_ASSIGNMENT_NO_FP
+
+BOOST_AUTO_TEST_CASE(unary_plus_operator)
+{
+    int data[] = { 1, 2, 3, 4 };
+    boost::compute::valarray<int> array(data, 4);
+    boost::compute::system::finish();
+
+    boost::compute::valarray<int> result = +array;
+    boost::compute::system::finish();
+    BOOST_CHECK_EQUAL(int(result[0]), +(int(1)));
+    BOOST_CHECK_EQUAL(int(result[1]), +(int(2)));
+    BOOST_CHECK_EQUAL(int(result[2]), +(int(3)));
+    BOOST_CHECK_EQUAL(int(result[3]), +(int(4)));
+}
+
+BOOST_AUTO_TEST_CASE(unary_minus_operator)
+{
+    int data[] = { -1, 2, 0, 4 };
+    boost::compute::valarray<int> array(data, 4);
+    boost::compute::system::finish();
+
+    boost::compute::valarray<int> result = -array;
+    boost::compute::system::finish();
+    BOOST_CHECK_EQUAL(int(result[0]), int(1));
+    BOOST_CHECK_EQUAL(int(result[1]), int(-2));
+    BOOST_CHECK_EQUAL(int(result[2]), int(0));
+    BOOST_CHECK_EQUAL(int(result[3]), int(-4));
+}
+
+BOOST_AUTO_TEST_CASE(unary_bitwise_not_operator)
+{
+    int data[] = { 1, 2, 3, 4 };
+    boost::compute::valarray<int> array(data, 4);
+    boost::compute::system::finish();
+
+    boost::compute::valarray<int> result = ~array;
+    boost::compute::system::finish();
+    BOOST_CHECK_EQUAL(int(result[0]), ~(int(1)));
+    BOOST_CHECK_EQUAL(int(result[1]), ~(int(2)));
+    BOOST_CHECK_EQUAL(int(result[2]), ~(int(3)));
+    BOOST_CHECK_EQUAL(int(result[3]), ~(int(4)));
+}
+
+BOOST_AUTO_TEST_CASE(unary_logical_not_operator)
+{
+    int data[] = { 1, -2, 0, 4 };
+    boost::compute::valarray<int> array(data, 4);
+    boost::compute::system::finish();
+
+    boost::compute::valarray<char> result = !array;
+    boost::compute::system::finish();
+    BOOST_CHECK_EQUAL(bool(result[0]), !(int(1)));
+    BOOST_CHECK_EQUAL(bool(result[1]), !(int(-2)));
+    BOOST_CHECK_EQUAL(bool(result[2]), !(int(0)));
+    BOOST_CHECK_EQUAL(bool(result[3]), !(int(4)));
+}
+
+/// \internal_
+/// Tests for binary operators that works for floating
+/// point types.
+#define BOOST_COMPUTE_TEST_VALARRAY_BINARY_OPERATOR(op, op_name) \
+BOOST_AUTO_TEST_CASE(op_name##_binary_operator) \
+{ \
+    float data1[] = { 1, 2, 3, 4 }; \
+    float data2[] = { 4, 2, 3, 0 }; \
+    boost::compute::valarray<float> array1(data1, 4); \
+    boost::compute::valarray<float> array2(data2, 4); \
+    boost::compute::system::finish(); \
+    \
+    boost::compute::valarray<float> result = 2.0f op array1; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_CLOSE(float(result[0]), float(2.0f op 1.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(result[1]), float(2.0f op 2.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(result[2]), float(2.0f op 3.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(result[3]), float(2.0f op 4.0f), 1e-4f); \
+    \
+    result = array1 op 2.0f; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_CLOSE(float(result[0]), float(1.0f op 2.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(result[1]), float(2.0f op 2.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(result[2]), float(3.0f op 2.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(result[3]), float(4.0f op 2.0f), 1e-4f); \
+    \
+    result = array2 op array1; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_CLOSE(float(result[0]), float(4.0f op 1.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(result[1]), float(2.0f op 2.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(result[2]), float(3.0f op 3.0f), 1e-4f); \
+    BOOST_CHECK_CLOSE(float(result[3]), float(0.0f op 4.0f), 1e-4f); \
+}
+
+BOOST_COMPUTE_TEST_VALARRAY_BINARY_OPERATOR(+, plus)
+BOOST_COMPUTE_TEST_VALARRAY_BINARY_OPERATOR(-, minus)
+BOOST_COMPUTE_TEST_VALARRAY_BINARY_OPERATOR(*, multiplies)
+BOOST_COMPUTE_TEST_VALARRAY_BINARY_OPERATOR(/, divides)
+
+#undef BOOST_COMPUTE_TEST_VALARRAY_BINARY_OPERATOR
+
+/// \internal_
+/// Tests for compound assignment operators that does NOT work for floating
+/// point types.
+/// Note: modulo operator works only for integer types.
+#define BOOST_COMPUTE_TEST_VALARRAY_BINARY_OPERATOR_NO_FP(op, op_name) \
+BOOST_AUTO_TEST_CASE(op_name##_binary_operator) \
+{ \
+    int data1[] = { 1, 2, 3, 4 }; \
+    int data2[] = { 4, 5, 2, 1 }; \
+    boost::compute::valarray<int> array1(data1, 4); \
+    boost::compute::valarray<int> array2(data2, 4); \
+    boost::compute::system::finish(); \
+    \
+    boost::compute::valarray<int> result = 5 op array1; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_EQUAL(int(result[0]), int(5 op 1)); \
+    BOOST_CHECK_EQUAL(int(result[1]), int(5 op 2)); \
+    BOOST_CHECK_EQUAL(int(result[2]), int(5 op 3)); \
+    BOOST_CHECK_EQUAL(int(result[3]), int(5 op 4)); \
+    \
+    result = array1 op 5; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_EQUAL(int(result[0]), int(1 op 5)); \
+    BOOST_CHECK_EQUAL(int(result[1]), int(2 op 5)); \
+    BOOST_CHECK_EQUAL(int(result[2]), int(3 op 5)); \
+    BOOST_CHECK_EQUAL(int(result[3]), int(4 op 5)); \
+    \
+    result = array1 op array2; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_EQUAL(int(result[0]), int(1 op 4)); \
+    BOOST_CHECK_EQUAL(int(result[1]), int(2 op 5)); \
+    BOOST_CHECK_EQUAL(int(result[2]), int(3 op 2)); \
+    BOOST_CHECK_EQUAL(int(result[3]), int(4 op 1)); \
+}
+
+BOOST_COMPUTE_TEST_VALARRAY_BINARY_OPERATOR_NO_FP(^, bit_xor)
+BOOST_COMPUTE_TEST_VALARRAY_BINARY_OPERATOR_NO_FP(&, bit_and)
+BOOST_COMPUTE_TEST_VALARRAY_BINARY_OPERATOR_NO_FP(|, bit_or)
+BOOST_COMPUTE_TEST_VALARRAY_BINARY_OPERATOR_NO_FP(<<, shift_left)
+BOOST_COMPUTE_TEST_VALARRAY_BINARY_OPERATOR_NO_FP(>>, shift_right)
+
+#undef BOOST_COMPUTE_TEST_VALARRAY_BINARY_OPERATOR_NO_FP
+
+/// \internal_
+/// Macro for generating tests for valarray comparison operators.
+#define BOOST_COMPUTE_TEST_VALARRAY_COMPARISON_OPERATOR(op, op_name) \
+BOOST_AUTO_TEST_CASE(op_name##_comparision_operator) \
+{ \
+    int data1[] = { 1, 2, 0, 4 }; \
+    int data2[] = { 4, 0, 2, 1 }; \
+    boost::compute::valarray<int> array1(data1, 4); \
+    boost::compute::valarray<int> array2(data2, 4); \
+    boost::compute::system::finish(); \
+    \
+    boost::compute::valarray<char> result = 2 op array1; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_EQUAL(bool(result[0]), bool(2 op 1)); \
+    BOOST_CHECK_EQUAL(bool(result[1]), bool(2 op 2)); \
+    BOOST_CHECK_EQUAL(bool(result[2]), bool(2 op 0)); \
+    BOOST_CHECK_EQUAL(bool(result[3]), bool(2 op 4)); \
+    \
+    result = array1 op 2; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_EQUAL(bool(result[0]), bool(1 op 2)); \
+    BOOST_CHECK_EQUAL(bool(result[1]), bool(2 op 2)); \
+    BOOST_CHECK_EQUAL(bool(result[2]), bool(0 op 2)); \
+    BOOST_CHECK_EQUAL(bool(result[3]), bool(4 op 2)); \
+    \
+    result = array1 op array2; \
+    boost::compute::system::finish(); \
+    BOOST_CHECK_EQUAL(bool(result[0]), bool(1 op 4)); \
+    BOOST_CHECK_EQUAL(bool(result[1]), bool(2 op 0)); \
+    BOOST_CHECK_EQUAL(bool(result[2]), bool(0 op 2)); \
+    BOOST_CHECK_EQUAL(bool(result[3]), bool(4 op 1)); \
+}
+
+BOOST_COMPUTE_TEST_VALARRAY_COMPARISON_OPERATOR(==, equal_to)
+BOOST_COMPUTE_TEST_VALARRAY_COMPARISON_OPERATOR(!=, not_equal_to)
+BOOST_COMPUTE_TEST_VALARRAY_COMPARISON_OPERATOR(>, greater)
+BOOST_COMPUTE_TEST_VALARRAY_COMPARISON_OPERATOR(<, less)
+BOOST_COMPUTE_TEST_VALARRAY_COMPARISON_OPERATOR(>=, greater_equal)
+BOOST_COMPUTE_TEST_VALARRAY_COMPARISON_OPERATOR(<=, less_equal)
+
+/// \internal_
+/// Macro for generating tests for valarray binary logical operators.
+#define BOOST_COMPUTE_TEST_VALARRAY_LOGICAL_OPERATOR(op, op_name) \
+    BOOST_COMPUTE_TEST_VALARRAY_COMPARISON_OPERATOR(op, op_name)
+
+BOOST_COMPUTE_TEST_VALARRAY_LOGICAL_OPERATOR(&&, logical_and)
+BOOST_COMPUTE_TEST_VALARRAY_LOGICAL_OPERATOR(||, logical_or)
+
+#undef BOOST_COMPUTE_TEST_VALARRAY_LOGICAL_OPERATOR
+
+#undef BOOST_COMPUTE_TEST_VALARRAY_COMPARISON_OPERATOR
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This addresses issue https://github.com/boostorg/compute/issues/381.

I've implemented all missing valarray operators (see [valarray operators](http://www.cplusplus.com/reference/valarray/valarray/operators/)) and added tests for them.

Implemented operators work only for default context (queue) and are asynchronous.

Note that in OpenCL it's impossible to create memory buffer with bool type and because of that ```valarray<char>``` is used  as a return type for comparison and logical operators instead of ```valarray<bool>```. 