### PR TITLE
Fix default values in uniform_int_distribution constructor

### DIFF
--- a/include/boost/compute/random/uniform_int_distribution.hpp
+++ b/include/boost/compute/random/uniform_int_distribution.hpp
@@ -11,6 +11,8 @@
 #ifndef BOOST_COMPUTE_RANDOM_UNIFORM_INT_DISTRIBUTION_HPP
 #define BOOST_COMPUTE_RANDOM_UNIFORM_INT_DISTRIBUTION_HPP
 
+#include <limits>
+
 #include <boost/compute/command_queue.hpp>
 #include <boost/compute/container/vector.hpp>
 #include <boost/compute/function.hpp>
@@ -37,7 +39,8 @@ public:
 
     /// Creates a new uniform distribution producing numbers in the range
     /// [\p a, \p b].
-    uniform_int_distribution(IntType a = 0, IntType b = 1)
+    explicit uniform_int_distribution(IntType a = 0,
+                                      IntType b = std::numeric_limits<IntType>::max())
         : m_a(a),
           m_b(b)
     {


### PR DESCRIPTION
This fixes the default values for the uniform_int_distribution
constructor to match std::uniform_int_distribution.