### PR TITLE
Add missing queue and context parameters in tests

### DIFF
--- a/test/test_accumulate.cpp
+++ b/test/test_accumulate.cpp
@@ -45,22 +45,25 @@ BOOST_AUTO_TEST_CASE(sum_int)
 BOOST_AUTO_TEST_CASE(product_int)
 {
     int data[] = { 2, 4, 6, 8 };
-    boost::compute::vector<int> vector(data, data + 4);
+    boost::compute::vector<int> vector(data, data + 4, queue);
     BOOST_CHECK_EQUAL(
         boost::compute::accumulate(
-            vector.begin(), vector.end(), 1, boost::compute::multiplies<int>()),
+            vector.begin(), vector.end(), 1, boost::compute::multiplies<int>(),
+            queue),
         384
     );
 
     BOOST_CHECK_EQUAL(
         boost::compute::accumulate(
-            vector.begin(), vector.end(), -1, boost::compute::multiplies<int>()),
+            vector.begin(), vector.end(), -1, boost::compute::multiplies<int>(),
+            queue),
         -384
     );
 
     BOOST_CHECK_EQUAL(
         boost::compute::accumulate(
-            vector.begin(), vector.end(), 2, boost::compute::multiplies<int>()),
+            vector.begin(), vector.end(), 2, boost::compute::multiplies<int>(),
+            queue),
         768
     );
 }

--- a/test/test_any_all_none_of.cpp
+++ b/test/test_any_all_none_of.cpp
@@ -28,7 +28,7 @@ namespace compute = boost::compute;
 BOOST_AUTO_TEST_CASE(any_all_none_of)
 {
     int data[] = { 1, 2, 3, 4, 5, 6 };
-    bc::vector<int> v(data, data + 6);
+    bc::vector<int> v(data, data + 6, queue);
 
     using ::boost::compute::_1;
 
@@ -53,15 +53,22 @@ BOOST_AUTO_TEST_CASE(any_nan_inf)
     float inf = std::numeric_limits<float>::infinity();
 
     float data[] = { 1.2f, 2.3f, nan, nan, 3.4f, inf, 4.5f, inf };
-    compute::vector<float> vector(data, data + 8);
+    compute::vector<float> vector(data, data + 8, queue);
 
-    BOOST_CHECK(compute::any_of(vector.begin(), vector.end(), isinf(_1) || isnan(_1)) == true);
-    BOOST_CHECK(compute::any_of(vector.begin(), vector.end(), isfinite(_1)) == true);
-    BOOST_CHECK(compute::all_of(vector.begin(), vector.end(), isfinite(_1)) == false);
-    BOOST_CHECK(compute::all_of(vector.begin(), vector.begin() + 2, isfinite(_1)) == true);
-    BOOST_CHECK(compute::all_of(vector.begin() + 2, vector.begin() + 4, isnan(_1)) == true);
-    BOOST_CHECK(compute::none_of(vector.begin(), vector.end(), isinf(_1)) == false);
-    BOOST_CHECK(compute::none_of(vector.begin(), vector.begin() + 4, isinf(_1)) == true);
+    BOOST_CHECK(compute::any_of(vector.begin(), vector.end(),
+                                isinf(_1) || isnan(_1), queue) == true);
+    BOOST_CHECK(compute::any_of(vector.begin(), vector.end(),
+                                isfinite(_1), queue) == true);
+    BOOST_CHECK(compute::all_of(vector.begin(), vector.end(),
+                                isfinite(_1), queue) == false);
+    BOOST_CHECK(compute::all_of(vector.begin(), vector.begin() + 2,
+                                isfinite(_1), queue) == true);
+    BOOST_CHECK(compute::all_of(vector.begin() + 2, vector.begin() + 4,
+                                isnan(_1), queue) == true);
+    BOOST_CHECK(compute::none_of(vector.begin(), vector.end(),
+                                 isinf(_1), queue) == false);
+    BOOST_CHECK(compute::none_of(vector.begin(), vector.begin() + 4,
+                                 isinf(_1), queue) == true);
 }
 
 BOOST_AUTO_TEST_CASE(any_of_doctest)

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -29,10 +29,10 @@ BOOST_AUTO_TEST_CASE(concept_check)
 
 BOOST_AUTO_TEST_CASE(size)
 {
-    boost::compute::array<int, 0> empty_array;
+    boost::compute::array<int, 0> empty_array(context);
     BOOST_CHECK_EQUAL(empty_array.size(), size_t(0));
 
-    boost::compute::array<int, 10> array10;
+    boost::compute::array<int, 10> array10(context);
     BOOST_CHECK_EQUAL(array10.size(), size_t(10));
 }
 

--- a/test/test_binary_search.cpp
+++ b/test/test_binary_search.cpp
@@ -24,44 +24,44 @@
 BOOST_AUTO_TEST_CASE(binary_search_int)
 {
     int data[] = { 1, 2, 2, 2, 4, 4, 5, 7 };
-    boost::compute::vector<int> vector(data, data + 8);
+    boost::compute::vector<int> vector(data, data + 8, queue);
 
-    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(0)) == false);
-    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(1)) == true);
-    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(2)) == true);
-    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(3)) == false);
-    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(4)) == true);
-    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(5)) == true);
-    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(6)) == false);
-    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(7)) == true);
-    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(8)) == false);
+    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(0), queue) == false);
+    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(1), queue) == true);
+    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(2), queue) == true);
+    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(3), queue) == false);
+    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(4), queue) == true);
+    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(5), queue) == true);
+    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(6), queue) == false);
+    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(7), queue) == true);
+    BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(8), queue) == false);
 }
 
 BOOST_AUTO_TEST_CASE(range_bounds_int)
 {
     int data[] = { 1, 2, 2, 2, 3, 3, 4, 5 };
-    boost::compute::vector<int> vector(data, data + 8);
+    boost::compute::vector<int> vector(data, data + 8, queue);
 
-    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(0)) == vector.begin());
-    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(0)) == vector.begin());
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(0), queue) == vector.begin());
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(0), queue) == vector.begin());
 
-    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(1)) == vector.begin());
-    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(1)) == vector.begin() + 1);
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(1), queue) == vector.begin());
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(1), queue) == vector.begin() + 1);
 
-    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(2)) == vector.begin() + 1);
-    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(2)) == vector.begin() + 4);
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(2), queue) == vector.begin() + 1);
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(2), queue) == vector.begin() + 4);
 
-    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(3)) == vector.begin() + 4);
-    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(3)) == vector.begin() + 6);
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(3), queue) == vector.begin() + 4);
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(3), queue) == vector.begin() + 6);
 
-    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(4)) == vector.begin() + 6);
-    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(4)) == vector.begin() + 7);
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(4), queue) == vector.begin() + 6);
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(4), queue) == vector.begin() + 7);
 
-    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(5)) == vector.begin() + 7);
-    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(5)) == vector.end());
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(5), queue) == vector.begin() + 7);
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(5), queue) == vector.end());
 
-    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(6)) == vector.end());
-    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(6)) == vector.end());
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(6), queue) == vector.end());
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(6), queue) == vector.end());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_closure.cpp
+++ b/test/test_closure.cpp
@@ -179,8 +179,10 @@ BOOST_AUTO_TEST_CASE(triangle_area)
     triangle_vertices.push_back(float4_(1, 0, 0, 1), queue);
     triangle_vertices.push_back(float4_(2, 0, 0, 1), queue);
 
