### PR TITLE
Install BoostComputeConfig.cmake to lib/cmake/BoostCompute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ configure_file(
 # install cmake config file
 install(
   FILES ${BoostCompute_BINARY_DIR}/BoostComputeConfig.cmake
-  DESTINATION share/cmake/BoostCompute
+  DESTINATION lib/cmake/BoostCompute
 )
 
 # install header files


### PR DESCRIPTION
I am packaging BoostCompute for Gentoo Linux. Normally on Linux systems cmake configurations go to /usr/lib/cmake, while Find*.cmake modules go to /usr/share/cmale/Modules. I assume the installation path should be changed.