### PR TITLE
find_extrema based on parallel reduction

### DIFF
--- a/include/boost/compute/algorithm/detail/find_extrema.hpp
+++ b/include/boost/compute/algorithm/detail/find_extrema.hpp
@@ -12,6 +12,7 @@
 #define BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_HPP
 
 #include <boost/compute/detail/iterator_range_size.hpp>
+#include <boost/compute/algorithm/detail/find_extrema_reduce.hpp>
 #include <boost/compute/algorithm/detail/find_extrema_with_atomics.hpp>
 #include <boost/compute/algorithm/detail/serial_find_extrema.hpp>
 
@@ -32,9 +33,18 @@ inline InputIterator find_extrema(InputIterator first,
         return first;
     }
 
+    const device &device = queue.get_device();
+
     // use serial method for small inputs
-    if(count < 64){
+    // and when device is a CPU
+    if(count < 64 || (device.type() & device::cpu)){
         return serial_find_extrema(first, last, sign, queue);
+    }
+
+    // find_extrema_reduce() is used only if requirements are met
+    if(find_extrema_reduce_requirements_met(first, last, queue))
+    {
+        return find_extrema_reduce(first, last, sign, queue);
     }
 
     // use serial method for OpenCL version 1.0 due to

--- a/include/boost/compute/algorithm/detail/find_extrema_reduce.hpp
+++ b/include/boost/compute/algorithm/detail/find_extrema_reduce.hpp
@@ -1,0 +1,260 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#ifndef BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_REDUCE_HPP
+#define BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_REDUCE_HPP
+
+#include <algorithm>
+#include <vector>
+
+#include <boost/compute/types.hpp>
+#include <boost/compute/command_queue.hpp>
+#include <boost/compute/algorithm/copy.hpp>
+#include <boost/compute/container/vector.hpp>
+#include <boost/compute/detail/meta_kernel.hpp>
+#include <boost/compute/detail/iterator_range_size.hpp>
+#include <boost/compute/detail/parameter_cache.hpp>
+#include <boost/compute/memory/local_buffer.hpp>
+#include <boost/compute/type_traits/type_name.hpp>
+#include <boost/compute/utility/program_cache.hpp>
+
+namespace boost {
+namespace compute {
+namespace detail {
+
+template<class InputIterator>
+bool find_extrema_reduce_requirements_met(InputIterator first,
+                                          InputIterator last,
+                                          command_queue &queue)
+{
+    typedef typename std::iterator_traits<InputIterator>::value_type input_type;
+
+    const device &device = queue.get_device();
+
+    // device must have dedicated local memory storage
+    // otherwise reduction would be highly inefficient
+    if(device.get_info<CL_DEVICE_LOCAL_MEM_TYPE>() != CL_LOCAL)
+    {
+        return false;
+    }
+
+    const size_t max_work_group_size = device.get_info<CL_DEVICE_MAX_WORK_GROUP_SIZE>();
+    // local memory size in bytes (per compute unit)
+    const size_t local_mem_size = device.get_info<CL_DEVICE_LOCAL_MEM_SIZE>();
+
+    std::string cache_key = std::string("__boost_find_extrema_reduce_")
+        + type_name<input_type>();
+    // load parameters
+    boost::shared_ptr<parameter_cache> parameters =
+        detail::parameter_cache::get_global_cache(device);
+
+    // Get preferred work group size
+    size_t work_group_size = parameters->get(cache_key, "wgsize", 256);
+
+    work_group_size = (std::min)(max_work_group_size, work_group_size);
+
+    // local memory size needed to perform parallel reduction
+    size_t required_local_mem_size = 0;
+    // indices size
+    required_local_mem_size += sizeof(uint_) * work_group_size;
+    // values size
+    required_local_mem_size += sizeof(input_type) * work_group_size;
+
+    // at least 4 work groups per compute unit otherwise reduction
+    // would be highly inefficient
+    return ((required_local_mem_size * 4) <= local_mem_size);
+}
+
+template<class InputIterator, class ResultIterator>
+inline size_t find_extrema_reduce(InputIterator first,
+                                  size_t count,
+                                  ResultIterator result,
+                                  vector<uint_>::iterator result_idx,
+                                  size_t work_groups_no,
+                                  size_t work_group_size,
+                                  char sign,
+                                  command_queue &queue)
+{
+    typedef typename std::iterator_traits<InputIterator>::value_type input_type;
+
+    const context &context = queue.get_context();
+
+    meta_kernel k("find_extrema_reduce");
+    size_t count_arg = k.add_arg<uint_>("count");
+    size_t output_arg = k.add_arg<input_type *>(memory_object::global_memory, "output");
+    size_t output_idx_arg = k.add_arg<uint_ *>(memory_object::global_memory, "output_idx");
+    size_t block_arg = k.add_arg<input_type *>(memory_object::local_memory, "block");
+    size_t block_idx_arg = k.add_arg<uint_ *>(memory_object::local_memory, "block_idx");
+
+    k <<
+        // Work item global id
+        k.decl<const uint_>("gid") << " = get_global_id(0);\n" <<
+        //
+        "if(gid >= count) {\n return;\n }\n" <<
+
+        // Index of element that will be read from input buffer
+        k.decl<uint_>("idx") << " = gid;\n" <<
+
+        k.decl<input_type>("acc") << ";\n" <<
+        // Index of currently best element
+        k.decl<uint_>("acc_idx") << " = idx;\n" <<
+
+        // Init accumulator with first[get_global_id(0)]
+        "acc = " << first[k.var<uint_>("idx")] << ";\n" <<
+        "idx += get_global_size(0);\n" <<
+
+        k.decl<bool>("compare_result") << ";\n" <<
+        "while( idx < count ){\n" <<
+            // Next element
+            k.decl<input_type>("next") << " = " << first[k.var<uint_>("idx")] << ";\n" <<
+            // Comparison between currently best element (acc) and next element
+            "compare_result = acc " << sign << " next;\n" <<
+            "acc = compare_result ? acc : next;\n" <<
+            "acc_idx = compare_result ? acc_idx : idx;\n" <<
+            "idx += get_global_size(0);\n" <<
+        "}\n" <<
+
+        // Work item local id
+        k.decl<const uint_>("lid") << " = get_local_id(0);\n" <<
+        "block[lid] = acc;\n" <<
+        "block_idx[lid] = acc_idx;\n" <<
+        "barrier(CLK_LOCAL_MEM_FENCE);\n" <<
+
+        k.decl<uint_>("group_offset") << " = count - (get_local_size(0) * get_group_id(0));\n";
+
+    k <<
+        "#pragma unroll\n"
+        "for(" << k.decl<uint_>("offset") << " = " << work_group_size << " / 2; offset > 0; " <<
+             "offset = offset / 2) {\n" <<
+             "if((lid < offset) && ((lid + offset) < group_offset)) { \n" <<
+                 k.decl<input_type>("mine") << " = block[lid];\n" <<
+                 k.decl<input_type>("other") << " = block[lid+offset];\n" <<
+                 "compare_result = mine " << sign << " other;\n" <<
+                 "block[lid] = compare_result ? mine : other;\n" <<
+                 "block_idx[lid] = compare_result ? " <<
+                     "block_idx[lid] : block_idx[lid+offset];\n" <<
+             "}\n"
+             "barrier(CLK_LOCAL_MEM_FENCE);\n" <<
+        "}\n" <<
+
+         // write block result to global output
+        "if(lid == 0){\n" <<
+        "    output[get_group_id(0)] = block[0];\n" <<
+        "    output_idx[get_group_id(0)] = block_idx[0];\n" <<
+        "}";
+
+    kernel kernel = k.compile(context);
+    kernel.set_arg(count_arg, static_cast<uint_>(count));
+    kernel.set_arg(output_arg, result.get_buffer());
+    kernel.set_arg(output_idx_arg, result_idx.get_buffer());
+    kernel.set_arg(block_arg, local_buffer<input_type>(work_group_size));
+    kernel.set_arg(block_idx_arg, local_buffer<uint_>(work_group_size));
+
+    queue.enqueue_1d_range_kernel(kernel,
+                                  0,
+                                  work_groups_no * work_group_size,
+                                  work_group_size);
+
+    return 0;
+}
+
+template<class InputIterator>
+InputIterator find_extrema_reduce(InputIterator first,
+                                  InputIterator last,
+                                  char sign,
+                                  command_queue &queue)
+{
+    typedef typename std::iterator_traits<InputIterator>::difference_type difference_type;
+    typedef typename std::iterator_traits<InputIterator>::value_type input_type;
+
+    const context &context = queue.get_context();
+    const device &device = queue.get_device();
+
+    // Getting information about used queue and device
+    const size_t compute_units_no = device.get_info<CL_DEVICE_MAX_COMPUTE_UNITS>();
+    const size_t max_work_group_size = device.get_info<CL_DEVICE_MAX_WORK_GROUP_SIZE>();
+
+    const size_t count = detail::iterator_range_size(first, last);
+
+    std::string cache_key = std::string("__boost_find_extrema_reduce_")
+        + type_name<input_type>();
+
+    // load parameters
+    boost::shared_ptr<parameter_cache> parameters =
+        detail::parameter_cache::get_global_cache(device);
+
+    // get preferred work group size and preferred number
+    // of work groups per compute unit
+    size_t work_group_size = parameters->get(cache_key, "wgsize", 256);
+    size_t work_groups_per_cu = parameters->get(cache_key, "wgpcu", 64);
+
+    // calculate work group size and number of work groups
+    work_group_size = (std::min)(max_work_group_size, work_group_size);
+    size_t work_groups_no = compute_units_no * work_groups_per_cu;
+    work_groups_no = (std::min)(
+            work_groups_no,
+            static_cast<size_t>(std::ceil(float(count) / work_group_size)));
+
+    // device vectors for extremum candidates and their indices
+    vector<input_type> results(work_groups_no, context);
+    vector<uint_> results_idx(work_groups_no, context);
+
+    // find extremum candidates and their indices
+    find_extrema_reduce(first, count,
+                        results.begin(), results_idx.begin(),
+                        work_groups_no, work_group_size,
+                        sign,
+                        queue);
+
+    // host vectors
+    std::vector<input_type> host_results(work_groups_no);
+    std::vector<uint_> host_results_idx(work_groups_no);
+
+    // copying extremum candidates found by
+    // find_extrema_reduce(...) to host
+    copy(results_idx.begin(),
+         results_idx.end(),
+         host_results_idx.begin(), queue);
+    copy(results.begin(),
+         results.end(),
+         host_results.begin(), queue);
+
+    typename std::vector<input_type>::iterator i = host_results.begin();
+    std::vector<uint_>::iterator idx = host_results_idx.begin();
+    std::vector<uint_>::iterator extreme_idx = idx;
+    input_type extreme = *i;
+
+    // find extremum from candidates found by find_extrema_reduce(...)
+    if(sign == '>') {
+        while(idx != host_results_idx.end()) {
+            bool compare_result =  *i > extreme;
+            extreme = compare_result ? *i : extreme;
+            extreme_idx = compare_result ? idx : extreme_idx;
+            idx++, i++;
+        }
+    }
+    else {
+        while(idx != host_results_idx.end()) {
+            bool compare_result =  *i < extreme;
+            extreme = compare_result ? *i : extreme;
+            extreme_idx = compare_result ? idx : extreme_idx;
+            idx++, i++;
+        }
+    }
+
+    // return iterator to extremum
+    return first + static_cast<difference_type>(*extreme_idx);
+}
+
+} // end detail namespace
+} // end compute namespace
+} // end boost namespace
+
+#endif // BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_REDUCE_HPP

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -169,7 +169,7 @@ endif()
 # bolt c++ template lib benchmarks (for comparison)
 if(${BOOST_COMPUTE_HAVE_BOLT} AND ${BOOST_COMPUTE_USE_CPP11})
   find_package(Bolt REQUIRED)
-  include_directories(${BOLT_INCLUDE_DIRS})
+  include_directories(SYSTEM ${BOLT_INCLUDE_DIRS})
 
   set(BOLT_BENCHMARKS
     bolt_accumulate

--- a/perf/perf_stl_max_element.cpp
+++ b/perf/perf_stl_max_element.cpp
@@ -28,13 +28,16 @@ int main(int argc, char *argv[])
     std::vector<int> host_vector(PERF_N);
     std::generate(host_vector.begin(), host_vector.end(), rand_int);
 
+    int max = 0;
+
     perf_timer t;
     for(size_t trial = 0; trial < PERF_TRIALS; trial++){
         t.start();
-        std::max_element(host_vector.begin(), host_vector.end());
+        max = *(std::max_element(host_vector.begin(), host_vector.end()));
         t.stop();
     }
     std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
+    std::cout << "max: " << max << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
This adds ```find_extrema_reduce``` function and change ```find_extrema``` function to use it if there is enough local memory on device to perform an efficient parallel reduction. If there is not, ```find_extema_with_atomics``` is used (just like it was).

```find_extrema_reduce``` and ```find_extema_with_atomics``` get the same time results in ```perf_max_element``` benchmark. For vectors with 134217728 elements the difference is visible. 

master branch:
```
=== max_element with stl ===
size,time (ms)
2,0.000231
4,0.000260
8,0.000286
16,0.000299
32,0.000312
64,0.000364
128,0.000421
256,0.000519
512,0.000779
1024,0.001274
2048,0.002192
4096,0.004097
8192,0.007887
16384,0.015551
32768,0.030970
65536,0.061633
131072,0.123388
262144,0.251553
524288,0.506069
1048576,1.010500
2097152,2.298420
4194304,4.540600
8388608,9.029470
16777216,18.179500
33554432,36.464900
=== max_element with compute ===
size,time (ms)
2,2.938670
4,2.953160
8,2.982040
16,3.020810
32,2.960240
64,3.023210
128,3.006550
256,3.052890
512,3.005860
1024,2.995740
2048,3.060540
4096,2.994000
8192,3.076960
16384,3.008020
32768,3.046970
65536,3.040360
131072,3.092490
262144,3.138090
524288,3.187000
1048576,2.986230
2097152,3.074310
4194304,3.280390
8388608,3.608900
16777216,4.278090
33554432,5.508340
--- 
67108864, 7.90407 ms
134217728, 13.3829 ms

=== max_element with bolt ===
size,time (ms)
2,0.239094
4,0.242006
8,0.242288
16,0.243363
32,0.242257
64,0.243461
128,0.243329
256,0.241237
512,0.413800
1024,0.520461
2048,0.729220
4096,1.151180
8192,1.964450
16384,3.618160
32768,6.824630
65536,11.551800
131072,22.584200
262144,28.026900
524288,28.072100
1048576,27.904700
2097152,28.255900
4194304,28.788000
8388608,26.075500
16777216,25.414200
33554432,28.391500
```

pr_improving_find_extrema branch:
```
=== max_element with compute ===
size,time (ms)
2,2.951420
4,3.024390
8,2.964650
16,3.017970
32,3.006210
64,3.144770
128,3.117730
256,3.126830
512,3.064650
1024,3.069900
2048,3.055710
4096,3.098720
8192,3.127860
16384,3.130310
32768,3.098050
65536,3.114520
131072,3.190490
262144,3.240010
524288,3.252840
1048576,3.347880
2097152,3.471760
4194304,3.582500
8388608,3.625560
16777216,4.242310
33554432,5.249320
--- 
67108864, 7.20043 ms
134217728, 11.2549 ms

```

However, when worst case scenario is used, i.e. vector contains elements from 0 to ```vector.size() - 1```, performance of  ```find_extema_with_atomics``` decreases. 

```cpp
int global = 0;
int next_int()
{
    return global++;
}
```

When function ```next_int()``` is used to fill vector instead of ```rand_int()```, performance of ```find_extema_reduce``` remains the same, but performance of  ```find_extema_with_atomics``` decreases:
```
2097152,5.000910
4194304,6.930040
8388608,10.957300
16777216,18.637500
33554432,34.256900
```

Another argument for merging this PR is fact that ```find_extema_reduce``` work for OpenCL 1.0, when current ```find_extema_with_atomics```  does not (I have to say that I don't no why it does not work). 