-    triangle_indices.push_back(uint4_(0, 1, 2, 0));
-    triangle_indices.push_back(uint4_(2, 1, 3, 0));
+    triangle_indices.push_back(uint4_(0, 1, 2, 0), queue);
+    triangle_indices.push_back(uint4_(2, 1, 3, 0), queue);
+
+    queue.finish();
 
     BOOST_COMPUTE_CLOSURE(float, triangle_area, (const uint4_ i), (triangle_vertices),
     {

--- a/test/test_complex.cpp
+++ b/test/test_complex.cpp
@@ -29,13 +29,14 @@ BOOST_AUTO_TEST_CASE(copy_complex_vector)
     host_vector.push_back(std::complex<float>(1.0f, -2.0f));
     host_vector.push_back(std::complex<float>(-2.0f, -1.0f));
 
-    boost::compute::vector<std::complex<float> > device_vector;
+    boost::compute::vector<std::complex<float> > device_vector(context);
     boost::compute::copy(
         host_vector.begin(),
         host_vector.end(),
-        device_vector.begin()
+        device_vector.begin(),
+        queue
     );
-    boost::compute::system::finish();
+    queue.finish();
     BOOST_CHECK_EQUAL(std::complex<float>(device_vector[0]), std::complex<float>(1.0f, 2.0f));
     BOOST_CHECK_EQUAL(std::complex<float>(device_vector[1]), std::complex<float>(-2.0f, 1.0f));
     BOOST_CHECK_EQUAL(std::complex<float>(device_vector[2]), std::complex<float>(1.0f, -2.0f));
@@ -45,13 +46,14 @@ BOOST_AUTO_TEST_CASE(copy_complex_vector)
 // fills a vector of complex<float>'s on the device with a constant value
 BOOST_AUTO_TEST_CASE(fill_complex_vector)
 {
-    boost::compute::vector<std::complex<float> > vector(6);
+    boost::compute::vector<std::complex<float> > vector(6, context);
     boost::compute::fill(
         vector.begin(),
         vector.end(),
-        std::complex<float>(2.0f, 5.0f)
+        std::complex<float>(2.0f, 5.0f),
+        queue
     );
-    boost::compute::system::finish();
+    queue.finish();
     BOOST_CHECK_EQUAL(std::complex<float>(vector[0]), std::complex<float>(2.0f, 5.0f));
     BOOST_CHECK_EQUAL(std::complex<float>(vector[1]), std::complex<float>(2.0f, 5.0f));
     BOOST_CHECK_EQUAL(std::complex<float>(vector[2]), std::complex<float>(2.0f, 5.0f));
@@ -64,36 +66,38 @@ BOOST_AUTO_TEST_CASE(fill_complex_vector)
 // transform with the real() and imag() functions
 BOOST_AUTO_TEST_CASE(extract_real_and_imag)
 {
-    boost::compute::vector<std::complex<float> > vector;
-    vector.push_back(std::complex<float>(1.0f, 3.0f));
-    vector.push_back(std::complex<float>(3.0f, 1.0f));
-    vector.push_back(std::complex<float>(5.0f, -1.0f));
-    vector.push_back(std::complex<float>(7.0f, -3.0f));
-    vector.push_back(std::complex<float>(9.0f, -5.0f));
+    boost::compute::vector<std::complex<float> > vector(context);
+    vector.push_back(std::complex<float>(1.0f, 3.0f), queue);
+    vector.push_back(std::complex<float>(3.0f, 1.0f), queue);
+    vector.push_back(std::complex<float>(5.0f, -1.0f), queue);
+    vector.push_back(std::complex<float>(7.0f, -3.0f), queue);
+    vector.push_back(std::complex<float>(9.0f, -5.0f), queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(5));
 
-    boost::compute::vector<float> reals(5);
+    boost::compute::vector<float> reals(5, context);
     boost::compute::transform(
         vector.begin(),
         vector.end(),
         reals.begin(),
-        boost::compute::real<float>()
+        boost::compute::real<float>(),
+        queue
     );
-    boost::compute::system::finish();
+    queue.finish();
     BOOST_CHECK_EQUAL(float(reals[0]), float(1.0f));
     BOOST_CHECK_EQUAL(float(reals[1]), float(3.0f));
     BOOST_CHECK_EQUAL(float(reals[2]), float(5.0f));
     BOOST_CHECK_EQUAL(float(reals[3]), float(7.0f));
     BOOST_CHECK_EQUAL(float(reals[4]), float(9.0f));
 
-    boost::compute::vector<float> imags(5);
+    boost::compute::vector<float> imags(5, context);
     boost::compute::transform(
         vector.begin(),
         vector.end(),
         imags.begin(),
-        boost::compute::imag<float>()
+        boost::compute::imag<float>(),
+        queue
     );
-    boost::compute::system::finish();
+    queue.finish();
     BOOST_CHECK_EQUAL(float(imags[0]), float(3.0f));
     BOOST_CHECK_EQUAL(float(imags[1]), float(1.0f));
     BOOST_CHECK_EQUAL(float(imags[2]), float(-1.0f));
@@ -104,22 +108,23 @@ BOOST_AUTO_TEST_CASE(extract_real_and_imag)
 // compute the complex conjugate of a vector of complex<float>'s
 BOOST_AUTO_TEST_CASE(complex_conj)
 {
-    boost::compute::vector<std::complex<float> > input;
-    input.push_back(std::complex<float>(1.0f, 3.0f));
-    input.push_back(std::complex<float>(3.0f, 1.0f));
-    input.push_back(std::complex<float>(5.0f, -1.0f));
-    input.push_back(std::complex<float>(7.0f, -3.0f));
-    input.push_back(std::complex<float>(9.0f, -5.0f));
+    boost::compute::vector<std::complex<float> > input(context);
+    input.push_back(std::complex<float>(1.0f, 3.0f), queue);
+    input.push_back(std::complex<float>(3.0f, 1.0f), queue);
+    input.push_back(std::complex<float>(5.0f, -1.0f), queue);
+    input.push_back(std::complex<float>(7.0f, -3.0f), queue);
+    input.push_back(std::complex<float>(9.0f, -5.0f), queue);
     BOOST_CHECK_EQUAL(input.size(), size_t(5));
 
-    boost::compute::vector<std::complex<float> > output(5);
+    boost::compute::vector<std::complex<float> > output(5, context);
     boost::compute::transform(
         input.begin(),
         input.end(),
         output.begin(),
-        boost::compute::conj<float>()
+        boost::compute::conj<float>(),
+        queue
     );
-    boost::compute::system::finish();
+    queue.finish();
     BOOST_CHECK_EQUAL(std::complex<float>(output[0]), std::complex<float>(1.0f, -3.0f));
     BOOST_CHECK_EQUAL(std::complex<float>(output[1]), std::complex<float>(3.0f, -1.0f));
     BOOST_CHECK_EQUAL(std::complex<float>(output[2]), std::complex<float>(5.0f, 1.0f));
@@ -141,12 +146,12 @@ BOOST_AUTO_TEST_CASE(complex_type_name)
 BOOST_AUTO_TEST_CASE(transform_multiply)
 {
     boost::compute::vector<std::complex<float> > x(context);
-    x.push_back(std::complex<float>(1.0f, 2.0f));
-    x.push_back(std::complex<float>(-2.0f, 5.0f));
+    x.push_back(std::complex<float>(1.0f, 2.0f), queue);
+    x.push_back(std::complex<float>(-2.0f, 5.0f), queue);
 
     boost::compute::vector<std::complex<float> > y(context);
-    y.push_back(std::complex<float>(3.0f, 4.0f));
-    y.push_back(std::complex<float>(2.0f, -1.0f));
+    y.push_back(std::complex<float>(3.0f, 4.0f), queue);
+    y.push_back(std::complex<float>(2.0f, -1.0f), queue);
 
     boost::compute::vector<std::complex<float> > z(2, context);
 

--- a/test/test_context.cpp
+++ b/test/test_context.cpp
@@ -14,11 +14,13 @@
 #include <boost/compute/system.hpp>
 #include <boost/compute/context.hpp>
 
+#include "check_macros.hpp"
+#include "context_setup.hpp"
+
 namespace compute = boost::compute;
 
 BOOST_AUTO_TEST_CASE(construct_from_cl_context)
 {
-    boost::compute::device device = boost::compute::system::default_device();
     cl_device_id id = device.id();
 
     // create cl_context
@@ -61,3 +63,5 @@ BOOST_AUTO_TEST_CASE(multiple_devices)
         BOOST_CHECK_EQUAL(ctx.get_devices().size(), platform.device_count());
     }
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_copy_if.cpp
+++ b/test/test_copy_if.cpp
@@ -24,21 +24,23 @@ namespace compute = boost::compute;
 BOOST_AUTO_TEST_CASE(copy_if_int)
 {
     int data[] = { 1, 6, 3, 5, 8, 2, 4 };
-    bc::vector<int> input(data, data + 7);
+    bc::vector<int> input(data, data + 7, queue);
 
-    bc::vector<int> output(input.size());
-    bc::fill(output.begin(), output.end(), -1);
+    bc::vector<int> output(input.size(), context);
+    bc::fill(output.begin(), output.end(), -1, queue);
 
     using ::boost::compute::_1;
 
     bc::vector<int>::iterator iter =
-        bc::copy_if(input.begin(), input.end(), output.begin(), _1 < 5);
+        bc::copy_if(input.begin(), input.end(),
+                    output.begin(), _1 < 5, queue);
     BOOST_VERIFY(iter == output.begin() + 4);
     CHECK_RANGE_EQUAL(int, 7, output, (1, 3, 2, 4, -1, -1, -1));
 
-    bc::fill(output.begin(), output.end(), 42);
+    bc::fill(output.begin(), output.end(), 42, queue);
     iter =
-        bc::copy_if(input.begin(), input.end(), output.begin(), _1 * 2 >= 10);
+        bc::copy_if(input.begin(), input.end(),
+                    output.begin(), _1 * 2 >= 10, queue);
     BOOST_VERIFY(iter == output.begin() + 3);
     CHECK_RANGE_EQUAL(int, 7, output, (6, 5, 8, 42, 42, 42, 42));
 }
@@ -46,19 +48,21 @@ BOOST_AUTO_TEST_CASE(copy_if_int)
 BOOST_AUTO_TEST_CASE(copy_if_odd)
 {
     int data[] = { 1, 2, 3, 4, 5, 1, 2, 3, 4, 5 };
-    bc::vector<int> input(data, data + 10);
+    bc::vector<int> input(data, data + 10, queue);
 
     using ::boost::compute::_1;
 
-    bc::vector<int> odds(input.size());
+    bc::vector<int> odds(input.size(), context);
     bc::vector<int>::iterator odds_end =
-        bc::copy_if(input.begin(), input.end(), odds.begin(), _1 % 2 == 1);
+        bc::copy_if(input.begin(), input.end(),
+                    odds.begin(), _1 % 2 == 1, queue);
     BOOST_CHECK(odds_end == odds.begin() + 6);
     CHECK_RANGE_EQUAL(int, 6, odds, (1, 3, 5, 1, 3, 5));
 
-    bc::vector<int> evens(input.size());
+    bc::vector<int> evens(input.size(), context);
     bc::vector<int>::iterator evens_end =
-        bc::copy_if(input.begin(), input.end(), evens.begin(), _1 % 2 == 0);
+        bc::copy_if(input.begin(), input.end(),
+                    evens.begin(), _1 % 2 == 0, queue);
     BOOST_CHECK(evens_end == evens.begin() + 4);
     CHECK_RANGE_EQUAL(int, 4, evens, (2, 4, 2, 4));
 }
@@ -70,11 +74,13 @@ BOOST_AUTO_TEST_CASE(clip_points_below_plane)
                      -2.0f, -3.0f, 4.0f, 0.0f,
                      4.0f, -3.0f, 2.0f, 0.0f };
     bc::vector<bc::float4_> points(reinterpret_cast<bc::float4_ *>(data),
-                                   reinterpret_cast<bc::float4_ *>(data) + 4);
+                                   reinterpret_cast<bc::float4_ *>(data) + 4,
+                                   queue);
 
     // create output vector filled with (0, 0, 0, 0)
-    bc::vector<bc::float4_> output(points.size());
-    bc::fill(output.begin(), output.end(), bc::float4_(0.0f, 0.0f, 0.0f, 0.0f));
+    bc::vector<bc::float4_> output(points.size(), context);
+    bc::fill(output.begin(), output.end(),
+             bc::float4_(0.0f, 0.0f, 0.0f, 0.0f), queue);
 
     // define the plane (at origin, +X normal)
     bc::float4_ plane_origin(0.0f, 0.0f, 0.0f, 0.0f);
@@ -87,23 +93,25 @@ BOOST_AUTO_TEST_CASE(clip_points_below_plane)
         bc::copy_if(points.begin(),
                     points.end(),
                     output.begin(),
-                    dot(_1 - plane_origin, plane_normal) > 0.0f);
+                    dot(_1 - plane_origin, plane_normal) > 0.0f,
+                    queue);
     BOOST_CHECK(iter == output.begin() + 2);
 }
 
 BOOST_AUTO_TEST_CASE(copy_index_if_int)
 {
     int data[] = { 1, 6, 3, 5, 8, 2, 4 };
-    compute::vector<int> input(data, data + 7);
+    compute::vector<int> input(data, data + 7, queue);
 
-    compute::vector<int> output(input.size());
-    compute::fill(output.begin(), output.end(), -1);
+    compute::vector<int> output(input.size(), context);
+    compute::fill(output.begin(), output.end(), -1, queue);
 
     using ::boost::compute::_1;
     using ::boost::compute::detail::copy_index_if;
 
     compute::vector<int>::iterator iter =
-        copy_index_if(input.begin(), input.end(), output.begin(), _1 < 5);
+        copy_index_if(input.begin(), input.end(), output.begin(),
+                      _1 < 5, queue);
     BOOST_VERIFY(iter == output.begin() + 4);
     CHECK_RANGE_EQUAL(int, 7, output, (0, 2, 5, 6, -1, -1, -1));
 }

--- a/test/test_count.cpp
+++ b/test/test_count.cpp
@@ -32,13 +32,13 @@ namespace compute = boost::compute;
 BOOST_AUTO_TEST_CASE(count_int)
 {
     int data[] = { 1, 2, 1, 2, 3 };
-    bc::vector<int> vector(data, data + 5);
-    BOOST_CHECK_EQUAL(bc::count(vector.begin(), vector.end(), 1), size_t(2));
-    BOOST_CHECK_EQUAL(bc::count(vector.begin(), vector.end(), 2), size_t(2));
-    BOOST_CHECK_EQUAL(bc::count(vector.begin(), vector.end(), 3), size_t(1));
-    BOOST_CHECK_EQUAL(bc::count(vector.begin() + 1, vector.end(), 1), size_t(1));
-    BOOST_CHECK_EQUAL(bc::count(vector.begin() + 1, vector.end() - 1, 3), size_t(0));
-    BOOST_CHECK_EQUAL(bc::count(vector.begin() + 1, vector.end() - 1, 2), size_t(2));
+    bc::vector<int> vector(data, data + 5, queue);
+    BOOST_CHECK_EQUAL(bc::count(vector.begin(), vector.end(), 1, queue), size_t(2));
+    BOOST_CHECK_EQUAL(bc::count(vector.begin(), vector.end(), 2, queue), size_t(2));
+    BOOST_CHECK_EQUAL(bc::count(vector.begin(), vector.end(), 3, queue), size_t(1));
+    BOOST_CHECK_EQUAL(bc::count(vector.begin() + 1, vector.end(), 1, queue), size_t(1));
+    BOOST_CHECK_EQUAL(bc::count(vector.begin() + 1, vector.end() - 1, 3, queue), size_t(0));
+    BOOST_CHECK_EQUAL(bc::count(vector.begin() + 1, vector.end() - 1, 2, queue), size_t(2));
 }
 
 BOOST_AUTO_TEST_CASE(count_constant_int_range)
@@ -63,10 +63,10 @@ BOOST_AUTO_TEST_CASE(count_constant_int_range)
 BOOST_AUTO_TEST_CASE(count_if_greater_than_two)
 {
     float data[] = { 1.0f, 2.5f, -1.0f, 3.0f, 5.0f, -8.0f };
-    bc::vector<float> vector(data, data + 5);
+    bc::vector<float> vector(data, data + 5, queue);
 
     BOOST_CHECK_EQUAL(
-        bc::count_if(vector.begin(), vector.end(), bc::_1 > 2.0f),
+        bc::count_if(vector.begin(), vector.end(), bc::_1 > 2.0f, queue),
         size_t(3)
     );
 }
@@ -80,35 +80,36 @@ BOOST_AUTO_TEST_CASE(count_int4)
                    4, 5, 6, 7,
                    0, 3, 2, 2 };
     bc::vector<bc::int4_> vector(reinterpret_cast<bc::int4_ *>(data),
-                                 reinterpret_cast<bc::int4_ *>(data) + 6);
+                                 reinterpret_cast<bc::int4_ *>(data) + 6,
+                                 queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(6));
 
     BOOST_CHECK_EQUAL(
-        bc::count(vector.begin(), vector.end(), bc::int4_(1, 2, 3, 4)),
+        bc::count(vector.begin(), vector.end(), bc::int4_(1, 2, 3, 4), queue),
         size_t(2)
     );
     BOOST_CHECK_EQUAL(
-        bc::count(vector.begin(), vector.end(), bc::int4_(4, 5, 6, 7)),
+        bc::count(vector.begin(), vector.end(), bc::int4_(4, 5, 6, 7), queue),
         size_t(2)
     );
     BOOST_CHECK_EQUAL(
-        bc::count(vector.begin(), vector.end(), bc::int4_(7, 8, 9, 1)),
+        bc::count(vector.begin(), vector.end(), bc::int4_(7, 8, 9, 1), queue),
         size_t(1)
     );
     BOOST_CHECK_EQUAL(
-        bc::count(vector.begin(), vector.end(), bc::int4_(0, 3, 2, 2)),
+        bc::count(vector.begin(), vector.end(), bc::int4_(0, 3, 2, 2), queue),
         size_t(1)
     );
     BOOST_CHECK_EQUAL(
-        bc::count(vector.begin(), vector.end(), bc::int4_(3, 4, 4, 5)),
+        bc::count(vector.begin(), vector.end(), bc::int4_(3, 4, 4, 5), queue),
         size_t(0)
     );
     BOOST_CHECK_EQUAL(
-        bc::count(vector.begin(), vector.end(), bc::int4_(1, 2, 3, 0)),
+        bc::count(vector.begin(), vector.end(), bc::int4_(1, 2, 3, 0), queue),
         size_t(0)
     );
     BOOST_CHECK_EQUAL(
-        bc::count(vector.begin(), vector.end(), bc::int4_(1, 9, 8, 7)),
+        bc::count(vector.begin(), vector.end(), bc::int4_(1, 9, 8, 7), queue),
         size_t(0)
     );
 }
@@ -116,11 +117,11 @@ BOOST_AUTO_TEST_CASE(count_int4)
 BOOST_AUTO_TEST_CASE(count_newlines)
 {
     std::string string = "abcdefg\nhijklmn\nopqrs\ntuv\nwxyz\n";
-    compute::vector<char> data(string.size());
-    compute::copy(string.begin(), string.end(), data.begin());
+    compute::vector<char> data(string.size(), context);
+    compute::copy(string.begin(), string.end(), data.begin(), queue);
 
     BOOST_CHECK_EQUAL(
-        compute::count(data.begin(), data.end(), '\n'),
+        compute::count(data.begin(), data.end(), '\n', queue),
         size_t(5)
     );
 }
@@ -130,27 +131,27 @@ BOOST_AUTO_TEST_CASE(count_uchar)
     using boost::compute::uchar_;
 
     unsigned char data[] = { 0x00, 0x10, 0x2F, 0x10, 0x01, 0x00, 0x01, 0x00 };
