### PR TITLE
Fixing problems reported in Boost Inspection Report

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,12 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2013 Kyle Lutz <kyle.r.lutz@gmail.com>
+# 
+#  Distributed under the Boost Software License, Version 1.0
+#  See accompanying file LICENSE_1_0.txt or copy at
+#  http://www.boost.org/LICENSE_1_0.txt
+#
+# ---------------------------------------------------------------------------
+
 cmake_minimum_required(VERSION 2.8)
 
 project(BoostCompute)

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -1,3 +1,12 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2013 Kyle Lutz <kyle.r.lutz@gmail.com>
+# 
+#  Distributed under the Boost Software License, Version 1.0
+#  See accompanying file LICENSE_1_0.txt or copy at
+#  http://www.boost.org/LICENSE_1_0.txt
+#
+# ---------------------------------------------------------------------------
+
 import quickbook ;
 import boostbook ;
 import doxygen ;

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,3 +1,12 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2013-2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+# 
+#  Distributed under the Boost Software License, Version 1.0
+#  See accompanying file LICENSE_1_0.txt or copy at
+#  http://www.boost.org/LICENSE_1_0.txt
+#
+# ---------------------------------------------------------------------------
+
 include_directories(../include)
 
 set(EXAMPLES

--- a/example/opencv_convolution.cpp
+++ b/example/opencv_convolution.cpp
@@ -36,7 +36,7 @@ const char source[] = BOOST_COMPUTE_STRINGIZE_SOURCE (
                                   CLK_ADDRESS_CLAMP_TO_EDGE   |
                                   CLK_FILTER_NEAREST;
 
-        // Store each work-item’s unique row and column
+        // Store each work-item's unique row and column
         int x   = get_global_id(0);
         int y   = get_global_id(1);
 
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
     {
         std::cout<<"Build Error: "<<std::endl
                  <<filter_program.build_log();
-	return -1;
+    return -1;
     }
 
     // create fliter kernel and set arguments

--- a/example/opencv_optical_flow.cpp
+++ b/example/opencv_optical_flow.cpp
@@ -45,8 +45,8 @@ const char source[] = BOOST_COMPUTE_STRINGIZE_SOURCE (
         float4 previous_pixel   = read_imagef(previous_image,
                                               sampler,
                                               coords);
-        int2 x1 	= (int2)(offset, 0.f);
-        int2 y1 	= (int2)(0.f, offset);
+        int2 x1     = (int2)(offset, 0.f);
+        int2 y1     = (int2)(0.f, offset);
 
         //get the difference
         float4 curdif = previous_pixel - current_pixel;

--- a/example/qimage_blur.cpp
+++ b/example/qimage_blur.cpp
@@ -1,3 +1,13 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
 #include <iostream>
 #include <algorithm>
 

--- a/example/simple_moving_average.cpp
+++ b/example/simple_moving_average.cpp
@@ -63,8 +63,8 @@ bool check_results(const std::vector<float>& values, const std::vector<float>& s
     bool res = true;
     for(int idx = 0 ; idx < size ; ++idx)
     {
-        int start = std::max(idx - semiWidth,0);
-        int end = std::min(idx + semiWidth,size-1);
+        int start = (std::max)(idx - semiWidth,0);
+        int end = (std::min)(idx + semiWidth,size-1);
         float res = 0;
         for(int j = start ; j <= end ; ++j)
         {

--- a/include/boost/compute/algorithm/accumulate.hpp
+++ b/include/boost/compute/algorithm/accumulate.hpp
@@ -85,13 +85,13 @@ BOOST_PP_SEQ_FOR_EACH(
 template<class T>
 inline bool can_accumulate_with_reduce(T init, min<T>)
 {
-    return init == std::numeric_limits<T>::max();
+    return init == (std::numeric_limits<T>::max)();
 }
 
 template<class T>
 inline bool can_accumulate_with_reduce(T init, max<T>)
 {
-    return init == std::numeric_limits<T>::min();
+    return init == (std::numeric_limits<T>::min)();
 }
 
 #undef BOOST_COMPUTE_DETAIL_DECLARE_CAN_ACCUMULATE_WITH_REDUCE

--- a/include/boost/compute/random/normal_distribution.hpp
+++ b/include/boost/compute/random/normal_distribution.hpp
@@ -62,13 +62,13 @@ public:
     }
 
     /// Returns the minimum value of the distribution.
-    result_type min() const
+    result_type min BOOST_PREVENT_MACRO_SUBSTITUTION () const
     {
         return -std::numeric_limits<RealType>::infinity();
     }
 
     /// Returns the maximum value of the distribution.
-    result_type max() const
+    result_type max BOOST_PREVENT_MACRO_SUBSTITUTION () const
     {
         return std::numeric_limits<RealType>::infinity();
     }

--- a/include/boost/compute/random/threefry_engine.hpp
+++ b/include/boost/compute/random/threefry_engine.hpp
@@ -1,34 +1,12 @@
-// Added By: Muhammad Junaid Muzammil <mjunaidmuzammil@gmail.com>
-// Copyright 2010-2012, D. E. Shaw Research.
-// All rights reserved.
-
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-
-// * Redistributions of source code must retain the above copyright
-//   notice, this list of conditions, and the following disclaimer.
-
-// * Redistributions in binary form must reproduce the above copyright
-//   notice, this list of conditions, and the following disclaimer in the
-//   documentation and/or other materials provided with the distribution.
-
-// * Neither the name of D. E. Shaw Research nor the names of its
-//   contributors may be used to endorse or promote products derived from
-//   this software without specific prior written permission.
-
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Muhammad Junaid Muzammil <mjunaidmuzammil@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
 
 #ifndef BOOST_COMPUTE_RANDOM_THREEFRY_HPP
 #define BOOST_COMPUTE_RANDOM_THREEFRY_HPP
@@ -97,6 +75,35 @@ private:
         std::string cache_key =
             std::string("threefry_engine_32x2");
 
+        // Copyright 2010-2012, D. E. Shaw Research.
+        // All rights reserved.
+
+        // Redistribution and use in source and binary forms, with or without
+        // modification, are permitted provided that the following conditions are
+        // met:
+
+        // * Redistributions of source code must retain the above copyright
+        //   notice, this list of conditions, and the following disclaimer.
+
+        // * Redistributions in binary form must reproduce the above copyright
+        //   notice, this list of conditions, and the following disclaimer in the
+        //   documentation and/or other materials provided with the distribution.
+
+        // * Neither the name of D. E. Shaw Research nor the names of its
+        //   contributors may be used to endorse or promote products derived from
+        //   this software without specific prior written permission.
+
+        // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+        // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+        // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+        // A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+        // OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+        // SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+        // LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+        // DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+        // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+        // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         const char source[] =
             "#define THREEFRY2x32_DEFAULT_ROUNDS 20\n"
             "#define SKEIN_KS_PARITY_32 0x1BD11BDA\n"

--- a/include/boost/compute/random/uniform_int_distribution.hpp
+++ b/include/boost/compute/random/uniform_int_distribution.hpp
@@ -40,7 +40,7 @@ public:
     /// Creates a new uniform distribution producing numbers in the range
     /// [\p a, \p b].
     explicit uniform_int_distribution(IntType a = 0,
-                                      IntType b = std::numeric_limits<IntType>::max())
+                                      IntType b = (std::numeric_limits<IntType>::max)())
         : m_a(a),
           m_b(b)
     {

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,3 +1,12 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2013 Kyle Lutz <kyle.r.lutz@gmail.com>
+# 
+#  Distributed under the Boost Software License, Version 1.0
+#  See accompanying file LICENSE_1_0.txt or copy at
+#  http://www.boost.org/LICENSE_1_0.txt
+#
+# ---------------------------------------------------------------------------
+
 include_directories(../include)
 
 set(PERF_BOOST_COMPONENTS system timer chrono program_options)

--- a/perf/perf.py
+++ b/perf/perf.py
@@ -1,5 +1,12 @@
 #!/usr/bin/python
 
+# Copyright (c) 2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+# Distributed under the Boost Software License, Version 1.0
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+#
+# See http://boostorg.github.com/compute for more information.
+
 # driver script for boost.compute benchmarking. will run a
 # benchmark for a given function (e.g. accumulate, sort).
 

--- a/perf/perf_accumulate.cpp
+++ b/perf/perf_accumulate.cpp
@@ -58,7 +58,7 @@ void tune_accumulate(const compute::vector<T>& data,
     const compute::uint_ tpbs[] = { 4, 8, 16, 32, 64, 128, 256, 512, 1024 };
     const compute::uint_ vpts[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
 
-    double min_time = std::numeric_limits<double>::max();
+    double min_time = (std::numeric_limits<double>::max)();
     compute::uint_ best_tpb = 0;
     compute::uint_ best_vpt = 0;
 

--- a/perf/perf_exclusive_scan.cpp
+++ b/perf/perf_exclusive_scan.cpp
@@ -1,3 +1,13 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Benoit
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
 #include <algorithm>
 #include <iostream>
 #include <numeric>

--- a/perf/perf_saxpy.cpp
+++ b/perf/perf_saxpy.cpp
@@ -76,7 +76,7 @@ void tune_saxpy(const compute::vector<T>& x,
     const compute::uint_ tpbs[] = { 4, 8, 16, 32, 64, 128, 256, 512, 1024 };
     const compute::uint_ vpts[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
 
-    double min_time = std::numeric_limits<double>::max();
+    double min_time = (std::numeric_limits<double>::max)();
     compute::uint_ best_tpb = 0;
     compute::uint_ best_vpt = 0;
 

--- a/perf/perf_sort.cpp
+++ b/perf/perf_sort.cpp
@@ -59,7 +59,7 @@ void tune_sort(const std::vector<T>& data,
 
     const compute::uint_ tpbs[] = { 32, 64, 128, 256, 512, 1024 };
 
-    double min_time = std::numeric_limits<double>::max();
+    double min_time = (std::numeric_limits<double>::max)();
     compute::uint_ best_tpb = 0;
 
     for(size_t i = 0; i < sizeof(tpbs) / sizeof(*tpbs); i++){

--- a/perf/perf_tbb_merge.cpp
+++ b/perf/perf_tbb_merge.cpp
@@ -17,7 +17,7 @@ struct ParallelMergeRange {
     Iterator out;               // where to put merged sequence
     bool empty()   const {return (end1-begin1)+(end2-begin2)==0;}
     bool is_divisible() const {
-        return std::min( end1-begin1, end2-begin2 ) > grainsize;
+        return (std::min)( end1-begin1, end2-begin2 ) > grainsize;
     }
     ParallelMergeRange( ParallelMergeRange& r, split ) {
         if( r.end1-r.begin1 < r.end2-r.begin2 ) {

--- a/perf/perf_tbb_merge.cpp
+++ b/perf/perf_tbb_merge.cpp
@@ -1,3 +1,13 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
 #include <algorithm>
 #include <iostream>
 #include <vector>

--- a/perf/perf_thrust_exclusive_scan.cu
+++ b/perf/perf_thrust_exclusive_scan.cu
@@ -1,5 +1,5 @@
 //---------------------------------------------------------------------------//
-// Copyright (c) 2013-2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+// Copyright (c) 2014 Benoit
 //
 // Distributed under the Boost Software License, Version 1.0
 // See accompanying file LICENSE_1_0.txt or copy at

--- a/perf/perfdoc.py
+++ b/perf/perfdoc.py
@@ -1,5 +1,12 @@
 #!/usr/bin/python
 
+# Copyright (c) 2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+# Distributed under the Boost Software License, Version 1.0
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+#
+# See http://boostorg.github.com/compute for more information.
+
 import os
 import sys
 import pylab

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,12 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2013 Kyle Lutz <kyle.r.lutz@gmail.com>
+# 
+#  Distributed under the Boost Software License, Version 1.0
+#  See accompanying file LICENSE_1_0.txt or copy at
+#  http://www.boost.org/LICENSE_1_0.txt
+#
+# ---------------------------------------------------------------------------
+
 include_directories(../include)
 
 set(BOOST_COMPONENTS unit_test_framework)

--- a/test/context_setup.hpp
+++ b/test/context_setup.hpp
@@ -1,3 +1,13 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2013-2014 Denis Demidov
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
 #ifndef BOOST_COMPUTE_TEST_CONTEXT_SETUP_HPP
 #define BOOST_COMPUTE_TEST_CONTEXT_SETUP_HPP
 

--- a/test/extra/CMakeLists.txt
+++ b/test/extra/CMakeLists.txt
@@ -1,3 +1,12 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+# 
+#  Distributed under the Boost Software License, Version 1.0
+#  See accompanying file LICENSE_1_0.txt or copy at
+#  http://www.boost.org/LICENSE_1_0.txt
+#
+# ---------------------------------------------------------------------------
+
 # include local test headers
 include_directories(..)
 

--- a/test/opencl_version_check.hpp
+++ b/test/opencl_version_check.hpp
@@ -1,3 +1,13 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Denis Demidov
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
 #ifndef BOOST_COMPUTE_TEST_OPENCL_VERSION_CHECK_HPP
 #define BOOST_COMPUTE_TEST_OPENCL_VERSION_CHECK_HPP
 

--- a/test/test_accumulate.cpp
+++ b/test/test_accumulate.cpp
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(min_and_max)
 
     BOOST_COMPUTE_FUNCTION(int2_, min_and_max, (int2_ accumulator, const int value),
     {
-        return (int2)(min(accumulator.x, value), max(accumulator.y, value));
+        return (int2)((min)(accumulator.x, value), (max)(accumulator.y, value));
     });
 
     int2_ result = boost::compute::accumulate(
@@ -230,12 +230,12 @@ BOOST_AUTO_TEST_CASE(min_max)
     using ::boost::compute::max;
 
     float min_value = boost::compute::accumulate(
-        vec.begin(), vec.end(), std::numeric_limits<float>::max(), min<float>(), queue
+        vec.begin(), vec.end(), (std::numeric_limits<float>::max)(), min<float>(), queue
     );
     BOOST_CHECK_EQUAL(min_value, 0.1f);
 
     float max_value = boost::compute::accumulate(
-        vec.begin(), vec.end(), std::numeric_limits<float>::min(), max<float>(), queue
+        vec.begin(), vec.end(), (std::numeric_limits<float>::min()), max<float>(), queue
     );
     BOOST_CHECK_EQUAL(max_value, 9.6f);
 

--- a/test/test_is_permutation.cpp
+++ b/test/test_is_permutation.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(is_permutation_int)
     bc::vector<bc::int_> vector2(dataset2, dataset2 + 5, queue);
 
     bool result =
-    	bc::is_permutation(vector1.begin(), vector1.begin() + 5,
+        bc::is_permutation(vector1.begin(), vector1.begin() + 5,
                            vector2.begin(), vector2.begin() + 5, queue);
 
     BOOST_VERIFY(result == true);

--- a/test/test_next_permutation.cpp
+++ b/test/test_next_permutation.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(next_permutation_int)
     bc::vector<bc::int_> vector(dataset, dataset + 5, queue);
 
     bool result =
-    	bc::next_permutation(vector.begin(), vector.begin() + 5, queue);
+        bc::next_permutation(vector.begin(), vector.begin() + 5, queue);
 
     CHECK_RANGE_EQUAL(int, 5, vector, (1, 3, 4, 5, 2));
     BOOST_VERIFY(result == true);
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(next_permutation_string)
     bc::vector<bc::char_> vector(dataset, dataset + 4, queue);
 
     bool result =
-    	bc::next_permutation(vector.begin(), vector.begin() + 4, queue);
+        bc::next_permutation(vector.begin(), vector.begin() + 4, queue);
 
     CHECK_RANGE_EQUAL(char, 4, vector, ('a', 'a', 'b', 'a'));
     BOOST_VERIFY(result == true);

--- a/test/test_prev_permutation.cpp
+++ b/test/test_prev_permutation.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(prev_permutation_int)
     bc::vector<bc::int_> vector(dataset, dataset + 5, queue);
 
     bool result =
-    	bc::prev_permutation(vector.begin(), vector.begin() + 5, queue);
+        bc::prev_permutation(vector.begin(), vector.begin() + 5, queue);
 
     CHECK_RANGE_EQUAL(int, 5, vector, (1, 3, 2, 5, 4));
     BOOST_VERIFY(result == true);
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(prev_permutation_string)
     bc::vector<bc::char_> vector(dataset, dataset + 4, queue);
 
     bool result =
-    	bc::prev_permutation(vector.begin(), vector.begin() + 4, queue);
+        bc::prev_permutation(vector.begin(), vector.begin() + 4, queue);
 
     CHECK_RANGE_EQUAL(char, 4, vector, ('a', 'b', 'a', 'a'));
     BOOST_VERIFY(result == true);


### PR DESCRIPTION
I fixed some of problems reported in [Boost Inspection Report for 1.59 beta rc1](http://boost.cowic.de/rc/docs-inspect-develop.html#compute). I could not fix all of them due to problems/issues/doubts I described below.

I fixed violations of Boost min/max guidelines, converted tabs into spaces, added missing license information and copyrights (based on who and when created the file). I'm not sure how to correctly add missing license and copyright info to .qbk files. 

I fixed one non-ASCII character in `/example/opencv_convolution.cpp`, but I did not change names with non-ASCII character/s as I don't think it would be right.

A few of Boost marcos used in Boost.Compute are deprecated, some since 1.50, some since 1.51. Boost.Compute requires Boost in version 1.48 or later. New macros that replaced deprecated ones (see [Boost macros](http://www.boost.org/doc/libs/1_58_0/libs/config/doc/html/boost_config/boost_macro_reference.html)) are - of course - not present in 1.48, so if Boost.Compute should work with 1.48 we need to keep these deprecated macros. Otherwise, required Boost version should be set to 1.51. 

( I also check that in `compute/include/boost/compute/config.hpp` internal macros like BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES are defined, but still sometimes in the code original macros from Boost are used, so that should be fixed too? )