### PR TITLE
Fix transform_if() test

### DIFF
--- a/test/test_transform_if.cpp
+++ b/test/test_transform_if.cpp
@@ -26,14 +26,15 @@ BOOST_AUTO_TEST_CASE(transform_if_odd)
     using boost::compute::lambda::_1;
 
     int data[] = { -2, -3, -4, -5, -6, -7, -8, -9 };
-    compute::vector<int> vector(data, data + 8, queue);
+    compute::vector<int> input(data, data + 8, queue);
+    compute::vector<int> output(input.size(), context);
 
     compute::vector<int>::iterator end = compute::transform_if(
-        vector.begin(), vector.end(), vector.begin(), abs<int>(), _1 % 2 != 0, queue
+        input.begin(), input.end(), output.begin(), abs<int>(), _1 % 2 != 0, queue
     );
-    BOOST_CHECK_EQUAL(std::distance(vector.begin(), end), 4);
+    BOOST_CHECK_EQUAL(std::distance(output.begin(), end), 4);
 
-    CHECK_RANGE_EQUAL(int, 4, vector, (+3, +5, +7, +9));
+    CHECK_RANGE_EQUAL(int, 4, output, (+3, +5, +7, +9));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This fixes the transform_if() test to copy to a separate output
vector as in-place operation is not supported.