-    compute::vector<uchar_> vector(8);
-    compute::copy(data, data + 8, vector.begin());
+    compute::vector<uchar_> vector(8, context);
+    compute::copy(data, data + 8, vector.begin(), queue);
 
     BOOST_CHECK_EQUAL(
-        compute::count(vector.begin(), vector.end(), 0x00),
+        compute::count(vector.begin(), vector.end(), 0x00, queue),
         size_t(3)
     );
     BOOST_CHECK_EQUAL(
-        compute::count(vector.begin(), vector.end(), 0x10),
+        compute::count(vector.begin(), vector.end(), 0x10, queue),
         size_t(2)
     );
     BOOST_CHECK_EQUAL(
-        compute::count(vector.begin(), vector.end(), 0x2F),
+        compute::count(vector.begin(), vector.end(), 0x2F, queue),
         size_t(1)
     );
     BOOST_CHECK_EQUAL(
-        compute::count(vector.begin(), vector.end(), 0x01),
+        compute::count(vector.begin(), vector.end(), 0x01, queue),
         size_t(2)
     );
     BOOST_CHECK_EQUAL(
-        compute::count(vector.begin(), vector.end(), 0xFF),
+        compute::count(vector.begin(), vector.end(), 0xFF, queue),
         size_t(0)
     );
 }
@@ -166,22 +167,23 @@ BOOST_AUTO_TEST_CASE(count_vector_component)
 
     using boost::compute::int2_;
 
-    compute::vector<int2_> vector(4);
+    compute::vector<int2_> vector(4, context);
     compute::copy(
         reinterpret_cast<int2_ *>(data),
         reinterpret_cast<int2_ *>(data) + 4,
-        vector.begin()
+        vector.begin(),
+        queue
     );
 
     using boost::compute::lambda::_1;
     using boost::compute::lambda::get;
 
     BOOST_CHECK_EQUAL(
-        compute::count_if(vector.begin(), vector.end(), get<0>(_1) < 4),
+        compute::count_if(vector.begin(), vector.end(), get<0>(_1) < 4, queue),
         size_t(2)
     );
     BOOST_CHECK_EQUAL(
-        compute::count_if(vector.begin(), vector.end(), get<1>(_1) > 3),
+        compute::count_if(vector.begin(), vector.end(), get<1>(_1) > 3, queue),
         size_t(3)
     );
 }

--- a/test/test_equal.cpp
+++ b/test/test_equal.cpp
@@ -23,12 +23,15 @@ BOOST_AUTO_TEST_CASE(equal_int)
     int data1[] = { 1, 2, 3, 4, 5, 6 };
     int data2[] = { 1, 2, 3, 7, 5, 6 };
 
-    boost::compute::vector<int> vector1(data1, data1 + 6);
-    boost::compute::vector<int> vector2(data2, data2 + 6);
+    boost::compute::vector<int> vector1(data1, data1 + 6, queue);
+    boost::compute::vector<int> vector2(data2, data2 + 6, queue);
 
-    BOOST_CHECK(boost::compute::equal(vector1.begin(), vector1.end(), vector2.begin()) == false);
-    BOOST_CHECK(boost::compute::equal(vector1.begin(), vector1.begin() + 2, vector2.begin()) == true);
-    BOOST_CHECK(boost::compute::equal(vector1.begin() + 4, vector1.end(), vector2.begin() + 4) == true);
+    BOOST_CHECK(boost::compute::equal(vector1.begin(), vector1.end(),
+                                      vector2.begin(), queue) == false);
+    BOOST_CHECK(boost::compute::equal(vector1.begin(), vector1.begin() + 2,
+                                      vector2.begin(), queue) == true);
+    BOOST_CHECK(boost::compute::equal(vector1.begin() + 4, vector1.end(),
+                                      vector2.begin() + 4, queue) == true);
 }
 
 BOOST_AUTO_TEST_CASE(equal_string)
@@ -37,8 +40,8 @@ BOOST_AUTO_TEST_CASE(equal_string)
     boost::compute::string b = "abcdefghijk";
     boost::compute::string c = "abcdezghijk";
 
-    BOOST_CHECK(boost::compute::equal(a.begin(), a.end(), b.begin()) == true);
-    BOOST_CHECK(boost::compute::equal(a.begin(), a.end(), c.begin()) == false);
+    BOOST_CHECK(boost::compute::equal(a.begin(), a.end(), b.begin(), queue) == true);
+    BOOST_CHECK(boost::compute::equal(a.begin(), a.end(), c.begin(), queue) == false);
 }
 
 BOOST_AUTO_TEST_CASE(equal_different_range_sizes)

--- a/test/test_equal_range.cpp
+++ b/test/test_equal_range.cpp
@@ -23,48 +23,48 @@
 BOOST_AUTO_TEST_CASE(equal_range_int)
 {
     int data[] = { 1, 2, 2, 2, 3, 3, 4, 5 };
-    boost::compute::vector<int> vector(data, data + 8);
+    boost::compute::vector<int> vector(data, data + 8, queue);
 
     typedef boost::compute::vector<int>::iterator iterator;
 
     std::pair<iterator, iterator> range0 =
-        boost::compute::equal_range(vector.begin(), vector.end(), int(0));
+        boost::compute::equal_range(vector.begin(), vector.end(), int(0), queue);
     BOOST_CHECK(range0.first == vector.begin());
     BOOST_CHECK(range0.second == vector.begin());
     BOOST_CHECK_EQUAL(std::distance(range0.first, range0.second), ptrdiff_t(0));
 
     std::pair<iterator, iterator> range1 =
-        boost::compute::equal_range(vector.begin(), vector.end(), int(1));
+        boost::compute::equal_range(vector.begin(), vector.end(), int(1), queue);
     BOOST_CHECK(range1.first == vector.begin());
     BOOST_CHECK(range1.second == vector.begin() + 1);
     BOOST_CHECK_EQUAL(std::distance(range1.first, range1.second), ptrdiff_t(1));
 
     std::pair<iterator, iterator> range2 =
-        boost::compute::equal_range(vector.begin(), vector.end(), int(2));
+        boost::compute::equal_range(vector.begin(), vector.end(), int(2), queue);
     BOOST_CHECK(range2.first == vector.begin() + 1);
     BOOST_CHECK(range2.second == vector.begin() + 4);
     BOOST_CHECK_EQUAL(std::distance(range2.first, range2.second), ptrdiff_t(3));
 
     std::pair<iterator, iterator> range3 =
-        boost::compute::equal_range(vector.begin(), vector.end(), int(3));
+        boost::compute::equal_range(vector.begin(), vector.end(), int(3), queue);
     BOOST_CHECK(range3.first == vector.begin() + 4);
     BOOST_CHECK(range3.second == vector.begin() + 6);
     BOOST_CHECK_EQUAL(std::distance(range3.first, range3.second), ptrdiff_t(2));
 
     std::pair<iterator, iterator> range4 =
-        boost::compute::equal_range(vector.begin(), vector.end(), int(4));
+        boost::compute::equal_range(vector.begin(), vector.end(), int(4), queue);
     BOOST_CHECK(range4.first == vector.begin() + 6);
     BOOST_CHECK(range4.second == vector.begin() + 7);
     BOOST_CHECK_EQUAL(std::distance(range4.first, range4.second), ptrdiff_t(1));
 
     std::pair<iterator, iterator> range5 =
-        boost::compute::equal_range(vector.begin(), vector.end(), int(5));
+        boost::compute::equal_range(vector.begin(), vector.end(), int(5), queue);
     BOOST_CHECK(range5.first == vector.begin() + 7);
     BOOST_CHECK(range5.second == vector.end());
     BOOST_CHECK_EQUAL(std::distance(range5.first, range5.second), ptrdiff_t(1));
 
     std::pair<iterator, iterator> range6 =
-        boost::compute::equal_range(vector.begin(), vector.end(), int(6));
+        boost::compute::equal_range(vector.begin(), vector.end(), int(6), queue);
     BOOST_CHECK(range6.first == vector.end());
     BOOST_CHECK(range6.second == vector.end());
     BOOST_CHECK_EQUAL(std::distance(range6.first, range6.second), ptrdiff_t(0));

--- a/test/test_extrema.cpp
+++ b/test/test_extrema.cpp
@@ -26,40 +26,41 @@
 BOOST_AUTO_TEST_CASE(int_min_max)
 {
     int data[] = { 9, 15, 1, 4 };
-    boost::compute::vector<int> vector(data, data + 4);
+    boost::compute::vector<int> vector(data, data + 4, queue);
 
     boost::compute::vector<int>::iterator min_iter =
-        boost::compute::min_element(vector.begin(), vector.end());
+        boost::compute::min_element(vector.begin(), vector.end(), queue);
     BOOST_CHECK(min_iter == vector.begin() + 2);
     BOOST_CHECK_EQUAL(*min_iter, 1);
 
     boost::compute::vector<int>::iterator max_iter =
-        boost::compute::max_element(vector.begin(), vector.end());
+        boost::compute::max_element(vector.begin(), vector.end(), queue);
     BOOST_CHECK(max_iter == vector.begin() + 1);
     BOOST_CHECK_EQUAL(*max_iter, 15);
 }
 
 BOOST_AUTO_TEST_CASE(iota_min_max)
 {
-    boost::compute::vector<int> vector(5000);
+    boost::compute::vector<int> vector(5000, context);
 
     // fill with 0 -> 4999
-    boost::compute::iota(vector.begin(), vector.end(), 0);
+    boost::compute::iota(vector.begin(), vector.end(), 0, queue);
 
     boost::compute::vector<int>::iterator min_iter =
-        boost::compute::min_element(vector.begin(), vector.end());
+        boost::compute::min_element(vector.begin(), vector.end(), queue);
     BOOST_CHECK(min_iter == vector.begin());
     BOOST_CHECK_EQUAL(*min_iter, 0);
 
     boost::compute::vector<int>::iterator max_iter =
-        boost::compute::max_element(vector.begin(), vector.end());
+        boost::compute::max_element(vector.begin(), vector.end(), queue);
     BOOST_CHECK(max_iter == vector.end() - 1);
     BOOST_CHECK_EQUAL(*max_iter, 4999);
 
     min_iter =
         boost::compute::min_element(
             vector.begin() + 1000,
-            vector.end() - 1000
+            vector.end() - 1000,
+            queue
         );
     BOOST_CHECK(min_iter == vector.begin() + 1000);
     BOOST_CHECK_EQUAL(*min_iter, 1000);
@@ -67,20 +68,21 @@ BOOST_AUTO_TEST_CASE(iota_min_max)
     max_iter =
         boost::compute::max_element(
             vector.begin() + 1000,
-            vector.end() - 1000
+            vector.end() - 1000,
+            queue
         );
     BOOST_CHECK(max_iter == vector.begin() + 3999);
     BOOST_CHECK_EQUAL(*max_iter, 3999);
 
     // fill with -2500 -> 2499
-    boost::compute::iota(vector.begin(), vector.end(), -2500);
+    boost::compute::iota(vector.begin(), vector.end(), -2500, queue);
     min_iter =
-        boost::compute::min_element(vector.begin(), vector.end());
+        boost::compute::min_element(vector.begin(), vector.end(), queue);
     BOOST_CHECK(min_iter == vector.begin());
     BOOST_CHECK_EQUAL(*min_iter, -2500);
 
     max_iter =
-        boost::compute::max_element(vector.begin(), vector.end());
+        boost::compute::max_element(vector.begin(), vector.end(), queue);
     BOOST_CHECK(max_iter == vector.end() - 1);
     BOOST_CHECK_EQUAL(*max_iter, 2499);
 }
@@ -95,7 +97,8 @@ BOOST_AUTO_TEST_CASE(max_vector_length)
                      1.9f, 1.9f };
     boost::compute::vector<boost::compute::float2_> vector(
         reinterpret_cast<boost::compute::float2_ *>(data),
-        reinterpret_cast<boost::compute::float2_ *>(data) + 5
+        reinterpret_cast<boost::compute::float2_ *>(data) + 5,
+        queue
     );
 
     // find length of the longest vector
