### PR TITLE
Support for custom functions in inclusive and exclusive scan

### DIFF
--- a/include/boost/compute/algorithm/detail/scan.hpp
+++ b/include/boost/compute/algorithm/detail/scan.hpp
@@ -19,20 +19,22 @@ namespace boost {
 namespace compute {
 namespace detail {
 
-template<class InputIterator, class OutputIterator>
+template<class InputIterator, class OutputIterator, class T, class BinaryOperator>
 inline OutputIterator scan(InputIterator first,
                            InputIterator last,
                            OutputIterator result,
                            bool exclusive,
+                           T init,
+                           BinaryOperator op,
                            command_queue &queue)
 {
     const device &device = queue.get_device();
 
     if(device.type() & device::cpu){
-        return scan_on_cpu(first, last, result, exclusive, queue);
+        return scan_on_cpu(first, last, result, exclusive, init, op, queue);
     }
     else {
-        return scan_on_gpu(first, last, result, exclusive, queue);
+        return scan_on_gpu(first, last, result, exclusive, init, op, queue);
     }
 }
 

--- a/include/boost/compute/algorithm/detail/scan_on_cpu.hpp
+++ b/include/boost/compute/algorithm/detail/scan_on_cpu.hpp
@@ -23,11 +23,13 @@ namespace boost {
 namespace compute {
 namespace detail {
 
-template<class InputIterator, class OutputIterator>
+template<class InputIterator, class OutputIterator, class T, class BinaryOperator>
 inline OutputIterator scan_on_cpu(InputIterator first,
                                   InputIterator last,
                                   OutputIterator result,
                                   bool exclusive,
+                                  T init,
+                                  BinaryOperator op,
                                   command_queue &queue)
 {
     if(first == last){
@@ -36,15 +38,32 @@ inline OutputIterator scan_on_cpu(InputIterator first,
 
     typedef typename
         std::iterator_traits<InputIterator>::value_type input_type;
+    typedef typename
+        std::iterator_traits<OutputIterator>::value_type output_type;
 
     const context &context = queue.get_context();
 
     // create scan kernel
     meta_kernel k("scan_on_cpu");
-    k.add_arg<ulong_>("n");
+
+    // Arguments
+    size_t n_arg = k.add_arg<ulong_>("n");
+    size_t init_arg = k.add_arg<output_type>("initial_value");
+
+    if(!exclusive){
+        k <<
+            k.decl<const ulong_>("start_idx") << " = 1;\n" <<
+            k.decl<output_type>("sum") << " = " << first[0] << ";\n" <<
+            result[0] << " = sum;\n";
+    }
+    else {
+        k <<
+            k.decl<const ulong_>("start_idx") << " = 0;\n" <<
+            k.decl<output_type>("sum") << " = initial_value;\n";
+    }
+
     k <<
-        k.decl<input_type>("sum") << " = 0;\n" <<
-        "for(ulong i = 0; i < n; i++){\n" <<
+        "for(ulong i = start_idx; i < n; i++){\n" <<
         k.decl<const input_type>("x") << " = "
             << first[k.var<ulong_>("i")] << ";\n";
 
@@ -52,7 +71,9 @@ inline OutputIterator scan_on_cpu(InputIterator first,
         k << result[k.var<ulong_>("i")] << " = sum;\n";
     }
 
-    k << "    sum = sum + x;\n";
+    k << "    sum = "
+        << op(k.var<output_type>("sum"), k.var<output_type>("x"))
+        << ";\n";
 
     if(!exclusive){
         k << result[k.var<ulong_>("i")] << " = sum;\n";
@@ -65,7 +86,8 @@ inline OutputIterator scan_on_cpu(InputIterator first,
 
     // setup kernel arguments
     size_t n = detail::iterator_range_size(first, last);
-    scan_kernel.set_arg<ulong_>(0, n);
+    scan_kernel.set_arg<ulong_>(n_arg, n);
+    scan_kernel.set_arg<output_type>(init_arg, static_cast<output_type>(init));
 
     // execute the kernel
     queue.enqueue_1d_range_kernel(scan_kernel, 0, 1, 1);

--- a/include/boost/compute/algorithm/detail/scan_on_gpu.hpp
+++ b/include/boost/compute/algorithm/detail/scan_on_gpu.hpp
@@ -24,14 +24,15 @@ namespace boost {
 namespace compute {
 namespace detail {
 
-template<class InputIterator, class OutputIterator>
+template<class InputIterator, class OutputIterator, class BinaryOperator>
 class local_scan_kernel : public meta_kernel
 {
 public:
     local_scan_kernel(InputIterator first,
                       InputIterator last,
                       OutputIterator result,
-                      bool exclusive)
+                      bool exclusive,
+                      BinaryOperator op)
         : meta_kernel("local_scan")
     {
         typedef typename std::iterator_traits<InputIterator>::value_type T;
@@ -44,6 +45,7 @@ public:
         m_scratch_arg = add_arg<T *>(memory_object::local_memory, "scratch");
         m_block_size_arg = add_arg<const cl_uint>("block_size");
         m_count_arg = add_arg<const cl_uint>("count");
+        m_init_value_arg = add_arg<const T>("init");
 
         // work-item parameters
         *this <<
@@ -59,7 +61,8 @@ public:
         // copy values from input to local memory
         if(exclusive){
             *this <<
-                "if(lid == 0){ scratch[lid] = 0; }\n" <<
+                decl<const T>("local_init") << "= (gid == 0) ? init : 0;\n" <<
+                "if(lid == 0){ scratch[lid] = local_init; }\n" <<
                 "else { scratch[lid] = " << first[expr<cl_uint>("gid-1")] << "; }\n";
         }
         else{
@@ -85,7 +88,7 @@ public:
             "    " << decl<const T>("x") << " = lid >= i ? scratch[lid-i] : 0;\n" <<
             "    barrier(CLK_LOCAL_MEM_FENCE);\n" <<
             "    if(lid >= i){\n" <<
-            "        scratch[lid] = scratch[lid] + x;\n" <<
+            "        scratch[lid] = " << op(var<T>("scratch[lid]"), var<T>("x")) << ";\n" <<
             "    }\n" <<
             "    barrier(CLK_LOCAL_MEM_FENCE);\n" <<
             "}\n";
@@ -108,7 +111,8 @@ public:
             *this <<
                 "if(lid == block_size - 1){\n" <<
                 "    block_sums[get_group_id(0)] = " <<
-                        first[expr<cl_uint>("gid")] << " + scratch[lid];\n" <<
+                       op(first[expr<cl_uint>("gid")], var<T>("scratch[lid]")) <<
+                       ";\n" <<
                 "}\n";
         }
         else {
@@ -123,13 +127,14 @@ public:
     size_t m_scratch_arg;
     size_t m_block_size_arg;
     size_t m_count_arg;
+    size_t m_init_value_arg;
 };
 
-template<class T>
+template<class T, class BinaryOperator>
 class write_scanned_output_kernel : public meta_kernel
 {
 public:
-    write_scanned_output_kernel()
+    write_scanned_output_kernel(BinaryOperator op)
         : meta_kernel("write_scanned_output")
     {
         bool checked = true;
@@ -150,7 +155,8 @@ public:
 
         // write output
         *this <<
-            "output[gid] += block_sums[block_id];\n";
+            "output[gid] = " <<
+                op(var<T>("block_sums[block_id]"), var<T>("output[gid] ")) << ";\n";
 
         if(checked){
             *this << "}\n";
@@ -179,19 +185,24 @@ inline size_t pick_scan_block_size(InputIterator first, InputIterator last)
     else                  { return 256; }
 }
 
-template<class InputIterator, class OutputIterator>
+template<class InputIterator, class OutputIterator, class T, class BinaryOperator>
 inline OutputIterator scan_impl(InputIterator first,
                                 InputIterator last,
                                 OutputIterator result,
                                 bool exclusive,
+                                T init,
+                                BinaryOperator op,
                                 command_queue &queue)
 {
     typedef typename
         std::iterator_traits<InputIterator>::value_type
-        value_type;
+        input_type;
     typedef typename
         std::iterator_traits<InputIterator>::difference_type
         difference_type;
+    typedef typename
+        std::iterator_traits<OutputIterator>::value_type
+        output_type;
 
     const context &context = queue.get_context();
     const size_t count = detail::iterator_range_size(first, last);
@@ -203,22 +214,23 @@ inline OutputIterator scan_impl(InputIterator first,
         block_count++;
     }
 
-    ::boost::compute::vector<value_type> block_sums(block_count, context);
+    ::boost::compute::vector<input_type> block_sums(block_count, context);
 
     // zero block sums
-    value_type zero;
-    std::memset(&zero, 0, sizeof(value_type));
+    input_type zero;
+    std::memset(&zero, 0, sizeof(input_type));
     ::boost::compute::fill(block_sums.begin(), block_sums.end(), zero, queue);
 
     // local scan
-    local_scan_kernel<InputIterator, OutputIterator>
-        local_scan_kernel(first, last, result, exclusive);
+    local_scan_kernel<InputIterator, OutputIterator, BinaryOperator>
+        local_scan_kernel(first, last, result, exclusive, op);
 
     ::boost::compute::kernel kernel = local_scan_kernel.compile(context);
-    kernel.set_arg(local_scan_kernel.m_scratch_arg, local_buffer<value_type>(block_size));
+    kernel.set_arg(local_scan_kernel.m_scratch_arg, local_buffer<input_type>(block_size));
     kernel.set_arg(local_scan_kernel.m_block_sums_arg, block_sums);
     kernel.set_arg(local_scan_kernel.m_block_size_arg, static_cast<cl_uint>(block_size));
     kernel.set_arg(local_scan_kernel.m_count_arg, static_cast<cl_uint>(count));
+    kernel.set_arg(local_scan_kernel.m_init_value_arg, static_cast<output_type>(init));
 
     queue.enqueue_1d_range_kernel(kernel,
                                   0,
@@ -231,13 +243,16 @@ inline OutputIterator scan_impl(InputIterator first,
                   block_sums.end(),
                   block_sums.begin(),
                   false,
+                  init,
+                  op,
                   queue
         );
     }
 
     // add block sums to each block
     if(block_count > 1){
-        write_scanned_output_kernel<value_type> write_output_kernel;
+        write_scanned_output_kernel<input_type, BinaryOperator>
+            write_output_kernel(op);
         kernel = write_output_kernel.compile(context);
         kernel.set_arg(write_output_kernel.m_output_arg, result.get_buffer());
         kernel.set_arg(write_output_kernel.m_block_sums_arg, block_sums);
@@ -252,21 +267,25 @@ inline OutputIterator scan_impl(InputIterator first,
     return result + static_cast<difference_type>(count);
 }
 
-template<class InputIterator, class OutputIterator>
+template<class InputIterator, class OutputIterator, class T, class BinaryOperator>
 inline OutputIterator dispatch_scan(InputIterator first,
                                     InputIterator last,
                                     OutputIterator result,
                                     bool exclusive,
+                                    T init,
+                                    BinaryOperator op,
                                     command_queue &queue)
 {
-    return scan_impl(first, last, result, exclusive, queue);
+    return scan_impl(first, last, result, exclusive, init, op, queue);
 }
 
-template<class InputIterator>
+template<class InputIterator, class T, class BinaryOperator>
 inline InputIterator dispatch_scan(InputIterator first,
                                    InputIterator last,
                                    InputIterator result,
                                    bool exclusive,
+                                   T init,
+                                   BinaryOperator op,
                                    command_queue &queue)
 {
     typedef typename std::iterator_traits<InputIterator>::value_type value_type;
@@ -281,26 +300,28 @@ inline InputIterator dispatch_scan(InputIterator first,
         copy(first, last, tmp.begin(), queue);
 
         // scan from temporary values
-        return scan_impl(tmp.begin(), tmp.end(), first, exclusive, queue);
+        return scan_impl(tmp.begin(), tmp.end(), first, exclusive, init, op, queue);
     }
     else {
         // scan input to output
-        return scan_impl(first, last, result, exclusive, queue);
+        return scan_impl(first, last, result, exclusive, init, op, queue);
     }
 }
 
-template<class InputIterator, class OutputIterator>
+template<class InputIterator, class OutputIterator, class T, class BinaryOperator>
 inline OutputIterator scan_on_gpu(InputIterator first,
                                   InputIterator last,
                                   OutputIterator result,
                                   bool exclusive,
+                                  T init,
+                                  BinaryOperator op,
                                   command_queue &queue)
 {
     if(first == last){
         return result;
     }
 
-    return dispatch_scan(first, last, result, exclusive, queue);
+    return dispatch_scan(first, last, result, exclusive, init, op, queue);
 }
 
 } // end detail namespace

--- a/include/boost/compute/algorithm/exclusive_scan.hpp
+++ b/include/boost/compute/algorithm/exclusive_scan.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_COMPUTE_ALGORITHM_EXCLUSIVE_SCAN_HPP
 #define BOOST_COMPUTE_ALGORITHM_EXCLUSIVE_SCAN_HPP
 
+#include <boost/compute/functional.hpp>
 #include <boost/compute/system.hpp>
 #include <boost/compute/command_queue.hpp>
 #include <boost/compute/algorithm/detail/scan.hpp>
@@ -27,13 +28,53 @@ namespace compute {
 /// \param first first element in the range to scan
 /// \param last last element in the range to scan
 /// \param result first element in the result range
+/// \param init value used to initialize the scan sequence
+/// \param binary_op associative binary operator
 /// \param queue command queue to perform the operation
 ///
 /// \return \c OutputIterator to the end of the result range
 ///
+/// The default operation is to add the elements up.
+///
 /// \snippet test/test_scan.cpp exclusive_scan_int
 ///
+/// But different associative operation can be specified as \p binary_op
+/// instead (e.g., multiplication, maximum, minimum). Also value used to
+/// initialized the scan sequence can be specified.
+///
+/// \snippet test/test_scan.cpp exclusive_scan_int_multiplies
+///
 /// \see inclusive_scan()
+template<class InputIterator, class OutputIterator, class T, class BinaryOperator>
+inline OutputIterator
+exclusive_scan(InputIterator first,
+               InputIterator last,
+               OutputIterator result,
+               T init,
+               BinaryOperator binary_op,
+               command_queue &queue = system::default_queue())
+{
+    return detail::scan(first, last, result, true, init, binary_op, queue);
+}
+
+/// \overload
+template<class InputIterator, class OutputIterator, class T>
+inline OutputIterator
+exclusive_scan(InputIterator first,
+               InputIterator last,
+               OutputIterator result,
+               T init,
+               command_queue &queue = system::default_queue())
+{
+    typedef typename
+        std::iterator_traits<OutputIterator>::value_type output_type;
+
+    return detail::scan(first, last, result, true,
+                        init, boost::compute::plus<output_type>(),
+                        queue);
+}
+
+/// \overload
 template<class InputIterator, class OutputIterator>
 inline OutputIterator
 exclusive_scan(InputIterator first,
@@ -41,7 +82,12 @@ exclusive_scan(InputIterator first,
                OutputIterator result,
                command_queue &queue = system::default_queue())
 {
-    return detail::scan(first, last, result, true, queue);
+    typedef typename
+        std::iterator_traits<OutputIterator>::value_type output_type;
+
+    return detail::scan(first, last, result, true,
+                        output_type(0), boost::compute::plus<output_type>(),
+                        queue);
 }
 
 } // end compute namespace

--- a/include/boost/compute/algorithm/inclusive_scan.hpp
+++ b/include/boost/compute/algorithm/inclusive_scan.hpp
@@ -11,6 +11,7 @@
 #ifndef BOOST_COMPUTE_ALGORITHM_INCLUSIVE_SCAN_HPP
 #define BOOST_COMPUTE_ALGORITHM_INCLUSIVE_SCAN_HPP
 
+#include <boost/compute/functional.hpp>
 #include <boost/compute/system.hpp>
 #include <boost/compute/command_queue.hpp>
 #include <boost/compute/algorithm/detail/scan.hpp>
@@ -27,13 +28,38 @@ namespace compute {
 /// \param first first element in the range to scan
 /// \param last last element in the range to scan
 /// \param result first element in the result range
+/// \param binary_op associative binary operator
 /// \param queue command queue to perform the operation
 ///
 /// \return \c OutputIterator to the end of the result range
 ///
+/// The default operation is to add the elements up.
+///
 /// \snippet test/test_scan.cpp inclusive_scan_int
 ///
+/// But different associative operation can be specified as \p binary_op
+/// instead (e.g., multiplication, maximum, minimum).
+///
+/// \snippet test/test_scan.cpp inclusive_scan_int_multiplies
+///
 /// \see exclusive_scan()
+template<class InputIterator, class OutputIterator, class BinaryOperator>
+inline OutputIterator
+inclusive_scan(InputIterator first,
+               InputIterator last,
+               OutputIterator result,
+               BinaryOperator binary_op,
+               command_queue &queue = system::default_queue())
+{
+    typedef typename
+        std::iterator_traits<OutputIterator>::value_type output_type;
+
+    return detail::scan(first, last, result, false,
+                        output_type(0), binary_op,
+                        queue);
+}
+
+/// \overload
 template<class InputIterator, class OutputIterator>
 inline OutputIterator
 inclusive_scan(InputIterator first,
@@ -41,7 +67,12 @@ inclusive_scan(InputIterator first,
                OutputIterator result,
                command_queue &queue = system::default_queue())
 {
-    return detail::scan(first, last, result, false, queue);
+    typedef typename
+        std::iterator_traits<OutputIterator>::value_type output_type;
+
+    return detail::scan(first, last, result, false,
+                        output_type(0), boost::compute::plus<output_type>(),
+                        queue);
 }
 
 } // end compute namespace

--- a/include/boost/compute/types/fundamental.hpp
+++ b/include/boost/compute/types/fundamental.hpp
@@ -53,6 +53,13 @@ public:
 
     vector_type()
     {
+
+    }
+
+    explicit vector_type(const Scalar scalar)
+    {
+        for(int i = 0; i < N; i++)
+            m_value[i] = scalar;
     }
 
     vector_type(const vector_type<Scalar, N> &other)
@@ -102,12 +109,18 @@ protected:
     BOOST_PP_REPEAT(size, BOOST_COMPUTE_VECTOR_TYPE_CTOR_ARG_FUNCTION, _)
 #define BOOST_COMPUTE_VECTOR_TYPE_ASSIGN_CTOR_ARG(z, i, _) \
     m_value[i] = BOOST_PP_CAT(arg, i);
+#define BOOST_COMPUTE_VECTOR_TYPE_ASSIGN_CTOR_SINGLE_ARG(z, i, _) \
+    m_value[i] = arg;
 
 #define BOOST_COMPUTE_DECLARE_VECTOR_TYPE_CLASS(cl_scalar, size, class_name) \
     class class_name : public vector_type<cl_scalar, size> \
     { \
     public: \
         class_name() { } \
+        explicit class_name( scalar_type arg ) \
+        { \
+            BOOST_PP_REPEAT(size, BOOST_COMPUTE_VECTOR_TYPE_ASSIGN_CTOR_SINGLE_ARG, _) \
+        } \
         class_name( \
             BOOST_PP_REPEAT(size, BOOST_COMPUTE_VECTOR_TYPE_CTOR_ARG_FUNCTION, _) \
         ) \

--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -11,6 +11,11 @@
 #define BOOST_TEST_MODULE TestScan
 #include <boost/test/unit_test.hpp>
 
+#include <numeric>
+#include <functional>
+#include <vector>
+
+#include <boost/compute/functional.hpp>
 #include <boost/compute/lambda.hpp>
 #include <boost/compute/system.hpp>
 #include <boost/compute/command_queue.hpp>
@@ -36,12 +41,12 @@ BOOST_AUTO_TEST_CASE(inclusive_scan_int)
     BOOST_CHECK_EQUAL(result.size(), size_t(5));
 
     // inclusive scan
-    bc::inclusive_scan(vector.begin(), vector.end(), result.begin());
+    bc::inclusive_scan(vector.begin(), vector.end(), result.begin(), queue);
     CHECK_RANGE_EQUAL(int, 5, result, (1, 3, 4, 6, 9));
 
     // in-place inclusive scan
     CHECK_RANGE_EQUAL(int, 5, vector, (1, 2, 1, 2, 3));
-    bc::inclusive_scan(vector.begin(), vector.end(), vector.begin());
+    bc::inclusive_scan(vector.begin(), vector.end(), vector.begin(), queue);
     CHECK_RANGE_EQUAL(int, 5, vector, (1, 3, 4, 6, 9));
 }
 
@@ -55,12 +60,12 @@ BOOST_AUTO_TEST_CASE(exclusive_scan_int)
     BOOST_CHECK_EQUAL(vector.size(), size_t(5));
 
     // exclusive scan
-    bc::exclusive_scan(vector.begin(), vector.end(), result.begin());
+    bc::exclusive_scan(vector.begin(), vector.end(), result.begin(), queue);
     CHECK_RANGE_EQUAL(int, 5, result, (0, 1, 3, 4, 6));
 
     // in-place exclusive scan
     CHECK_RANGE_EQUAL(int, 5, vector, (1, 2, 1, 2, 3));
-    bc::exclusive_scan(vector.begin(), vector.end(), vector.begin());
+    bc::exclusive_scan(vector.begin(), vector.end(), vector.begin(), queue);
     CHECK_RANGE_EQUAL(int, 5, vector, (0, 1, 3, 4, 6));
 }
 
@@ -75,11 +80,13 @@ BOOST_AUTO_TEST_CASE(inclusive_scan_int2)
                    9, 0 };
 
     boost::compute::vector<int2_> input(reinterpret_cast<int2_*>(data),
-                                        reinterpret_cast<int2_*>(data) + 5);
+                                        reinterpret_cast<int2_*>(data) + 5,
+                                        queue);
     BOOST_CHECK_EQUAL(input.size(), size_t(5));
 
-    boost::compute::vector<int2_> output(5);
-    boost::compute::inclusive_scan(input.begin(), input.end(), output.begin());
+    boost::compute::vector<int2_> output(5, context);
+    boost::compute::inclusive_scan(input.begin(), input.end(), output.begin(),
+                                   queue);
     CHECK_RANGE_EQUAL(
         int2_, 5, output,
         (int2_(1, 2), int2_(4, 6), int2_(9, 12), int2_(16, 20), int2_(25, 20))
@@ -91,7 +98,7 @@ BOOST_AUTO_TEST_CASE(inclusive_scan_counting_iterator)
     bc::vector<int> result(10, context);
     bc::inclusive_scan(bc::make_counting_iterator(1),
                        bc::make_counting_iterator(11),
-                       result.begin());
+                       result.begin(), queue);
     CHECK_RANGE_EQUAL(int, 10, result, (1, 3, 6, 10, 15, 21, 28, 36, 45, 55));
 }
 
@@ -100,7 +107,7 @@ BOOST_AUTO_TEST_CASE(exclusive_scan_counting_iterator)
     bc::vector<int> result(10, context);
     bc::exclusive_scan(bc::make_counting_iterator(1),
                        bc::make_counting_iterator(11),
-                       result.begin());
+                       result.begin(), queue);
     CHECK_RANGE_EQUAL(int, 10, result, (0, 1, 3, 6, 10, 15, 21, 28, 36, 45));
 }
 
@@ -111,7 +118,7 @@ BOOST_AUTO_TEST_CASE(inclusive_scan_transform_iterator)
     bc::vector<float> output(5, context);
 
     // normal inclusive scan of the input
-    bc::inclusive_scan(input.begin(), input.end(), output.begin());
+    bc::inclusive_scan(input.begin(), input.end(), output.begin(), queue);
     bc::system::finish();
     BOOST_CHECK_CLOSE(float(output[0]), 1.0f, 1e-4f);
     BOOST_CHECK_CLOSE(float(output[1]), 3.0f, 1e-4f);
@@ -124,7 +131,7 @@ BOOST_AUTO_TEST_CASE(inclusive_scan_transform_iterator)
 
     bc::inclusive_scan(bc::make_transform_iterator(input.begin(), pown(_1, 2)),
                        bc::make_transform_iterator(input.end(), pown(_1, 2)),
-                       output.begin());
+                       output.begin(), queue);
     bc::system::finish();
     BOOST_CHECK_CLOSE(float(output[0]), 1.0f, 1e-4f);
     BOOST_CHECK_CLOSE(float(output[1]), 5.0f, 1e-4f);
@@ -173,6 +180,167 @@ boost::compute::exclusive_scan(
 //! [exclusive_scan_int]
 
     CHECK_RANGE_EQUAL(int, 4, output, (0, 1, 3, 6));
+}
+
+BOOST_AUTO_TEST_CASE(inclusive_scan_int_multiplies)
+{
+//! [inclusive_scan_int_multiplies]
+// setup input
+int data[] = { 1, 2, 1, 2, 3 };
+boost::compute::vector<int> input(data, data + 5, queue);
+
+// setup output
+boost::compute::vector<int> output(5, context);
+
+// inclusive scan with multiplication
+boost::compute::inclusive_scan(
+    input.begin(), input.end(), output.begin(),
+    boost::compute::multiplies<int>(), queue
+);
+
+// output = [1, 2, 2, 4, 12]
+//! [inclusive_scan_int_multiplies]
+
+    BOOST_CHECK_EQUAL(input.size(), size_t(5));
+    BOOST_CHECK_EQUAL(output.size(), size_t(5));
+
+    CHECK_RANGE_EQUAL(int, 5, output, (1, 2, 2, 4, 12));
+
+    // in-place inclusive scan
+    CHECK_RANGE_EQUAL(int, 5, input, (1, 2, 1, 2, 3));
+    boost::compute::inclusive_scan(input.begin(), input.end(), input.begin(),
+                                   boost::compute::multiplies<int>(), queue);
+    CHECK_RANGE_EQUAL(int, 5, input, (1, 2, 2, 4, 12));
+}
+
+BOOST_AUTO_TEST_CASE(exclusive_scan_int_multiplies)
+{
+//! [exclusive_scan_int_multiplies]
+// setup input
+int data[] = { 1, 2, 1, 2, 3 };
+boost::compute::vector<int> input(data, data + 5, queue);
+
+// setup output
+boost::compute::vector<int> output(5, context);
+
+// exclusive_scan with multiplication
+// initial value equals 10
+boost::compute::exclusive_scan(
+    input.begin(), input.end(), output.begin(),
+    int(10), boost::compute::multiplies<int>(), queue
+);
+
+// output = [10, 10, 20, 20, 40]
+//! [exclusive_scan_int_multiplies]
+
+    BOOST_CHECK_EQUAL(input.size(), size_t(5));
+    BOOST_CHECK_EQUAL(output.size(), size_t(5));
+
+    CHECK_RANGE_EQUAL(int, 5, output, (10, 10, 20, 20, 40));
+
+    // in-place exclusive scan
+    CHECK_RANGE_EQUAL(int, 5, input, (1, 2, 1, 2, 3));
+    bc::exclusive_scan(input.begin(), input.end(), input.begin(),
+                       int(10), bc::multiplies<int>(), queue);
+    CHECK_RANGE_EQUAL(int, 5, input, (10, 10, 20, 20, 40));
+}
+
+BOOST_AUTO_TEST_CASE(inclusive_scan_int_multiplies_long_vector)
+{
+    size_t size = 1000;
+    bc::vector<int> device_vector(size, int(2), queue);
+    BOOST_CHECK_EQUAL(device_vector.size(), size);
+    bc::inclusive_scan(device_vector.begin(), device_vector.end(),
+                       device_vector.begin(), bc::multiplies<int>(), queue);
+
+    std::vector<int> host_vector(size, 2);
+    BOOST_CHECK_EQUAL(host_vector.size(), size);
+    bc::copy(device_vector.begin(), device_vector.end(),
+             host_vector.begin(), queue);
+
+    std::vector<int> test(size, 2);
+    BOOST_CHECK_EQUAL(test.size(), size);
+    std::partial_sum(test.begin(), test.end(),
+                     test.begin(), std::multiplies<int>());
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(host_vector.begin(), host_vector.end(),
+                                  test.begin(), test.end());
+}
+
+BOOST_AUTO_TEST_CASE(exclusive_scan_int_multiplies_long_vector)
+{
+    size_t size = 1000;
+    bc::vector<int> device_vector(size, int(2), queue);
+    BOOST_CHECK_EQUAL(device_vector.size(), size);
+    bc::exclusive_scan(device_vector.begin(), device_vector.end(),
+                       device_vector.begin(), int(10), bc::multiplies<int>(),
+                       queue);
+
+    std::vector<int> host_vector(size, 2);
+    BOOST_CHECK_EQUAL(host_vector.size(), size);
+    bc::copy(device_vector.begin(), device_vector.end(),
+             host_vector.begin(), queue);
+
+    std::vector<int> test(size, 2);
+    BOOST_CHECK_EQUAL(test.size(), size);
+    test[0] = 10;
+    std::partial_sum(test.begin(), test.end(),
+                     test.begin(), std::multiplies<int>());
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(host_vector.begin(), host_vector.end(),
+                                  test.begin(), test.end());
+}
+
+BOOST_AUTO_TEST_CASE(inclusive_scan_int_custom_function)
+{
+    BOOST_COMPUTE_FUNCTION(int, multi, (int x, int y),
+    {
+        return x * y * 2;
+    });
+
+    int data[] = { 1, 2, 1, 2, 3 };
+    bc::vector<int> vector(data, data + 5, queue);
+    BOOST_CHECK_EQUAL(vector.size(), size_t(5));
+
+    bc::vector<int> result(5, context);
+    BOOST_CHECK_EQUAL(result.size(), size_t(5));
+
+    // inclusive scan
+    bc::inclusive_scan(vector.begin(), vector.end(), result.begin(),
+                       multi, queue);
+    CHECK_RANGE_EQUAL(int, 5, result, (1, 4, 8, 32, 192));
+
+    // in-place inclusive scan
+    CHECK_RANGE_EQUAL(int, 5, vector, (1, 2, 1, 2, 3));
+    bc::inclusive_scan(vector.begin(), vector.end(), vector.begin(),
+                       multi, queue);
+    CHECK_RANGE_EQUAL(int, 5, vector, (1, 4, 8, 32, 192));
+}
+
+BOOST_AUTO_TEST_CASE(exclusive_scan_int_custom_function)
+{
+    BOOST_COMPUTE_FUNCTION(int, multi, (int x, int y),
+    {
+        return x * y * 2;
+    });
+
+    int data[] = { 1, 2, 1, 2, 3 };
+    bc::vector<int> vector(data, data + 5, queue);
+    BOOST_CHECK_EQUAL(vector.size(), size_t(5));
+
+    bc::vector<int> result(5, context);
+    BOOST_CHECK_EQUAL(result.size(), size_t(5));
+
+    // exclusive_scan
+    bc::exclusive_scan(vector.begin(), vector.end(), result.begin(),
+                       int(1), multi, queue);
+    CHECK_RANGE_EQUAL(int, 5, result, (1, 2, 8, 16, 64));
+
+    // in-place exclusive scan
+    CHECK_RANGE_EQUAL(int, 5, vector, (1, 2, 1, 2, 3));
+    bc::exclusive_scan(vector.begin(), vector.end(), vector.begin(),
+                       int(1), multi, queue);
+    CHECK_RANGE_EQUAL(int, 5, vector, (1, 2, 8, 16, 64));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_types.cpp
+++ b/test/test_types.cpp
@@ -25,6 +25,15 @@ BOOST_AUTO_TEST_CASE(vector_ctor)
     BOOST_CHECK_EQUAL(i4[1], 2);
     BOOST_CHECK_EQUAL(i4[2], 3);
     BOOST_CHECK_EQUAL(i4[3], 4);
+
+    i4 = boost::compute::int4_(1);
+    BOOST_CHECK(i4 == boost::compute::int4_(1, 1, 1, 1));
+    BOOST_CHECK(i4 == (boost::compute::vector_type<int, size_t(4)>(1)));
+    BOOST_CHECK_EQUAL(i4, boost::compute::int4_(1, 1, 1, 1));
+    BOOST_CHECK_EQUAL(i4[0], 1);
+    BOOST_CHECK_EQUAL(i4[1], 1);
+    BOOST_CHECK_EQUAL(i4[2], 1);
+    BOOST_CHECK_EQUAL(i4[3], 1);
 }
 
 BOOST_AUTO_TEST_CASE(vector_string)


### PR DESCRIPTION
This addresses issue https://github.com/boostorg/compute/issues/374.

Now in inclusive and exclusive scan custom associative binary operator can be used instead of default addition operator. For exclusive scan also initial value can be set. 

I've updated docs for inclusive and exclusive scan.

I've also added single argument constructor for vector types (``int2(1) == int2(1,1) == vector_type<int,2>(1)``, ``int4(4) = int4(4, 4, 4, 4)  == vector_type<int,4>(1)``, etc.).