### PR TITLE
Added CUDADIR to scaning paths

### DIFF
--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -59,11 +59,11 @@ ELSE (APPLE)
 	# The AMD SDK currently does not place its headers
 	# in /usr/include, therefore also search relative
 	# to the library
-	FIND_PATH(OPENCL_INCLUDE_DIRS CL/cl.h PATHS ${_OPENCL_INC_CAND} "/usr/local/cuda/include" "/opt/cuda/include" "/opt/AMDAPP/include" ENV OpenCL_INCPATH)
-	FIND_PATH(_OPENCL_CPP_INCLUDE_DIRS CL/cl.hpp PATHS ${_OPENCL_INC_CAND} "/usr/local/cuda/include" "/opt/cuda/include" "/opt/AMDAPP/include" ENV OpenCL_INCPATH)
+	FIND_PATH(OPENCL_INCLUDE_DIRS CL/cl.h PATHS "$ENV{CUDADIR}/include" ${_OPENCL_INC_CAND} "/usr/local/cuda/include" "/opt/cuda/include" "/opt/AMDAPP/include" ENV OpenCL_INCPATH)
+	FIND_PATH(_OPENCL_CPP_INCLUDE_DIRS CL/cl.hpp PATHS "$ENV{CUDADIR}/include" ${_OPENCL_INC_CAND} "/usr/local/cuda/include" "/opt/cuda/include" "/opt/AMDAPP/include" ENV OpenCL_INCPATH)
 	# for Mali GPUs, libmali must be linked 
 	FIND_LIBRARY(OPENCL_LIBRARIES_MALI mali
-		PATHS ENV LD_LIBRARY_PATH ENV OpenCL_LIBPATH "/usr/lib64"
+		PATHS ENV LD_LIBRARY_PATH ENV OpenCL_LIBPATH "/usr/lib64" "$ENV{CUDADIR}/lib64"
 	)
 	IF (OPENCL_LIBRARIES_MALI)
 		SET(OPENCL_LIBRARIES ${OPENCL_LIBRARIES} ${OPENCL_LIBRARIES_MALI})


### PR DESCRIPTION
Hello

As CUDA is not always installed at /usr/lib64/nvidia it is reasonable to scan CUDADIR environment variable

Regards,
Tomek