@@ -113,7 +116,8 @@ BOOST_AUTO_TEST_CASE(max_vector_length)
             boost::compute::make_transform_iterator(
                 vector.end(),
                 boost::compute::length<boost::compute::float2_>()
-            )
+            ),
+            queue
         );
     BOOST_CHECK(
         max_iter == boost::compute::make_transform_iterator(
@@ -134,7 +138,8 @@ BOOST_AUTO_TEST_CASE(max_vector_length)
             boost::compute::make_transform_iterator(
                 vector.end(),
                 boost::compute::length<boost::compute::float2_>()
-            )
+            ),
+            queue
         );
     BOOST_CHECK(
         min_iter == boost::compute::make_transform_iterator(
@@ -152,7 +157,7 @@ BOOST_AUTO_TEST_CASE(max_bits_set)
     using boost::compute::uint_;
 
     uint_ data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-    boost::compute::vector<uint_> vector(data, data + 10);
+    boost::compute::vector<uint_> vector(data, data + 10, queue);
 
     boost::compute::vector<uint_>::iterator iter =
         boost::compute::max_element(
@@ -163,7 +168,8 @@ BOOST_AUTO_TEST_CASE(max_bits_set)
             boost::compute::make_transform_iterator(
                 vector.end(),
                 boost::compute::popcount<uint_>()
-            )
+            ),
+            queue
         ).base();
 
     BOOST_CHECK(iter == vector.begin() + 7);

--- a/test/test_fill.cpp
+++ b/test/test_fill.cpp
@@ -33,19 +33,19 @@ typedef boost::mpl::list
 
 template<class T>
 inline void test_fill(T v1, T v2, T v3, bc::command_queue queue) {
-    bc::vector<T> vector(4);
-    bc::fill(vector.begin(), vector.end(), v1);
-    bc::system::finish();
+    bc::vector<T> vector(4, queue.get_context());
+    bc::fill(vector.begin(), vector.end(), v1, queue);
+    queue.finish();
     CHECK_RANGE_EQUAL(T, 4, vector, (v1, v1, v1, v1));
 
-    vector.resize(1000);
-    bc::fill(vector.begin(), vector.end(), v2);
-    bc::system::finish();
+    vector.resize(1000, queue);
+    bc::fill(vector.begin(), vector.end(), v2, queue);
+    queue.finish();
     BOOST_CHECK_EQUAL(vector.front(), v2);
     BOOST_CHECK_EQUAL(vector.back(), v2);
 
-    bc::fill(vector.begin() + 500, vector.end(), v3);
-    bc::system::finish();
+    bc::fill(vector.begin() + 500, vector.end(), v3, queue);
+    queue.finish();
     BOOST_CHECK_EQUAL(vector.front(), v2);
     BOOST_CHECK_EQUAL(vector[499], v2);
     BOOST_CHECK_EQUAL(vector[500], v3);
@@ -126,31 +126,31 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( fill_vec16, S, scalar_types )
 
 template<class T>
 inline void test_fill_n(T v1, T v2, T v3, bc::command_queue queue) {
-    bc::vector<T> vector(4);
-    bc::fill_n(vector.begin(), 4, v1);
-    bc::system::finish();
+    bc::vector<T> vector(4, queue.get_context());
+    bc::fill_n(vector.begin(), 4, v1, queue);
+    queue.finish();
     CHECK_RANGE_EQUAL(T, 4, vector, (v1, v1, v1, v1));
 
-    bc::fill_n(vector.begin(), 3, v2);
-    bc::system::finish();
+    bc::fill_n(vector.begin(), 3, v2, queue);
+    queue.finish();
     CHECK_RANGE_EQUAL(T, 4, vector, (v2, v2, v2, v1));
 
-    bc::fill_n(vector.begin() + 1, 2, v3);
-    bc::system::finish();
+    bc::fill_n(vector.begin() + 1, 2, v3, queue);
+    queue.finish();
     CHECK_RANGE_EQUAL(T, 4, vector, (v2, v3, v3, v1));
 
-    bc::fill_n(vector.begin(), 4, v2);
-    bc::system::finish();
+    bc::fill_n(vector.begin(), 4, v2, queue);
+    queue.finish();
     CHECK_RANGE_EQUAL(T, 4, vector, (v2, v2, v2, v2));
 
     // fill last element
-    bc::fill_n(vector.end() - 1, 1, v3);
-    bc::system::finish();
+    bc::fill_n(vector.end() - 1, 1, v3, queue);
+    queue.finish();
     CHECK_RANGE_EQUAL(T, 4, vector, (v2, v2, v2, v3));
 
     // fill first element
-    bc::fill_n(vector.begin(), 1, v1);
-    bc::system::finish();
+    bc::fill_n(vector.begin(), 1, v1, queue);
+    queue.finish();
     CHECK_RANGE_EQUAL(T, 4, vector, (v1, v2, v2, v3));
 }
 

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -29,26 +29,26 @@ namespace compute = boost::compute;
 BOOST_AUTO_TEST_CASE(find_int)
 {
     int data[] = { 9, 15, 1, 4, 9, 9, 4, 15, 12, 1 };
-    bc::vector<int> vector(data, data + 10);
+    bc::vector<int> vector(data, data + 10, queue);
 
     bc::vector<int>::iterator iter =
-        bc::find(vector.begin(), vector.end(), 4);
+        bc::find(vector.begin(), vector.end(), 4, queue);
     BOOST_CHECK(iter == vector.begin() + 3);
     BOOST_CHECK_EQUAL(*iter, 4);
 
-    iter = bc::find(vector.begin(), vector.end(), 12);
+    iter = bc::find(vector.begin(), vector.end(), 12, queue);
     BOOST_CHECK(iter == vector.begin() + 8);
     BOOST_CHECK_EQUAL(*iter, 12);
 
-    iter = bc::find(vector.begin(), vector.end(), 1);
+    iter = bc::find(vector.begin(), vector.end(), 1, queue);
     BOOST_CHECK(iter == vector.begin() + 2);
     BOOST_CHECK_EQUAL(*iter, 1);
 
-    iter = bc::find(vector.begin(), vector.end(), 9);
+    iter = bc::find(vector.begin(), vector.end(), 9, queue);
     BOOST_CHECK(iter == vector.begin());
     BOOST_CHECK_EQUAL(*iter, 9);
 
-    iter = bc::find(vector.begin(), vector.end(), 100);
+    iter = bc::find(vector.begin(), vector.end(), 100, queue);
     BOOST_CHECK(iter == vector.end());
 }
 
@@ -59,26 +59,27 @@ BOOST_AUTO_TEST_CASE(find_int2)
     int data[] = { 1, 2, 4, 5, 7, 8 };
     bc::vector<int2_> vector(
         reinterpret_cast<int2_ *>(data),
-        reinterpret_cast<int2_ *>(data) + 3
+        reinterpret_cast<int2_ *>(data) + 3,
+        queue
     );
     CHECK_RANGE_EQUAL(int2_, 3, vector, (int2_(1, 2), int2_(4, 5), int2_(7, 8)));
 
     bc::vector<int2_>::iterator iter =
-        bc::find(vector.begin(), vector.end(), int2_(4, 5));
+        bc::find(vector.begin(), vector.end(), int2_(4, 5), queue);
     BOOST_CHECK(iter == vector.begin() + 1);
     BOOST_CHECK_EQUAL(*iter, int2_(4, 5));
 
-    iter = bc::find(vector.begin(), vector.end(), int2_(10, 11));
+    iter = bc::find(vector.begin(), vector.end(), int2_(10, 11), queue);
     BOOST_CHECK(iter == vector.end());
 }
 
 BOOST_AUTO_TEST_CASE(find_if_not_int)
 {
     int data[] = { 2, 4, 6, 8, 1, 3, 5, 7, 9 };
-    bc::vector<int> vector(data, data + 9);
+    bc::vector<int> vector(data, data + 9, queue);
 
     bc::vector<int>::iterator iter =
-        bc::find_if_not(vector.begin(), vector.end(), bc::_1 == 2);
+        bc::find_if_not(vector.begin(), vector.end(), bc::_1 == 2, queue);
     BOOST_CHECK(iter == vector.begin() + 1);
     BOOST_CHECK_EQUAL(*iter, 4);
 }

--- a/test/test_flat_map.cpp
+++ b/test/test_flat_map.cpp
@@ -33,28 +33,28 @@ BOOST_AUTO_TEST_CASE(concept_check)
 
 BOOST_AUTO_TEST_CASE(insert)
 {
-    boost::compute::flat_map<int, float> map;
-    map.insert(std::make_pair(1, 1.1f));
-    map.insert(std::make_pair(-1, -1.1f));
-    map.insert(std::make_pair(3, 3.3f));
-    map.insert(std::make_pair(2, 2.2f));
+    boost::compute::flat_map<int, float> map(context);
+    map.insert(std::make_pair(1, 1.1f), queue);
+    map.insert(std::make_pair(-1, -1.1f), queue);
+    map.insert(std::make_pair(3, 3.3f), queue);
+    map.insert(std::make_pair(2, 2.2f), queue);
     BOOST_CHECK_EQUAL(map.size(), size_t(4));
     BOOST_CHECK(map.find(-1) == map.begin() + 0);
     BOOST_CHECK(map.find(1) == map.begin() + 1);
     BOOST_CHECK(map.find(2) == map.begin() + 2);
     BOOST_CHECK(map.find(3) == map.begin() + 3);
 
-    map.insert(std::make_pair(2, -2.2f));
+    map.insert(std::make_pair(2, -2.2f), queue);
     BOOST_CHECK_EQUAL(map.size(), size_t(4));
 }
 
 BOOST_AUTO_TEST_CASE(at)
 {
-    boost::compute::flat_map<int, float> map;
-    map.insert(std::make_pair(1, 1.1f));
-    map.insert(std::make_pair(4, 4.4f));
-    map.insert(std::make_pair(3, 3.3f));
-    map.insert(std::make_pair(2, 2.2f));
+    boost::compute::flat_map<int, float> map(context);
+    map.insert(std::make_pair(1, 1.1f), queue);
+    map.insert(std::make_pair(4, 4.4f), queue);
+    map.insert(std::make_pair(3, 3.3f), queue);
+    map.insert(std::make_pair(2, 2.2f), queue);
     BOOST_CHECK_EQUAL(float(map.at(1)), float(1.1f));
     BOOST_CHECK_EQUAL(float(map.at(2)), float(2.2f));
     BOOST_CHECK_EQUAL(float(map.at(3)), float(3.3f));

--- a/test/test_flat_set.cpp
+++ b/test/test_flat_set.cpp
@@ -36,28 +36,28 @@ BOOST_AUTO_TEST_CASE(insert)
 {
     bc::flat_set<int> set(context);
     typedef bc::flat_set<int>::iterator iterator;
-    std::pair<iterator, bool> location = set.insert(12);
+    std::pair<iterator, bool> location = set.insert(12, queue);
     BOOST_CHECK(location.first == set.begin());
     BOOST_CHECK(location.second == true);
     BOOST_CHECK_EQUAL(*location.first, 12);
     BOOST_CHECK_EQUAL(set.size(), size_t(1));
 
-    location = set.insert(12);
+    location = set.insert(12, queue);
     BOOST_CHECK(location.first == set.begin());
     BOOST_CHECK(location.second == false);
     BOOST_CHECK_EQUAL(set.size(), size_t(1));
 
-    location = set.insert(4);
+    location = set.insert(4, queue);
     BOOST_CHECK(location.first == set.begin());
     BOOST_CHECK(location.second == true);
     BOOST_CHECK_EQUAL(set.size(), size_t(2));
 
-    location = set.insert(12);
+    location = set.insert(12, queue);
     BOOST_CHECK(location.first == set.begin() + 1);
     BOOST_CHECK(location.second == false);
     BOOST_CHECK_EQUAL(set.size(), size_t(2));
 
-    location = set.insert(9);
+    location = set.insert(9, queue);
     BOOST_CHECK(location.first == set.begin() + 1);
     BOOST_CHECK(location.second == true);
     BOOST_CHECK_EQUAL(set.size(), size_t(3));
@@ -67,35 +67,40 @@ BOOST_AUTO_TEST_CASE(erase)
 {
     bc::flat_set<int> set(context);
     typedef bc::flat_set<int>::iterator iterator;
-    set.insert(1);
-    set.insert(2);
-    set.insert(3);
-    set.insert(4);
-    set.insert(5);
+    set.insert(1, queue);
+    set.insert(2, queue);
+    set.insert(3, queue);
+    set.insert(4, queue);
+    set.insert(5, queue);
     BOOST_CHECK_EQUAL(set.size(), size_t(5));
 
-    iterator i = set.erase(set.begin());
+    iterator i = set.erase(set.begin(), queue);
+    queue.finish();
     BOOST_CHECK(i == set.begin() + 1);
     BOOST_CHECK_EQUAL(set.size(), size_t(4));
     BOOST_CHECK_EQUAL(*set.begin(), 2);
 
-    size_t count = set.erase(3);
+    size_t count = set.erase(3, queue);
+    queue.finish();
     BOOST_CHECK_EQUAL(count, size_t(1));
     BOOST_CHECK_EQUAL(set.size(), size_t(3));
     BOOST_CHECK_EQUAL(*set.begin(), 2);
 
-    count = set.erase(9);
+    count = set.erase(9, queue);
+    queue.finish();
     BOOST_CHECK_EQUAL(count, size_t(0));
     BOOST_CHECK_EQUAL(set.size(), size_t(3));
     BOOST_CHECK_EQUAL(*set.begin(), 2);
 
-    i = set.erase(set.begin() + 1);
+    i = set.erase(set.begin() + 1, queue);
+    queue.finish();
     BOOST_CHECK(i == set.begin() + 2);
     BOOST_CHECK_EQUAL(set.size(), size_t(2));
     BOOST_CHECK_EQUAL(*set.begin(), 2);
     BOOST_CHECK_EQUAL(*(set.end() - 1), 5);
 
-    set.erase(set.begin(), set.end());
+    set.erase(set.begin(), set.end(), queue);
+    queue.finish();
     BOOST_CHECK_EQUAL(set.size(), size_t(0));
 }
 

--- a/test/test_generate.cpp
+++ b/test/test_generate.cpp
@@ -27,8 +27,8 @@ namespace bc = boost::compute;
 
 BOOST_AUTO_TEST_CASE(generate4)
 {
-    bc::vector<int> vector(4);
-    bc::fill(vector.begin(), vector.end(), 2);
+    bc::vector<int> vector(4, context);
+    bc::fill(vector.begin(), vector.end(), 2, queue);
     CHECK_RANGE_EQUAL(int, 4, vector, (2, 2, 2, 2));
 
     BOOST_COMPUTE_FUNCTION(int, ret4, (void),
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(generate4)
         return 4;
     });
 
-    bc::generate(vector.begin(), vector.end(), ret4);
+    bc::generate(vector.begin(), vector.end(), ret4, queue);
     CHECK_RANGE_EQUAL(int, 4, vector, (4, 4, 4, 4));
 }
 

--- a/test/test_iota.cpp
+++ b/test/test_iota.cpp
@@ -24,17 +24,17 @@ namespace bc = boost::compute;
 
 BOOST_AUTO_TEST_CASE(iota_int)
 {
-    bc::vector<int> vector(4);
-    bc::iota(vector.begin(), vector.end(), 0);
+    bc::vector<int> vector(4, context);
+    bc::iota(vector.begin(), vector.end(), 0, queue);
     CHECK_RANGE_EQUAL(int, 4, vector, (0, 1, 2, 3));
 
-    bc::iota(vector.begin(), vector.end(), 10);
+    bc::iota(vector.begin(), vector.end(), 10, queue);
     CHECK_RANGE_EQUAL(int, 4, vector, (10, 11, 12, 13));
 
-    bc::iota(vector.begin() + 2, vector.end(), -5);
+    bc::iota(vector.begin() + 2, vector.end(), -5, queue);
     CHECK_RANGE_EQUAL(int, 4, vector, (10, 11, -5, -4));
 
-    bc::iota(vector.begin(), vector.end() - 2, 4);
+    bc::iota(vector.begin(), vector.end() - 2, 4, queue);
     CHECK_RANGE_EQUAL(int, 4, vector, (4, 5, -5, -4));
 }
 
@@ -51,15 +51,18 @@ boost::compute::iota(vec.begin(), vec.end(), 0, queue);
 
 BOOST_AUTO_TEST_CASE(iota_permutation_iterator)
 {
-    bc::vector<int> output(5);
-    bc::fill(output.begin(), output.end(), 0);
+    bc::vector<int> output(5, context);
+    bc::fill(output.begin(), output.end(), 0, queue);
 
     int map_data[] = { 2, 0, 1, 4, 3 };
-    bc::vector<int> map(map_data, map_data + 5);
+    bc::vector<int> map(map_data, map_data + 5, queue);
 
-    bc::iota(bc::make_permutation_iterator(output.begin(), map.begin()),
-             bc::make_permutation_iterator(output.end(), map.end()),
-             1);
+    bc::iota(
+        bc::make_permutation_iterator(output.begin(), map.begin()),
+        bc::make_permutation_iterator(output.end(), map.end()),
+        1,
+        queue
+    );
     CHECK_RANGE_EQUAL(int, 5, output, (2, 3, 1, 5, 4));
 }
 

--- a/test/test_lambda.cpp
+++ b/test/test_lambda.cpp
@@ -33,34 +33,36 @@ namespace compute = boost::compute;
 
 BOOST_AUTO_TEST_CASE(squared_plus_one)
 {
-    bc::vector<int> vector;
-    vector.push_back(1);
-    vector.push_back(2);
-    vector.push_back(3);
-    vector.push_back(4);
-    vector.push_back(5);
+    bc::vector<int> vector(context);
+    vector.push_back(1, queue);
+    vector.push_back(2, queue);
+    vector.push_back(3, queue);
+    vector.push_back(4, queue);
+    vector.push_back(5, queue);
 
     // multiply each value by itself and add one
     bc::transform(vector.begin(),
                   vector.end(),
                   vector.begin(),
-                  (bc::_1 * bc::_1) + 1);
+                  (bc::_1 * bc::_1) + 1,
+                  queue);
     CHECK_RANGE_EQUAL(int, 5, vector, (2, 5, 10, 17, 26));
 }
 
 BOOST_AUTO_TEST_CASE(abs_int)
 {
-    bc::vector<int> vector;
-    vector.push_back(-1);
-    vector.push_back(-2);
-    vector.push_back(3);
-    vector.push_back(-4);
-    vector.push_back(5);
+    bc::vector<int> vector(context);
+    vector.push_back(-1, queue);
+    vector.push_back(-2, queue);
+    vector.push_back(3, queue);
+    vector.push_back(-4, queue);
+    vector.push_back(5, queue);
 
     bc::transform(vector.begin(),
                   vector.end(),
                   vector.begin(),
-                  abs(bc::_1));
+                  abs(bc::_1),
+                  queue);
     CHECK_RANGE_EQUAL(int, 5, vector, (1, 2, 3, 4, 5));
 }
 
@@ -265,10 +267,10 @@ BOOST_AUTO_TEST_CASE(lambda_get_pair)
     using boost::compute::lambda::get;
 
     compute::vector<std::pair<int, float> > vector(context);
-    vector.push_back(std::make_pair(1, 1.2f));
-    vector.push_back(std::make_pair(3, 3.4f));
-    vector.push_back(std::make_pair(5, 5.6f));
-    vector.push_back(std::make_pair(7, 7.8f));
+    vector.push_back(std::make_pair(1, 1.2f), queue);
+    vector.push_back(std::make_pair(3, 3.4f), queue);
+    vector.push_back(std::make_pair(5, 5.6f), queue);
+    vector.push_back(std::make_pair(7, 7.8f), queue);
 
     // extract first compoenent of each pair
     compute::vector<int> first_component(4, context);
@@ -300,10 +302,10 @@ BOOST_AUTO_TEST_CASE(lambda_get_tuple)
 
     compute::vector<boost::tuple<int, char, float> > vector(context);
 
-    vector.push_back(boost::make_tuple(1, 'a', 1.2f));
-    vector.push_back(boost::make_tuple(3, 'b', 3.4f));
-    vector.push_back(boost::make_tuple(5, 'c', 5.6f));
-    vector.push_back(boost::make_tuple(7, 'd', 7.8f));
+    vector.push_back(boost::make_tuple(1, 'a', 1.2f), queue);
+    vector.push_back(boost::make_tuple(3, 'b', 3.4f), queue);
+    vector.push_back(boost::make_tuple(5, 'c', 5.6f), queue);
+    vector.push_back(boost::make_tuple(7, 'd', 7.8f), queue);
 
     // extract first compoenent of each tuple
     compute::vector<int> first_component(4, context);
@@ -346,7 +348,7 @@ BOOST_AUTO_TEST_CASE(lambda_get_zip_iterator)
 
     float data[] = { 1.2f, 2.3f, 3.4f, 4.5f, 5.6f, 6.7f, 7.8f, 9.0f };
     compute::vector<float> input(8, context);
-    compute::copy(data, data + 8, input.begin());
+    compute::copy(data, data + 8, input.begin(), queue);
 
     compute::vector<float> output(8, context);
 
@@ -357,7 +359,8 @@ BOOST_AUTO_TEST_CASE(lambda_get_zip_iterator)
         compute::make_zip_iterator(
             boost::make_tuple(input.end(), output.end())
         ),
-        get<1>(_1) = get<0>(_1)
+        get<1>(_1) = get<0>(_1),
+        queue
     );
     CHECK_RANGE_EQUAL(float, 8, output,
         (1.2f, 2.3f, 3.4f, 4.5f, 5.6f, 6.7f, 7.8f, 9.0f)

--- a/test/test_lexicographical_compare.cpp
+++ b/test/test_lexicographical_compare.cpp
@@ -48,25 +48,28 @@ BOOST_AUTO_TEST_CASE(lexicographical_compare_number)
     int data3[] = { 1, 2, 3, 4, 5 };
     int data4[] = { 9, 2, 3, 4, 5, 100 };
 
-    boost::compute::vector<int> vector1(data1, data1 + 6);
-    boost::compute::vector<int> vector2(data2, data2 + 6);
-    boost::compute::vector<int> vector3(data3, data3 + 5);
-    boost::compute::vector<int> vector4(data4, data4 + 6);
+    boost::compute::vector<int> vector1(data1, data1 + 6, queue);
+    boost::compute::vector<int> vector2(data2, data2 + 6, queue);
+    boost::compute::vector<int> vector3(data3, data3 + 5, queue);
+    boost::compute::vector<int> vector4(data4, data4 + 6, queue);
 
     BOOST_CHECK(boost::compute::lexicographical_compare(vector1.begin(),
                                                         vector1.end(),
                                                         vector2.begin(),
-                                                        vector2.end()) == true);
+                                                        vector2.end(),
+                                                        queue) == true);
 
     BOOST_CHECK(boost::compute::lexicographical_compare(vector1.begin(),
                                                         vector1.end(),
                                                         vector3.begin(),
-                                                        vector3.end()) == false);
+                                                        vector3.end(),
+                                                        queue) == false);
 
     BOOST_CHECK(boost::compute::lexicographical_compare(vector3.begin(),
                                                         vector3.end(),
                                                         vector4.begin(),
-                                                        vector4.end()) == true);
+                                                        vector4.end(),
+                                                        queue) == true);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_malloc.cpp
+++ b/test/test_malloc.cpp
@@ -20,7 +20,7 @@ namespace bc = boost::compute;
 
 BOOST_AUTO_TEST_CASE(malloc_int)
 {
-    bc::experimental::device_ptr<int> ptr = bc::experimental::malloc<int>(5);
+    bc::experimental::device_ptr<int> ptr = bc::experimental::malloc<int>(5, context);
 
     int input_data[] = { 2, 5, 8, 3, 6 };
     bc::copy(input_data, input_data + 5, ptr);

--- a/test/test_mismatch.cpp
+++ b/test/test_mismatch.cpp
@@ -22,13 +22,14 @@ BOOST_AUTO_TEST_CASE(mismatch_int)
     int data1[] = { 1, 2, 3, 4, 5, 6 };
     int data2[] = { 1, 2, 3, 7, 5, 6 };
 
-    boost::compute::vector<int> vector1(data1, data1 + 6);
-    boost::compute::vector<int> vector2(data2, data2 + 6);
+    boost::compute::vector<int> vector1(data1, data1 + 6, queue);
+    boost::compute::vector<int> vector2(data2, data2 + 6, queue);
 
     typedef boost::compute::vector<int>::iterator iter;
 
     std::pair<iter, iter> location =
-        boost::compute::mismatch(vector1.begin(), vector1.end(), vector2.begin());
+        boost::compute::mismatch(vector1.begin(), vector1.end(),
+                                 vector2.begin(), queue);
     BOOST_CHECK(location.first == vector1.begin() + 3);
     BOOST_CHECK_EQUAL(int(*location.first), int(4));
     BOOST_CHECK(location.second == vector2.begin() + 3);

--- a/test/test_pair.cpp
+++ b/test/test_pair.cpp
@@ -28,10 +28,10 @@
 
 BOOST_AUTO_TEST_CASE(vector_pair_int_float)
 {
-    boost::compute::vector<std::pair<int, float> > vector;
-    vector.push_back(std::make_pair(1, 1.1f));
-    vector.push_back(std::make_pair(2, 2.2f));
-    vector.push_back(std::make_pair(3, 3.3f));
+    boost::compute::vector<std::pair<int, float> > vector(context);
+    vector.push_back(std::make_pair(1, 1.1f), queue);
+    vector.push_back(std::make_pair(2, 2.2f), queue);
+    vector.push_back(std::make_pair(3, 3.3f), queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(3));
     BOOST_CHECK(vector[0] == std::make_pair(1, 1.1f));
     BOOST_CHECK(vector[1] == std::make_pair(2, 2.2f));
@@ -40,16 +40,16 @@ BOOST_AUTO_TEST_CASE(vector_pair_int_float)
 
 BOOST_AUTO_TEST_CASE(copy_pair_vector)
 {
-    boost::compute::vector<std::pair<int, float> > input;
-    input.push_back(std::make_pair(1, 2.0f));
-    input.push_back(std::make_pair(3, 4.0f));
-    input.push_back(std::make_pair(5, 6.0f));
-    input.push_back(std::make_pair(7, 8.0f));
+    boost::compute::vector<std::pair<int, float> > input(context);
+    input.push_back(std::make_pair(1, 2.0f), queue);
+    input.push_back(std::make_pair(3, 4.0f), queue);
+    input.push_back(std::make_pair(5, 6.0f), queue);
+    input.push_back(std::make_pair(7, 8.0f), queue);
     BOOST_CHECK_EQUAL(input.size(), size_t(4));
 
-    boost::compute::vector<std::pair<int, float> > output(4);
-    boost::compute::copy(input.begin(), input.end(), output.begin());
-    boost::compute::system::finish();
+    boost::compute::vector<std::pair<int, float> > output(4, context);
+    boost::compute::copy(input.begin(), input.end(), output.begin(), queue);
+    queue.finish();
     BOOST_CHECK(output[0] == std::make_pair(1, 2.0f));
     BOOST_CHECK(output[1] == std::make_pair(3, 4.0f));
     BOOST_CHECK(output[2] == std::make_pair(5, 6.0f));
@@ -63,9 +63,9 @@ BOOST_AUTO_TEST_CASE(fill_pair_vector)
         return;
     }
 
-    boost::compute::vector<std::pair<int, float> > vector(5);
-    boost::compute::fill(vector.begin(), vector.end(), std::make_pair(4, 2.0f));
-    boost::compute::system::finish();
+    boost::compute::vector<std::pair<int, float> > vector(5, context);
+    boost::compute::fill(vector.begin(), vector.end(), std::make_pair(4, 2.0f), queue);
+    queue.finish();
     BOOST_CHECK(vector[0] == std::make_pair(4, 2.0f));
     BOOST_CHECK(vector[1] == std::make_pair(4, 2.0f));
     BOOST_CHECK(vector[2] == std::make_pair(4, 2.0f));
@@ -81,9 +81,9 @@ BOOST_AUTO_TEST_CASE(fill_char_pair_vector)
     }
 
     std::pair<char, unsigned char> value('c', static_cast<unsigned char>(127));
-    boost::compute::vector<std::pair<char, unsigned char> > vector(5);
-    boost::compute::fill(vector.begin(), vector.end(), value);
-    boost::compute::system::finish();
+    boost::compute::vector<std::pair<char, unsigned char> > vector(5, context);
+    boost::compute::fill(vector.begin(), vector.end(), value, queue);
+    queue.finish();
     BOOST_CHECK(vector[0] == value);
     BOOST_CHECK(vector[1] == value);
     BOOST_CHECK(vector[2] == value);
@@ -93,64 +93,68 @@ BOOST_AUTO_TEST_CASE(fill_char_pair_vector)
 
 BOOST_AUTO_TEST_CASE(transform_pair_get)
 {
-    boost::compute::vector<std::pair<int, float> > input;
-    input.push_back(std::make_pair(1, 2.0f));
-    input.push_back(std::make_pair(3, 4.0f));
-    input.push_back(std::make_pair(5, 6.0f));
-    input.push_back(std::make_pair(7, 8.0f));
+    boost::compute::vector<std::pair<int, float> > input(context);
+    input.push_back(std::make_pair(1, 2.0f), queue);
+    input.push_back(std::make_pair(3, 4.0f), queue);
+    input.push_back(std::make_pair(5, 6.0f), queue);
+    input.push_back(std::make_pair(7, 8.0f), queue);
 
-    boost::compute::vector<int> first_output(4);
+    boost::compute::vector<int> first_output(4, context);
     boost::compute::transform(
         input.begin(),
         input.end(),
         first_output.begin(),
-        ::boost::compute::get<0>()
+        ::boost::compute::get<0>(),
+        queue
     );
     CHECK_RANGE_EQUAL(int, 4, first_output, (1, 3, 5, 7));
 
-    boost::compute::vector<float> second_output(4);
+    boost::compute::vector<float> second_output(4, context);
     boost::compute::transform(
         input.begin(),
         input.end(),
         second_output.begin(),
-        ::boost::compute::get<1>()
+        ::boost::compute::get<1>(),
+        queue
     );
     CHECK_RANGE_EQUAL(float, 4, second_output, (2.0f, 4.0f, 6.0f, 8.0f));
 }
 
 BOOST_AUTO_TEST_CASE(transform_pair_field)
 {
-    boost::compute::vector<std::pair<int, float> > input;
-    input.push_back(std::make_pair(1, 2.0f));
-    input.push_back(std::make_pair(3, 4.0f));
-    input.push_back(std::make_pair(5, 6.0f));
-    input.push_back(std::make_pair(7, 8.0f));
+    boost::compute::vector<std::pair<int, float> > input(context);
+    input.push_back(std::make_pair(1, 2.0f), queue);
+    input.push_back(std::make_pair(3, 4.0f), queue);
+    input.push_back(std::make_pair(5, 6.0f), queue);
+    input.push_back(std::make_pair(7, 8.0f), queue);
 
-    boost::compute::vector<int> first_output(4);
+    boost::compute::vector<int> first_output(4, context);
     boost::compute::transform(
         input.begin(),
         input.end(),
         first_output.begin(),
-        boost::compute::field<int>("first")
+        boost::compute::field<int>("first"),
+        queue
     );
     CHECK_RANGE_EQUAL(int, 4, first_output, (1, 3, 5, 7));
 
-    boost::compute::vector<float> second_output(4);
+    boost::compute::vector<float> second_output(4, context);
     boost::compute::transform(
         input.begin(),
         input.end(),
         second_output.begin(),
-        boost::compute::field<float>("second")
+        boost::compute::field<float>("second"),
+        queue
     );
     CHECK_RANGE_EQUAL(float, 4, second_output, (2.0f, 4.0f, 6.0f, 8.0f));
 }
 
 BOOST_AUTO_TEST_CASE(find_vector_pair)
 {
-    boost::compute::vector<std::pair<int, float> > vector;
-    vector.push_back(std::make_pair(1, 1.1f));
-    vector.push_back(std::make_pair(2, 2.2f));
-    vector.push_back(std::make_pair(3, 3.3f));
+    boost::compute::vector<std::pair<int, float> > vector(context);
+    vector.push_back(std::make_pair(1, 1.1f), queue);
+    vector.push_back(std::make_pair(2, 2.2f), queue);
+    vector.push_back(std::make_pair(3, 3.3f), queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(3));
 
     BOOST_CHECK(
@@ -163,7 +167,8 @@ BOOST_AUTO_TEST_CASE(find_vector_pair)
                 vector.end(),
                 boost::compute::get<0>()
             ),
-            int(2)
+            int(2),
+            queue
         ).base() == vector.begin() + 1
     );
 
@@ -177,7 +182,8 @@ BOOST_AUTO_TEST_CASE(find_vector_pair)
                 vector.end(),
                 boost::compute::get<1>()
             ),
-            float(3.3f)
+            float(3.3f),
+            queue
         ).base() == vector.begin() + 2
     );
 }

--- a/test/test_partial_sum.cpp
+++ b/test/test_partial_sum.cpp
@@ -28,12 +28,12 @@ namespace bc = boost::compute;
 BOOST_AUTO_TEST_CASE(partial_sum_int)
 {
     int data[] = { 1, 2, 5, 3, 9, 1, 4, 2 };
-    bc::vector<int> a(8);
-    bc::copy(data, data + 8, a.begin());
+    bc::vector<int> a(8, context);
+    bc::copy(data, data + 8, a.begin(), queue);
 
-    bc::vector<int> b(a.size());
+    bc::vector<int> b(a.size(), context);
     bc::vector<int>::iterator iter =
-        bc::partial_sum(a.begin(), a.end(), b.begin());
+        bc::partial_sum(a.begin(), a.end(), b.begin(), queue);
     BOOST_CHECK(iter == b.end());
     CHECK_RANGE_EQUAL(int, 8, b, (1, 3, 8, 11, 20, 21, 25, 27));
 }

--- a/test/test_partition.cpp
+++ b/test/test_partition.cpp
@@ -27,14 +27,14 @@ namespace bc = boost::compute;
 BOOST_AUTO_TEST_CASE(partition_float_vector)
 {
     bc::vector<float> vector(context);
-    vector.push_back(1.0f);
-    vector.push_back(2.0f);
-    vector.push_back(-1.0f);
-    vector.push_back(-2.0f);
-    vector.push_back(3.0f);
-    vector.push_back(4.0f);
-    vector.push_back(-3.0f);
-    vector.push_back(-4.0f);
+    vector.push_back(1.0f, queue);
+    vector.push_back(2.0f, queue);
+    vector.push_back(-1.0f, queue);
+    vector.push_back(-2.0f, queue);
+    vector.push_back(3.0f, queue);
+    vector.push_back(4.0f, queue);
+    vector.push_back(-3.0f, queue);
+    vector.push_back(-4.0f, queue);
 
     // verify is_partitioned()
     BOOST_VERIFY(bc::is_partitioned(vector.begin(),
@@ -70,11 +70,11 @@ BOOST_AUTO_TEST_CASE(partition_small_vector)
     bc::vector<float> vector(context);
     bc::partition(vector.begin(), vector.end(), bc::signbit_<float>(), queue);
 
-    vector.push_back(1.0f);
+    vector.push_back(1.0f, queue);
     bc::partition(vector.begin(), vector.end(), bc::signbit_<float>(), queue);
     CHECK_RANGE_EQUAL(float, 1, vector, (1.0f));
 
-    vector.push_back(-1.0f);
+    vector.push_back(-1.0f, queue);
     bc::partition(vector.begin(), vector.end(), bc::signbit_<float>(), queue);
     CHECK_RANGE_EQUAL(float, 2, vector, (-1.0f, 1.0f));
 }

--- a/test/test_pinned_allocator.cpp
+++ b/test/test_pinned_allocator.cpp
@@ -20,8 +20,8 @@ namespace compute = boost::compute;
 
 BOOST_AUTO_TEST_CASE(vector_with_pinned_allocator)
 {
-    compute::vector<int, compute::pinned_allocator<int> > vector;
-    vector.push_back(12);
+    compute::vector<int, compute::pinned_allocator<int> > vector(context);
+    vector.push_back(12, queue);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_program_cache.cpp
+++ b/test/test_program_cache.cpp
@@ -14,12 +14,14 @@
 #include <boost/compute/system.hpp>
 #include <boost/compute/utility/program_cache.hpp>
 
+#include "context_setup.hpp"
+
 namespace compute = boost::compute;
 
 BOOST_AUTO_TEST_CASE(setup)
 {
     // get default context
-    compute::context ctx = compute::system::default_context();
+    compute::context ctx = context;
 
     // get program cache
     boost::shared_ptr<compute::program_cache> cache =
@@ -93,3 +95,5 @@ BOOST_AUTO_TEST_CASE(evict)
     BOOST_CHECK(cache.get("d") == boost::none);
     BOOST_CHECK(cache.get("e") == boost::none);
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_random_fill.cpp
+++ b/test/test_random_fill.cpp
@@ -18,15 +18,13 @@
 #include <boost/compute/container/vector.hpp>
 #include <boost/compute/lambda.hpp>
 
+#include "context_setup.hpp"
+
 namespace compute = boost::compute;
 
 BOOST_AUTO_TEST_CASE(random_fill_float)
 {
     using compute::lambda::_1;
-
-    compute::device device = compute::system::default_device();
-    compute::context context(device);
-    compute::command_queue queue(context, device);
 
     compute::vector<float> vector(10, context);
 
@@ -74,3 +72,5 @@ BOOST_AUTO_TEST_CASE(random_fill_float)
         size_t(0)
     );
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_random_shuffle.cpp
+++ b/test/test_random_shuffle.cpp
@@ -26,10 +26,10 @@ namespace bc = boost::compute;
 BOOST_AUTO_TEST_CASE(shuffle_int_vector)
 {
     bc::vector<int> vector(context);
-    vector.push_back(1);
-    vector.push_back(9);
-    vector.push_back(19);
-    vector.push_back(29);
+    vector.push_back(1, queue);
+    vector.push_back(9, queue);
+    vector.push_back(19, queue);
+    vector.push_back(29, queue);
 
     std::set<int> original_values;
     for(size_t i = 0; i < vector.size(); i++){

--- a/test/test_replace.cpp
+++ b/test/test_replace.cpp
@@ -26,23 +26,23 @@ namespace bc = boost::compute;
 
 BOOST_AUTO_TEST_CASE(replace_int)
 {
-    bc::vector<int> vector(5);
-    bc::iota(vector.begin(), vector.end(), 0);
+    bc::vector<int> vector(5, context);
+    bc::iota(vector.begin(), vector.end(), 0, queue);
     CHECK_RANGE_EQUAL(int, 5, vector, (0, 1, 2, 3, 4));
 
-    bc::replace(vector.begin(), vector.end(), 2, 6);
+    bc::replace(vector.begin(), vector.end(), 2, 6, queue);
     CHECK_RANGE_EQUAL(int, 5, vector, (0, 1, 6, 3, 4));
 }
 
 BOOST_AUTO_TEST_CASE(replace_copy_int)
 {
-    bc::vector<int> a(5);
-    bc::iota(a.begin(), a.end(), 0);
+    bc::vector<int> a(5, context);
+    bc::iota(a.begin(), a.end(), 0, queue);
     CHECK_RANGE_EQUAL(int, 5, a, (0, 1, 2, 3, 4));
 
-    bc::vector<int> b(5);
+    bc::vector<int> b(5, context);
     bc::vector<int>::iterator iter =
-        bc::replace_copy(a.begin(), a.end(), b.begin(), 3, 9);
+        bc::replace_copy(a.begin(), a.end(), b.begin(), 3, 9, queue);
     BOOST_CHECK(iter == b.end());
     CHECK_RANGE_EQUAL(int, 5, b, (0, 1, 2, 9, 4));
 

--- a/test/test_reverse.cpp
+++ b/test/test_reverse.cpp
@@ -27,64 +27,65 @@ namespace bc = boost::compute;
 
 BOOST_AUTO_TEST_CASE(reverse_int)
 {
-    bc::vector<int> vector(5);
-    bc::iota(vector.begin(), vector.end(), 0);
+    bc::vector<int> vector(5, context);
+    bc::iota(vector.begin(), vector.end(), 0, queue);
     CHECK_RANGE_EQUAL(int, 5, vector, (0, 1, 2, 3, 4));
 
-    bc::reverse(vector.begin(), vector.end());
+    bc::reverse(vector.begin(), vector.end(), queue);
     CHECK_RANGE_EQUAL(int, 5, vector, (4, 3, 2, 1, 0));
 
-    bc::reverse(vector.begin() + 1, vector.end());
+    bc::reverse(vector.begin() + 1, vector.end(), queue);
     CHECK_RANGE_EQUAL(int, 5, vector, (4, 0, 1, 2, 3));
 
-    bc::reverse(vector.begin() + 1, vector.end() - 1);
+    bc::reverse(vector.begin() + 1, vector.end() - 1, queue);
     CHECK_RANGE_EQUAL(int, 5, vector, (4, 2, 1, 0, 3));
 
-    bc::reverse(vector.begin(), vector.end() - 2);
+    bc::reverse(vector.begin(), vector.end() - 2, queue);
     CHECK_RANGE_EQUAL(int, 5, vector, (1, 2, 4, 0, 3));
 
-    vector.resize(6);
-    bc::iota(vector.begin(), vector.end(), 10);
+    vector.resize(6, queue);
+    bc::iota(vector.begin(), vector.end(), 10, queue);
     CHECK_RANGE_EQUAL(int, 6, vector, (10, 11, 12, 13, 14, 15));
 
-    bc::reverse(vector.begin(), vector.end());
+    bc::reverse(vector.begin(), vector.end(), queue);
     CHECK_RANGE_EQUAL(int, 6, vector, (15, 14, 13, 12, 11, 10));
 
-    bc::reverse(vector.begin() + 3, vector.end());
+    bc::reverse(vector.begin() + 3, vector.end(), queue);
     CHECK_RANGE_EQUAL(int, 6, vector, (15, 14, 13, 10, 11, 12));
 
-    bc::reverse(vector.begin() + 1, vector.end() - 2);
+    bc::reverse(vector.begin() + 1, vector.end() - 2, queue);
     CHECK_RANGE_EQUAL(int, 6, vector, (15, 10, 13, 14, 11, 12));
 }
 
 BOOST_AUTO_TEST_CASE(reverse_copy_int)
 {
-    bc::vector<int> a(5);
-    bc::iota(a.begin(), a.end(), 0);
+    bc::vector<int> a(5, context);
+    bc::iota(a.begin(), a.end(), 0, queue);
     CHECK_RANGE_EQUAL(int, 5, a, (0, 1, 2, 3, 4));
 
-    bc::vector<int> b(5);
+    bc::vector<int> b(5, context);
     bc::vector<int>::iterator iter =
-        bc::reverse_copy(a.begin(), a.end(), b.begin());
+        bc::reverse_copy(a.begin(), a.end(), b.begin(), queue);
     BOOST_CHECK(iter == b.end());
     CHECK_RANGE_EQUAL(int, 5, b, (4, 3, 2, 1, 0));
 
-    iter = bc::reverse_copy(b.begin() + 1, b.end(), a.begin() + 1);
+    iter = bc::reverse_copy(b.begin() + 1, b.end(), a.begin() + 1, queue);
     BOOST_CHECK(iter == a.end());
     CHECK_RANGE_EQUAL(int, 5, a, (0, 0, 1, 2, 3));
 
-    iter = bc::reverse_copy(a.begin(), a.end() - 1, b.begin());
+    iter = bc::reverse_copy(a.begin(), a.end() - 1, b.begin(), queue);
     BOOST_CHECK(iter == (b.end() - 1));
     CHECK_RANGE_EQUAL(int, 5, b, (2, 1, 0, 0, 0));
 }
 
 BOOST_AUTO_TEST_CASE(reverse_copy_counting_iterator)
 {
-    bc::vector<int> vector(5);
+    bc::vector<int> vector(5, context);
     bc::reverse_copy(
         bc::make_counting_iterator(1),
         bc::make_counting_iterator(6),
-        vector.begin()
+        vector.begin(),
+        queue
     );
     CHECK_RANGE_EQUAL(int, 5, vector, (5, 4, 3, 2, 1));
 }

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -24,35 +24,35 @@ namespace bc = boost::compute;
 // test trivial sorting of zero and one element vectors
 BOOST_AUTO_TEST_CASE(sort_int_0_and_1)
 {
-    boost::compute::vector<int> vec;
+    boost::compute::vector<int> vec(context);
     BOOST_CHECK_EQUAL(vec.size(), size_t(0));
-    BOOST_CHECK(boost::compute::is_sorted(vec.begin(), vec.end()) == true);
-    boost::compute::sort(vec.begin(), vec.end());
+    BOOST_CHECK(boost::compute::is_sorted(vec.begin(), vec.end(), queue) == true);
+    boost::compute::sort(vec.begin(), vec.end(), queue);
 
-    vec.push_back(11);
+    vec.push_back(11, queue);
     BOOST_CHECK_EQUAL(vec.size(), size_t(1));
-    BOOST_CHECK(boost::compute::is_sorted(vec.begin(), vec.end()) == true);
-    boost::compute::sort(vec.begin(), vec.end());
+    BOOST_CHECK(boost::compute::is_sorted(vec.begin(), vec.end(), queue) == true);
+    boost::compute::sort(vec.begin(), vec.end(), queue);
 }
 
 // test sorting of two element int vectors
 BOOST_AUTO_TEST_CASE(sort_int_2)
 {
     int data[] = { 4, 2 };
-    boost::compute::vector<int> vec(data, data + 2);
+    boost::compute::vector<int> vec(data, data + 2, queue);
 
     // check that vec is unsorted
-    BOOST_CHECK(boost::compute::is_sorted(vec.begin(), vec.end()) == false);
+    BOOST_CHECK(boost::compute::is_sorted(vec.begin(), vec.end(), queue) == false);
 
     // sort vec
-    boost::compute::sort(vec.begin(), vec.end());
+    boost::compute::sort(vec.begin(), vec.end(), queue);
 
     // check that vec is sorted
-    BOOST_CHECK(boost::compute::is_sorted(vec.begin(), vec.end()) == true);
+    BOOST_CHECK(boost::compute::is_sorted(vec.begin(), vec.end(), queue) == true);
 
     // sort already sorted vec and ensure it is still sorted
     boost::compute::sort(vec.begin(), vec.end());
-    BOOST_CHECK(boost::compute::is_sorted(vec.begin(), vec.end()) == true);
+    BOOST_CHECK(boost::compute::is_sorted(vec.begin(), vec.end(), queue) == true);
 }
 
 BOOST_AUTO_TEST_CASE(sort_float_3)
@@ -68,12 +68,12 @@ BOOST_AUTO_TEST_CASE(sort_char_vector)
     using boost::compute::char_;
 
     char_ data[] = { 'c', 'a', '0', '7', 'B', 'F', '\0', '$' };
-    boost::compute::vector<char_> vector(data, data + 8);
+    boost::compute::vector<char_> vector(data, data + 8, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == false);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
     boost::compute::sort(vector.begin(), vector.end());
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == true);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(char_, 8, vector, ('\0', '$', '0', '7', 'B', 'F', 'a', 'c'));
 }
 
@@ -82,12 +82,12 @@ BOOST_AUTO_TEST_CASE(sort_uchar_vector)
     using boost::compute::uchar_;
 
     uchar_ data[] = { 0x12, 0x00, 0xFF, 0xB4, 0x80, 0x32, 0x64, 0xA2 };
-    boost::compute::vector<uchar_> vector(data, data + 8);
+    boost::compute::vector<uchar_> vector(data, data + 8, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == false);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
     boost::compute::sort(vector.begin(), vector.end());
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == true);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(uchar_, 8, vector, (0x00, 0x12, 0x32, 0x64, 0x80, 0xA2, 0xB4, 0xFF));
 }
 
@@ -96,12 +96,12 @@ BOOST_AUTO_TEST_CASE(sort_short_vector)
     using boost::compute::short_;
 
     short_ data[] = { -4, 152, -94, 963, 31002, -456, 0, -2113 };
-    boost::compute::vector<short_> vector(data, data + 8);
+    boost::compute::vector<short_> vector(data, data + 8, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == false);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
     boost::compute::sort(vector.begin(), vector.end());
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == true);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(short_, 8, vector, (-2113, -456, -94, -4, 0, 152, 963, 31002));
 }
 
@@ -110,24 +110,24 @@ BOOST_AUTO_TEST_CASE(sort_ushort_vector)
     using boost::compute::ushort_;
 
     ushort_ data[] = { 4, 152, 94, 963, 63202, 34560, 0, 2113 };
-    boost::compute::vector<ushort_> vector(data, data + 8);
+    boost::compute::vector<ushort_> vector(data, data + 8, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == false);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
     boost::compute::sort(vector.begin(), vector.end());
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == true);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(ushort_, 8, vector, (0, 4, 94, 152, 963, 2113, 34560, 63202));
 }
 
 BOOST_AUTO_TEST_CASE(sort_int_vector)
 {
     int data[] = { -4, 152, -5000, 963, 75321, -456, 0, 1112 };
-    boost::compute::vector<int> vector(data, data + 8);
+    boost::compute::vector<int> vector(data, data + 8, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == false);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
     boost::compute::sort(vector.begin(), vector.end());
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == true);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(int, 8, vector, (-5000, -456, -4, 0, 152, 963, 1112, 75321));
 }
 
@@ -136,12 +136,12 @@ BOOST_AUTO_TEST_CASE(sort_uint_vector)
     using boost::compute::uint_;
 
     uint_ data[] = { 500, 1988, 123456, 562, 0, 4000000, 9852, 102030 };
-    boost::compute::vector<uint_> vector(data, data + 8);
+    boost::compute::vector<uint_> vector(data, data + 8, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == false);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
     boost::compute::sort(vector.begin(), vector.end());
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == true);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(uint_, 8, vector, (0, 500, 562, 1988, 9852, 102030, 123456, 4000000));
 }
 
@@ -150,12 +150,12 @@ BOOST_AUTO_TEST_CASE(sort_long_vector)
     using boost::compute::long_;
 
     long_ data[] = { 500, 1988, 123456, 562, 0, 4000000, 9852, 102030 };
-    boost::compute::vector<long_> vector(data, data + 8);
+    boost::compute::vector<long_> vector(data, data + 8, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == false);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
     boost::compute::sort(vector.begin(), vector.end());
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == true);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(long_, 8, vector, (0, 500, 562, 1988, 9852, 102030, 123456, 4000000));
 }
 
@@ -164,9 +164,9 @@ BOOST_AUTO_TEST_CASE(sort_ulong_vector)
     using boost::compute::ulong_;
 
     ulong_ data[] = { 500, 1988, 123456, 562, 0, 4000000, 9852, 102030 };
-    boost::compute::vector<ulong_> vector(data, data + 8);
+    boost::compute::vector<ulong_> vector(data, data + 8, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == false);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
     boost::compute::sort(vector.begin(), vector.end());
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == true);
@@ -177,12 +177,12 @@ BOOST_AUTO_TEST_CASE(sort_float_vector)
 {
     float data[] = { -6023.0f, 152.5f, -63.0f, 1234567.0f, 11.2f,
                      -5000.1f, 0.0f, 14.0f, -8.25f, -0.0f };
-    boost::compute::vector<float> vector(data, data + 10);
+    boost::compute::vector<float> vector(data, data + 10, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(10));
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == false);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
     boost::compute::sort(vector.begin(), vector.end());
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == true);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(
         float, 10, vector,
         (-6023.0f, -5000.1f, -63.0f, -8.25f, -0.0f, 0.0f, 11.2f, 14.0f, 152.5f, 1234567.0f)
@@ -198,12 +198,12 @@ BOOST_AUTO_TEST_CASE(sort_double_vector)
 
     double data[] = { -6023.0, 152.5, -63.0, 1234567.0, 11.2,
                      -5000.1, 0.0, 14.0, -8.25, -0.0 };
-    boost::compute::vector<double> vector(data, data + 10);
+    boost::compute::vector<double> vector(data, data + 10, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(10));
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == false);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
     boost::compute::sort(vector.begin(), vector.end());
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == true);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(
         double, 10, vector,
         (-6023.0, -5000.1, -63.0, -8.25, -0.0, 0.0, 11.2, 14.0, 152.5, 1234567.0)
@@ -214,10 +214,11 @@ BOOST_AUTO_TEST_CASE(sort_double_vector)
 BOOST_AUTO_TEST_CASE(reverse_sort_int_vector)
 {
     int data[] = { -4, 152, -5000, 963, 75321, -456, 0, 1112 };
-    boost::compute::vector<int> vector(data, data + 8);
+    boost::compute::vector<int> vector(data, data + 8, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
 
-    boost::compute::sort(vector.begin(), vector.end(), boost::compute::greater<int>());
+    boost::compute::sort(vector.begin(), vector.end(),
+                         boost::compute::greater<int>(), queue);
     CHECK_RANGE_EQUAL(int, 8, vector, (75321, 1112, 963, 152, 0, -4, -456, -5000));
 }
 

--- a/test/test_tuple.cpp
+++ b/test/test_tuple.cpp
@@ -32,20 +32,20 @@ namespace compute = boost::compute;
 
 BOOST_AUTO_TEST_CASE(vector_tuple_int_float)
 {
-    boost::compute::vector<boost::tuple<int, float> > vector;
+    boost::compute::vector<boost::tuple<int, float> > vector(context);
 
-    vector.push_back(boost::make_tuple(1, 2.1f));
-    vector.push_back(boost::make_tuple(2, 3.2f));
-    vector.push_back(boost::make_tuple(3, 4.3f));
+    vector.push_back(boost::make_tuple(1, 2.1f), queue);
+    vector.push_back(boost::make_tuple(2, 3.2f), queue);
+    vector.push_back(boost::make_tuple(3, 4.3f), queue);
 }
 
 BOOST_AUTO_TEST_CASE(copy_vector_tuple)
 {
     // create vector of tuples on device
     boost::compute::vector<boost::tuple<char, int, float> > input(context);
-    input.push_back(boost::make_tuple('a', 1, 2.3f));
-    input.push_back(boost::make_tuple('c', 3, 4.5f));
-    input.push_back(boost::make_tuple('f', 6, 7.8f));
+    input.push_back(boost::make_tuple('a', 1, 2.3f), queue);
+    input.push_back(boost::make_tuple('c', 3, 4.5f), queue);
+    input.push_back(boost::make_tuple('f', 6, 7.8f), queue);
 
     // copy on device
     boost::compute::vector<boost::tuple<char, int, float> > output(context);
@@ -53,7 +53,8 @@ BOOST_AUTO_TEST_CASE(copy_vector_tuple)
     boost::compute::copy(
         input.begin(),
         input.end(),
-        output.begin()
+        output.begin(),
+        queue
     );
 
     // copy to host
@@ -62,7 +63,8 @@ BOOST_AUTO_TEST_CASE(copy_vector_tuple)
     boost::compute::copy(
         input.begin(),
         input.end(),
-        host_output.begin()
+        host_output.begin(),
+        queue
     );
 
     // check tuple data
@@ -74,9 +76,9 @@ BOOST_AUTO_TEST_CASE(copy_vector_tuple)
 BOOST_AUTO_TEST_CASE(extract_tuple_elements)
 {
     compute::vector<boost::tuple<char, int, float> > vector(context);
-    vector.push_back(boost::make_tuple('a', 1, 2.3f));
-    vector.push_back(boost::make_tuple('c', 3, 4.5f));
-    vector.push_back(boost::make_tuple('f', 6, 7.8f));
+    vector.push_back(boost::make_tuple('a', 1, 2.3f), queue);
+    vector.push_back(boost::make_tuple('c', 3, 4.5f), queue);
+    vector.push_back(boost::make_tuple('f', 6, 7.8f), queue);
 
     compute::vector<char> chars(3, context);
     compute::transform(
@@ -105,10 +107,10 @@ BOOST_AUTO_TEST_CASE(fill_tuple_vector)
     }
 
     compute::vector<boost::tuple<char, int, float> > vector(5, context);
-    compute::fill(vector.begin(), vector.end(), boost::make_tuple('z', 4, 3.14f));
+    compute::fill(vector.begin(), vector.end(), boost::make_tuple('z', 4, 3.14f), queue);
 
     std::vector<boost::tuple<char, int, float> > host_output(5);
-    compute::copy(vector.begin(), vector.end(), host_output.begin());
+    compute::copy(vector.begin(), vector.end(), host_output.begin(), queue);
     BOOST_CHECK_EQUAL(host_output[0], boost::make_tuple('z', 4, 3.14f));
     BOOST_CHECK_EQUAL(host_output[1], boost::make_tuple('z', 4, 3.14f));
     BOOST_CHECK_EQUAL(host_output[2], boost::make_tuple('z', 4, 3.14f));

--- a/test/test_unique_copy.cpp
+++ b/test/test_unique_copy.cpp
@@ -24,11 +24,11 @@ BOOST_AUTO_TEST_CASE(unique_copy_int)
 {
     int data[] = {1, 6, 6, 4, 2, 2, 4};
 
-    bc::vector<int> input(data, data + 7);
-    bc::vector<int> result(5);
+    bc::vector<int> input(data, data + 7, queue);
+    bc::vector<int> result(5, context);
     
     bc::vector<int>::iterator iter =
-        bc::unique_copy(input.begin(), input.end(), result.begin());
+        bc::unique_copy(input.begin(), input.end(), result.begin(), queue);
     
     BOOST_VERIFY(iter == result.begin() + 5);
     CHECK_RANGE_EQUAL(int, 5, result, (1, 6, 4, 2, 4));

--- a/test/test_user_defined_types.cpp
+++ b/test/test_user_defined_types.cpp
@@ -67,15 +67,13 @@ BOOST_COMPUTE_FUNCTION(bool, compare_UDD_device, (UDD lhs, UDD rhs),
     return lhs.a < rhs.a;
 });
 
+#include "check_macros.hpp"
+#include "context_setup.hpp"
+
 // see: issue #11 (https://github.com/boostorg/compute/issues/11)
 BOOST_AUTO_TEST_CASE(issue_11)
 {
-    // get default device and setup context
-    compute::device gpu = compute::system::default_device();
-    compute::context context(gpu);
-    compute::command_queue queue(context, gpu);
-
-    if(gpu.vendor() == "NVIDIA" && gpu.platform().name() == "Apple"){
+    if(device.vendor() == "NVIDIA" && device.platform().name() == "Apple"){
         // FIXME: this test currently segfaults on NVIDIA GPUs on Apple
         std::cerr << "skipping issue test on NVIDIA GPU on Apple platform" << std::endl;
         return;
@@ -120,3 +118,5 @@ BOOST_AUTO_TEST_CASE(issue_11)
         BOOST_CHECK_EQUAL(tmp[i], host_vector[i]);
     }
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -38,24 +38,24 @@ BOOST_AUTO_TEST_CASE(concept_check)
 
 BOOST_AUTO_TEST_CASE(size)
 {
-    bc::vector<int> empty_vector;
+    bc::vector<int> empty_vector(context);
     BOOST_CHECK_EQUAL(empty_vector.size(), size_t(0));
     BOOST_CHECK_EQUAL(empty_vector.empty(), true);
 
-    bc::vector<int> int_vector(10);
+    bc::vector<int> int_vector(10, context);
     BOOST_CHECK_EQUAL(int_vector.size(), size_t(10));
     BOOST_CHECK_EQUAL(int_vector.empty(), false);
 }
 
 BOOST_AUTO_TEST_CASE(resize)
 {
-    bc::vector<int> int_vector(10);
+    bc::vector<int> int_vector(10, context);
     BOOST_CHECK_EQUAL(int_vector.size(), size_t(10));
 
-    int_vector.resize(20);
+    int_vector.resize(20, queue);
     BOOST_CHECK_EQUAL(int_vector.size(), size_t(20));
 
-    int_vector.resize(5);
+    int_vector.resize(5, queue);
     BOOST_CHECK_EQUAL(int_vector.size(), size_t(5));
 }
 
@@ -75,21 +75,21 @@ BOOST_AUTO_TEST_CASE(array_operator)
 BOOST_AUTO_TEST_CASE(front_and_back)
 {
     int int_data[] = { 1, 2, 3, 4, 5 };
-    bc::vector<int> int_vector(5);
-    bc::copy(int_data, int_data + 5, int_vector.begin());
-    bc::system::finish();
+    bc::vector<int> int_vector(5, context);
+    bc::copy(int_data, int_data + 5, int_vector.begin(), queue);
+    queue.finish();
     BOOST_CHECK_EQUAL(int_vector.front(), 1);
     BOOST_CHECK_EQUAL(int_vector.back(), 5);
 
-    bc::fill(int_vector.begin(), int_vector.end(), 10);
-    bc::system::finish();
+    bc::fill(int_vector.begin(), int_vector.end(), 10, queue);
+    queue.finish();
     BOOST_CHECK_EQUAL(int_vector.front(), 10);
     BOOST_CHECK_EQUAL(int_vector.back(), 10);
 
     float float_data[] = { 1.1f, 2.2f, 3.3f, 4.4f, 5.5f };
-    bc::vector<float> float_vector(5);
-    bc::copy(float_data, float_data + 5, float_vector.begin());
-    bc::system::finish();
+    bc::vector<float> float_vector(5, context);
+    bc::copy(float_data, float_data + 5, float_vector.begin(), queue);
+    queue.finish();
     BOOST_CHECK_EQUAL(float_vector.front(), 1.1f);
     BOOST_CHECK_EQUAL(float_vector.back(), 5.5f);
 }
@@ -102,40 +102,41 @@ BOOST_AUTO_TEST_CASE(host_iterator_constructor)
     host_vector.push_back(30);
     host_vector.push_back(40);
 
-    bc::vector<int> device_vector(host_vector.begin(), host_vector.end());
+    bc::vector<int> device_vector(host_vector.begin(), host_vector.end(),
+                                  queue);
     CHECK_RANGE_EQUAL(int, 4, device_vector, (10, 20, 30, 40));
 }
 
 BOOST_AUTO_TEST_CASE(device_iterator_constructor)
 {
     int data[] = { 1, 5, 10, 15 };
-    bc::vector<int> a(data, data + 4);
+    bc::vector<int> a(data, data + 4, queue);
     CHECK_RANGE_EQUAL(int, 4, a, (1, 5, 10, 15));
 
-    bc::vector<int> b(a.begin(), a.end());
+    bc::vector<int> b(a.begin(), a.end(), queue);
     CHECK_RANGE_EQUAL(int, 4, b, (1, 5, 10, 15));
 }
 
 BOOST_AUTO_TEST_CASE(push_back)
 {
-    bc::vector<int> vector;
+    bc::vector<int> vector(context);
     BOOST_VERIFY(vector.empty());
 
-    vector.push_back(12);
+    vector.push_back(12, queue);
     BOOST_VERIFY(!vector.empty());
     BOOST_CHECK_EQUAL(vector.size(), size_t(1));
     CHECK_RANGE_EQUAL(int, 1, vector, (12));
 
-    vector.push_back(24);
+    vector.push_back(24, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(2));
     CHECK_RANGE_EQUAL(int, 2, vector, (12, 24));
 
-    vector.push_back(36);
+    vector.push_back(36, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(3));
     CHECK_RANGE_EQUAL(int, 3, vector, (12, 24, 36));
 
     for(int i = 0; i < 100; i++){
-        vector.push_back(i);
+        vector.push_back(i, queue);
     }
     BOOST_CHECK_EQUAL(vector.size(), size_t(103));
     BOOST_CHECK_EQUAL(vector[0], 12);
@@ -146,10 +147,10 @@ BOOST_AUTO_TEST_CASE(push_back)
 
 BOOST_AUTO_TEST_CASE(at)
 {
-    bc::vector<int> vector;
-    vector.push_back(1);
-    vector.push_back(2);
-    vector.push_back(3);
+    bc::vector<int> vector(context);
+    vector.push_back(1, queue);
+    vector.push_back(2, queue);
+    vector.push_back(3, queue);
     BOOST_CHECK_EQUAL(vector.at(0), 1);
     BOOST_CHECK_EQUAL(vector.at(1), 2);
     BOOST_CHECK_EQUAL(vector.at(2), 3);
@@ -159,22 +160,22 @@ BOOST_AUTO_TEST_CASE(at)
 BOOST_AUTO_TEST_CASE(erase)
 {
     int data[] = { 1, 2, 5, 7, 9 };
-    bc::vector<int> vector(data, data + 5);
-    bc::system::finish();
+    bc::vector<int> vector(data, data + 5, queue);
+    queue.finish();
     BOOST_CHECK_EQUAL(vector.size(), 5);
 
-    vector.erase(vector.begin() + 1);
+    vector.erase(vector.begin() + 1, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(4));
     CHECK_RANGE_EQUAL(int, 4, vector, (1, 5, 7, 9));
 
-    vector.erase(vector.begin() + 2, vector.end());
+    vector.erase(vector.begin() + 2, vector.end(), queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(2));
     CHECK_RANGE_EQUAL(int, 2, vector, (1, 5));
 }
 
 BOOST_AUTO_TEST_CASE(max_size)
 {
-    bc::vector<int> vector(100);
+    bc::vector<int> vector(100, context);
     BOOST_CHECK_EQUAL(vector.size(), size_t(100));
     BOOST_VERIFY(vector.max_size() > vector.size());
 }
@@ -208,27 +209,27 @@ BOOST_AUTO_TEST_CASE(vector_double)
         return;
     }
 
-    bc::vector<double> vector;
-    vector.push_back(1.21);
-    vector.push_back(3.14);
-    vector.push_back(7.89);
+    bc::vector<double> vector(context);
+    vector.push_back(1.21, queue);
+    vector.push_back(3.14, queue);
+    vector.push_back(7.89, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(3));
     CHECK_RANGE_EQUAL(double, 3, vector, (1.21, 3.14, 7.89));
 
-    bc::vector<double> other = vector;
+    bc::vector<double> other(vector.begin(), vector.end(), queue);
     CHECK_RANGE_EQUAL(double, 3, other, (1.21, 3.14, 7.89));
 
-    bc::fill(other.begin(), other.end(), 8.95);
+    bc::fill(other.begin(), other.end(), 8.95, queue);
     CHECK_RANGE_EQUAL(double, 3, other, (8.95, 8.95, 8.95));
 }
 
 BOOST_AUTO_TEST_CASE(vector_iterator)
 {
-    bc::vector<int> vector;
-    vector.push_back(2);
-    vector.push_back(4);
-    vector.push_back(6);
-    vector.push_back(8);
+    bc::vector<int> vector(context);
+    vector.push_back(2, queue);
+    vector.push_back(4, queue);
+    vector.push_back(6, queue);
+    vector.push_back(8, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(4));
     BOOST_CHECK_EQUAL(vector[0], 2);
     BOOST_CHECK_EQUAL(*vector.begin(), 2);
@@ -247,23 +248,23 @@ BOOST_AUTO_TEST_CASE(vector_iterator)
 BOOST_AUTO_TEST_CASE(vector_erase_remove)
 {
     int data[] = { 2, 6, 3, 4, 2, 4, 5, 6, 1 };
-    bc::vector<int> vector(data, data + 9);
+    bc::vector<int> vector(data, data + 9, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(9));
 
     // remove 4's
-    vector.erase(bc::remove(vector.begin(), vector.end(), 4), vector.end());
+    vector.erase(bc::remove(vector.begin(), vector.end(), 4, queue), vector.end());
     BOOST_CHECK_EQUAL(vector.size(), size_t(7));
-    BOOST_VERIFY(bc::find(vector.begin(), vector.end(), 4) == vector.end());
+    BOOST_VERIFY(bc::find(vector.begin(), vector.end(), 4, queue) == vector.end());
 
     // remove 2's
-    vector.erase(bc::remove(vector.begin(), vector.end(), 2), vector.end());
+    vector.erase(bc::remove(vector.begin(), vector.end(), 2, queue), vector.end());
     BOOST_CHECK_EQUAL(vector.size(), size_t(5));
-    BOOST_VERIFY(bc::find(vector.begin(), vector.end(), 2) == vector.end());
+    BOOST_VERIFY(bc::find(vector.begin(), vector.end(), 2, queue) == vector.end());
 
     // remove 6's
-    vector.erase(bc::remove(vector.begin(), vector.end(), 6), vector.end());
+    vector.erase(bc::remove(vector.begin(), vector.end(), 6, queue), vector.end());
     BOOST_CHECK_EQUAL(vector.size(), size_t(3));
-    BOOST_VERIFY(bc::find(vector.begin(), vector.end(), 6) == vector.end());
+    BOOST_VERIFY(bc::find(vector.begin(), vector.end(), 6, queue) == vector.end());
 
     // check the rest of the values
     CHECK_RANGE_EQUAL(int, 3, vector, (3, 5, 1));

--- a/test/test_zip_iterator.cpp
+++ b/test/test_zip_iterator.cpp
@@ -133,7 +133,8 @@ BOOST_AUTO_TEST_CASE(copy)
                 float_vector.end()
             )
         ),
-        tuple_vector.begin()
+        tuple_vector.begin(),
+        queue
     );
 
     // copy tuple vector to host
@@ -142,7 +143,8 @@ BOOST_AUTO_TEST_CASE(copy)
     boost::compute::copy(
         tuple_vector.begin(),
         tuple_vector.end(),
-        host_vector.begin()
+        host_vector.begin(),
+        queue
     );
 
     // check tuple values


### PR DESCRIPTION
This adds missing queue and context parameters to functions calls in tests. I've also changed some tests to use queue, context and device from `context_setup.hpp`.