### PR TITLE
Fixing problems reported in Boost Inspection Report

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,12 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2013 Kyle Lutz <kyle.r.lutz@gmail.com>
+# 
+#  Distributed under the Boost Software License, Version 1.0
+#  See accompanying file LICENSE_1_0.txt or copy at
+#  http://www.boost.org/LICENSE_1_0.txt
+#
+# ---------------------------------------------------------------------------
+
 cmake_minimum_required(VERSION 2.8)
 
 project(BoostCompute)

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -1,3 +1,12 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2013 Kyle Lutz <kyle.r.lutz@gmail.com>
+# 
+#  Distributed under the Boost Software License, Version 1.0
+#  See accompanying file LICENSE_1_0.txt or copy at
+#  http://www.boost.org/LICENSE_1_0.txt
+#
+# ---------------------------------------------------------------------------
+
 import quickbook ;
 import boostbook ;
 import doxygen ;

--- a/doc/advanced_topics.qbk
+++ b/doc/advanced_topics.qbk
@@ -1,3 +1,11 @@
+[/===========================================================================
+ Copyright (c) 2013-2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+
+ Distributed under the Boost Software License, Version 1.0
+ See accompanying file LICENSE_1_0.txt or copy at
+ http://www.boost.org/LICENSE_1_0.txt
+=============================================================================/]
+
 [section Advanced Topics]
 
 The following topics show advanced features of the Boost Compute library.

--- a/doc/compute.qbk
+++ b/doc/compute.qbk
@@ -1,3 +1,11 @@
+[/===========================================================================
+ Copyright (c) 2013-2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+
+ Distributed under the Boost Software License, Version 1.0
+ See accompanying file LICENSE_1_0.txt or copy at
+ http://www.boost.org/LICENSE_1_0.txt
+=============================================================================/]
+
 [library Boost.Compute
     [quickbook 1.5]
     [authors [Lutz, Kyle]]

--- a/doc/design.qbk
+++ b/doc/design.qbk
@@ -1,3 +1,11 @@
+[/===========================================================================
+ Copyright (c) 2013-2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+
+ Distributed under the Boost Software License, Version 1.0
+ See accompanying file LICENSE_1_0.txt or copy at
+ http://www.boost.org/LICENSE_1_0.txt
+=============================================================================/]
+
 [section:design Design]
 
 [section Library Architecture]

--- a/doc/faq.qbk
+++ b/doc/faq.qbk
@@ -1,3 +1,11 @@
+[/===========================================================================
+ Copyright (c) 2013-2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+
+ Distributed under the Boost Software License, Version 1.0
+ See accompanying file LICENSE_1_0.txt or copy at
+ http://www.boost.org/LICENSE_1_0.txt
+=============================================================================/]
+
 [section:faq Frequently Asked Questions]
 
 [h3 How do I report a bug, issue, or feature request?]

--- a/doc/getting_started.qbk
+++ b/doc/getting_started.qbk
@@ -1,3 +1,11 @@
+[/===========================================================================
+ Copyright (c) 2013-2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+
+ Distributed under the Boost Software License, Version 1.0
+ See accompanying file LICENSE_1_0.txt or copy at
+ http://www.boost.org/LICENSE_1_0.txt
+=============================================================================/]
+
 [section:getting_started Getting Started]
 
 [section Downloading]

--- a/doc/interop.qbk
+++ b/doc/interop.qbk
@@ -1,3 +1,11 @@
+[/===========================================================================
+ Copyright (c) 2013-2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+
+ Distributed under the Boost Software License, Version 1.0
+ See accompanying file LICENSE_1_0.txt or copy at
+ http://www.boost.org/LICENSE_1_0.txt
+=============================================================================/]
+
 [section:interop Interoperability]
 
 Boost.Compute provides a number of facilities to ease interoperability with

--- a/doc/introduction.qbk
+++ b/doc/introduction.qbk
@@ -1,3 +1,11 @@
+[/===========================================================================
+ Copyright (c) 2013-2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+
+ Distributed under the Boost Software License, Version 1.0
+ See accompanying file LICENSE_1_0.txt or copy at
+ http://www.boost.org/LICENSE_1_0.txt
+=============================================================================/]
+
 [section:introduction Introduction]
 
 The Boost Compute library provides a C++ interface to multi-core CPU and GPGPU

--- a/doc/performance.qbk
+++ b/doc/performance.qbk
@@ -1,3 +1,11 @@
+[/===========================================================================
+ Copyright (c) 2013-2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+
+ Distributed under the Boost Software License, Version 1.0
+ See accompanying file LICENSE_1_0.txt or copy at
+ http://www.boost.org/LICENSE_1_0.txt
+=============================================================================/]
+
 [section:performance Performance]
 
 The following tests were run with an NVIDIA Tesla K40c GPU on a system

--- a/doc/platforms_and_compilers.qbk
+++ b/doc/platforms_and_compilers.qbk
@@ -1,3 +1,11 @@
+[/===========================================================================
+ Copyright (c) 2013-2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+
+ Distributed under the Boost Software License, Version 1.0
+ See accompanying file LICENSE_1_0.txt or copy at
+ http://www.boost.org/LICENSE_1_0.txt
+=============================================================================/]
+
 [section:platforms_and_compilers Platforms and Compilers]
 
 Boost.Compute has been tested on the following:

--- a/doc/porting_guide.qbk
+++ b/doc/porting_guide.qbk
@@ -1,3 +1,11 @@
+[/===========================================================================
+ Copyright (c) 2013-2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+
+ Distributed under the Boost Software License, Version 1.0
+ See accompanying file LICENSE_1_0.txt or copy at
+ http://www.boost.org/LICENSE_1_0.txt
+=============================================================================/]
+
 [section Porting Guide]
 
 [section OpenCL API]

--- a/doc/reference.qbk
+++ b/doc/reference.qbk
@@ -1,3 +1,11 @@
+[/===========================================================================
+ Copyright (c) 2013-2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+
+ Distributed under the Boost Software License, Version 1.0
+ See accompanying file LICENSE_1_0.txt or copy at
+ http://www.boost.org/LICENSE_1_0.txt
+=============================================================================/]
+
 [section:reference Reference]
 
 [section API Overview]

--- a/doc/tutorial.qbk
+++ b/doc/tutorial.qbk
@@ -1,3 +1,11 @@
+[/===========================================================================
+ Copyright (c) 2013-2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+
+ Distributed under the Boost Software License, Version 1.0
+ See accompanying file LICENSE_1_0.txt or copy at
+ http://www.boost.org/LICENSE_1_0.txt
+=============================================================================/]
+
 [section:tutorial Tutorial]
 
 [section Hello World]

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,3 +1,12 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2013-2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+# 
+#  Distributed under the Boost Software License, Version 1.0
+#  See accompanying file LICENSE_1_0.txt or copy at
+#  http://www.boost.org/LICENSE_1_0.txt
+#
+# ---------------------------------------------------------------------------
+
 include_directories(../include)
 
 set(EXAMPLES

--- a/example/opencv_convolution.cpp
+++ b/example/opencv_convolution.cpp
@@ -36,7 +36,7 @@ const char source[] = BOOST_COMPUTE_STRINGIZE_SOURCE (
                                   CLK_ADDRESS_CLAMP_TO_EDGE   |
                                   CLK_FILTER_NEAREST;
 
-        // Store each work-item’s unique row and column
+        // Store each work-item's unique row and column
         int x   = get_global_id(0);
         int y   = get_global_id(1);
 
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
     {
         std::cout<<"Build Error: "<<std::endl
                  <<filter_program.build_log();
-	return -1;
+    return -1;
     }
 
     // create fliter kernel and set arguments

--- a/example/opencv_optical_flow.cpp
+++ b/example/opencv_optical_flow.cpp
@@ -45,8 +45,8 @@ const char source[] = BOOST_COMPUTE_STRINGIZE_SOURCE (
         float4 previous_pixel   = read_imagef(previous_image,
                                               sampler,
                                               coords);
-        int2 x1 	= (int2)(offset, 0.f);
-        int2 y1 	= (int2)(0.f, offset);
+        int2 x1     = (int2)(offset, 0.f);
+        int2 y1     = (int2)(0.f, offset);
 
         //get the difference
         float4 curdif = previous_pixel - current_pixel;

--- a/example/qimage_blur.cpp
+++ b/example/qimage_blur.cpp
@@ -1,3 +1,13 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
 #include <iostream>
 #include <algorithm>
 

--- a/example/simple_moving_average.cpp
+++ b/example/simple_moving_average.cpp
@@ -63,8 +63,8 @@ bool check_results(const std::vector<float>& values, const std::vector<float>& s
     bool res = true;
     for(int idx = 0 ; idx < size ; ++idx)
     {
-        int start = std::max(idx - semiWidth,0);
-        int end = std::min(idx + semiWidth,size-1);
+        int start = (std::max)(idx - semiWidth,0);
+        int end = (std::min)(idx + semiWidth,size-1);
         float res = 0;
         for(int j = start ; j <= end ; ++j)
         {

--- a/include/boost/compute/algorithm/accumulate.hpp
+++ b/include/boost/compute/algorithm/accumulate.hpp
@@ -85,13 +85,13 @@ BOOST_PP_SEQ_FOR_EACH(
 template<class T>
 inline bool can_accumulate_with_reduce(T init, min<T>)
 {
-    return init == std::numeric_limits<T>::max();
+    return init == (std::numeric_limits<T>::max)();
 }
 
 template<class T>
 inline bool can_accumulate_with_reduce(T init, max<T>)
 {
-    return init == std::numeric_limits<T>::min();
+    return init == (std::numeric_limits<T>::min)();
 }
 
 #undef BOOST_COMPUTE_DETAIL_DECLARE_CAN_ACCUMULATE_WITH_REDUCE

--- a/include/boost/compute/async/wait.hpp
+++ b/include/boost/compute/async/wait.hpp
@@ -18,7 +18,7 @@ namespace boost {
 namespace compute {
 namespace detail {
 
-#ifndef BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES
+#ifndef BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 template<class Event>
 inline void insert_events_variadic(wait_list &l, Event&& event)
 {
@@ -32,11 +32,11 @@ inline void insert_events_variadic(wait_list &l, Event&& event, Rest&&... rest)
 
     insert_events_variadic(l, std::forward<Rest>(rest)...);
 }
-#endif // BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES
+#endif // BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 
 } // end detail namespace
 
-#ifndef BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES
+#ifndef BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 /// Blocks until all events have completed. Events can either be \ref event
 /// objects or \ref future "future<T>" objects.
 ///
@@ -48,7 +48,7 @@ inline void wait_for_all(Events&&... events)
     detail::insert_events_variadic(l, std::forward<Events>(events)...);
     l.wait();
 }
-#endif // BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES
+#endif // BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 
 } // end compute namespace
 } // end boost namespace

--- a/include/boost/compute/config.hpp
+++ b/include/boost/compute/config.hpp
@@ -20,21 +20,22 @@
 #error Boost.Compute requires Boost version 1.48 or later
 #endif
 
-// the BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES macro is defined
+// the BOOST_COMPUTE_NO_VARIADIC_TEMPLATES macro is defined
 // if the compiler does not *fully* support variadic templates
-#if defined(BOOST_NO_VARIADIC_TEMPLATES) || \
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || \
+    defined(BOOST_NO_VARIADIC_TEMPLATES) || \
     (defined(__GNUC__) && !defined(__clang__) && \
      __GNUC__ == 4 && __GNUC_MINOR__ <= 6)
-  #define BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES
-#endif
+  #define BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
+#endif // BOOST_NO_CXX11_VARIADIC_TEMPLATES
 
-// the BOOST_COMPUTE_DETAIL_NO_STD_TUPLE macro is defined if the
+// the BOOST_COMPUTE_NO_STD_TUPLE macro is defined if the
 // compiler/stdlib does not support std::tuple
 #if defined(BOOST_NO_CXX11_HDR_TUPLE) || \
     defined(BOOST_NO_0X_HDR_TUPLE) || \
-    defined(BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES)
-  #define BOOST_COMPUTE_DETAIL_NO_STD_TUPLE
-#endif
+    defined(BOOST_COMPUTE_NO_VARIADIC_TEMPLATES)
+  #define BOOST_COMPUTE_NO_STD_TUPLE
+#endif // BOOST_NO_CXX11_HDR_TUPLE
 
 // defines BOOST_COMPUTE_CL_CALLBACK to the value of CL_CALLBACK
 // if it is defined (it was added in OpenCL 1.1). this is used to
@@ -55,5 +56,15 @@
     (defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || defined(BOOST_NO_RVALUE_REFERENCES))
 #  define BOOST_COMPUTE_NO_RVALUE_REFERENCES
 #endif // BOOST_NO_CXX11_RVALUE_REFERENCES
+
+#if defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST) || \
+    defined(BOOST_NO_0X_HDR_INITIALIZER_LIST)
+#  define BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
+#endif // BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+
+#if defined(BOOST_NO_CXX11_HDR_CHRONO) || \
+    defined(BOOST_NO_0X_HDR_CHRONO)
+#  define BOOST_COMPUTE_NO_HDR_CHRONO
+#endif // BOOST_NO_CXX11_HDR_CHRONO
 
 #endif // BOOST_COMPUTE_CONFIG_HPP

--- a/include/boost/compute/container/vector.hpp
+++ b/include/boost/compute/container/vector.hpp
@@ -20,8 +20,7 @@
 
 #include <boost/compute/config.hpp>
 
-#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST) && \
-    !defined(BOOST_NO_0X_HDR_INITIALIZER_LIST)
+#ifndef BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
 #include <initializer_list>
 #endif
 
@@ -214,8 +213,7 @@ public:
         ::boost::compute::copy(vector.begin(), vector.end(), begin(), queue);
     }
 
-    #if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST) && \
-        !defined(BOOST_NO_0X_HDR_INITIALIZER_LIST)
+    #ifndef BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
     vector(std::initializer_list<T> list,
            command_queue &queue = system::default_queue())
         : m_size(list.size()),
@@ -225,7 +223,7 @@ public:
 
         ::boost::compute::copy(list.begin(), list.end(), begin(), queue);
     }
-    #endif // !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+    #endif // BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
 
     vector<T>& operator=(const vector<T> &other)
     {

--- a/include/boost/compute/detail/duration.hpp
+++ b/include/boost/compute/detail/duration.hpp
@@ -13,7 +13,7 @@
 
 #include <boost/config.hpp>
 
-#if !defined(BOOST_NO_CXX11_HDR_CHRONO) && !defined(BOOST_NO_0X_HDR_CHRONO)
+#ifndef BOOST_COMPUTE_NO_HDR_CHRONO
 #include <chrono>
 #endif
 
@@ -23,7 +23,7 @@ namespace boost {
 namespace compute {
 namespace detail {
 
-#if !defined(BOOST_NO_CXX11_HDR_CHRONO) && !defined(BOOST_NO_0X_HDR_CHRONO)
+#ifndef BOOST_COMPUTE_NO_HDR_CHRONO
 template<class Rep, class Period>
 inline std::chrono::duration<Rep, Period>
 make_duration_from_nanoseconds(std::chrono::duration<Rep, Period>, size_t nanoseconds)
@@ -32,7 +32,7 @@ make_duration_from_nanoseconds(std::chrono::duration<Rep, Period>, size_t nanose
         std::chrono::nanoseconds(nanoseconds)
     );
 }
-#endif // BOOST_NO_CXX11_HDR_CHRONO
+#endif // BOOST_COMPUTE_NO_HDR_CHRONO
 
 template<class Rep, class Period>
 inline boost::chrono::duration<Rep, Period>

--- a/include/boost/compute/functional/bind.hpp
+++ b/include/boost/compute/functional/bind.hpp
@@ -207,7 +207,7 @@ struct bound_function
 
 } // end detail namespace
 
-#if !defined(BOOST_NO_VARIADIC_TEMPLATES) || defined(BOOST_COMPUTE_DOXYGEN_INVOKED)
+#if !defined(BOOST_COMPUTE_NO_VARIADIC_TEMPLATES) || defined(BOOST_COMPUTE_DOXYGEN_INVOKED)
 /// Returns a function wrapper which invokes \p f with \p args when called.
 ///
 /// For example, to generate a unary function object which returns \c true
@@ -253,7 +253,7 @@ bind(F f, A1 a1, A2 a2, A3 a3)
 
     return detail::bound_function<F, Args>(f, boost::make_tuple(a1, a2, a3));
 }
-#endif // BOOST_NO_VARIADIC_TEMPLATES
+#endif // BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 
 } // end compute namespace
 } // end boost namespace

--- a/include/boost/compute/kernel.hpp
+++ b/include/boost/compute/kernel.hpp
@@ -271,7 +271,7 @@ public:
         #endif
     }
 
-    #ifndef BOOST_NO_VARIADIC_TEMPLATES
+    #ifndef BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
     /// Sets the arguments for the kernel to \p args.
     template<class... T>
     void set_args(T&&... args)
@@ -280,7 +280,7 @@ public:
 
         _set_args<0>(args...);
     }
-    #endif // BOOST_NO_VARIADIC_TEMPLATES
+    #endif // BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 
     #if defined(CL_VERSION_2_0) || defined(BOOST_COMPUTE_DOXYGEN_INVOKED)
     /// Sets additional execution information for the kernel.

--- a/include/boost/compute/random/normal_distribution.hpp
+++ b/include/boost/compute/random/normal_distribution.hpp
@@ -62,13 +62,13 @@ public:
     }
 
     /// Returns the minimum value of the distribution.
-    result_type min() const
+    result_type min BOOST_PREVENT_MACRO_SUBSTITUTION () const
     {
         return -std::numeric_limits<RealType>::infinity();
     }
 
     /// Returns the maximum value of the distribution.
-    result_type max() const
+    result_type max BOOST_PREVENT_MACRO_SUBSTITUTION () const
     {
         return std::numeric_limits<RealType>::infinity();
     }

--- a/include/boost/compute/random/threefry_engine.hpp
+++ b/include/boost/compute/random/threefry_engine.hpp
@@ -1,34 +1,12 @@
-// Added By: Muhammad Junaid Muzammil <mjunaidmuzammil@gmail.com>
-// Copyright 2010-2012, D. E. Shaw Research.
-// All rights reserved.
-
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-
-// * Redistributions of source code must retain the above copyright
-//   notice, this list of conditions, and the following disclaimer.
-
-// * Redistributions in binary form must reproduce the above copyright
-//   notice, this list of conditions, and the following disclaimer in the
-//   documentation and/or other materials provided with the distribution.
-
-// * Neither the name of D. E. Shaw Research nor the names of its
-//   contributors may be used to endorse or promote products derived from
-//   this software without specific prior written permission.
-
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Muhammad Junaid Muzammil <mjunaidmuzammil@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
 
 #ifndef BOOST_COMPUTE_RANDOM_THREEFRY_HPP
 #define BOOST_COMPUTE_RANDOM_THREEFRY_HPP
@@ -97,6 +75,35 @@ private:
         std::string cache_key =
             std::string("threefry_engine_32x2");
 
+        // Copyright 2010-2012, D. E. Shaw Research.
+        // All rights reserved.
+
+        // Redistribution and use in source and binary forms, with or without
+        // modification, are permitted provided that the following conditions are
+        // met:
+
+        // * Redistributions of source code must retain the above copyright
+        //   notice, this list of conditions, and the following disclaimer.
+
+        // * Redistributions in binary form must reproduce the above copyright
+        //   notice, this list of conditions, and the following disclaimer in the
+        //   documentation and/or other materials provided with the distribution.
+
+        // * Neither the name of D. E. Shaw Research nor the names of its
+        //   contributors may be used to endorse or promote products derived from
+        //   this software without specific prior written permission.
+
+        // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+        // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+        // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+        // A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+        // OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+        // SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+        // LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+        // DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+        // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+        // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         const char source[] =
             "#define THREEFRY2x32_DEFAULT_ROUNDS 20\n"
             "#define SKEIN_KS_PARITY_32 0x1BD11BDA\n"

--- a/include/boost/compute/random/uniform_int_distribution.hpp
+++ b/include/boost/compute/random/uniform_int_distribution.hpp
@@ -40,7 +40,7 @@ public:
     /// Creates a new uniform distribution producing numbers in the range
     /// [\p a, \p b].
     explicit uniform_int_distribution(IntType a = 0,
-                                      IntType b = std::numeric_limits<IntType>::max())
+                                      IntType b = (std::numeric_limits<IntType>::max)())
         : m_a(a),
           m_b(b)
     {

--- a/include/boost/compute/types/tuple.hpp
+++ b/include/boost/compute/types/tuple.hpp
@@ -24,7 +24,7 @@
 #include <boost/compute/type_traits/type_name.hpp>
 #include <boost/compute/detail/meta_kernel.hpp>
 
-#ifndef BOOST_COMPUTE_DETAIL_NO_STD_TUPLE
+#ifndef BOOST_COMPUTE_NO_STD_TUPLE
 #include <tuple>
 #endif
 
@@ -86,7 +86,7 @@ BOOST_PP_REPEAT_FROM_TO(1, BOOST_COMPUTE_MAX_ARITY, BOOST_COMPUTE_INJECT_IMPL, ~
 #undef BOOST_COMPUTE_INJECT_DECL
 #undef BOOST_COMPUTE_INJECT_TYPE
 
-#ifdef BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES
+#ifdef BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 // type_name() specializations for boost::tuple (without variadic templates)
 #define BOOST_COMPUTE_PRINT_TYPE(z, n, unused)                                 \
             + type_name<T ## n>() + "_"
@@ -154,9 +154,9 @@ struct type_name_trait<boost::tuple<T...>>
         return s.str();
     }
 };
-#endif // BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES
+#endif // BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 
-#ifndef BOOST_COMPUTE_DETAIL_NO_STD_TUPLE
+#ifndef BOOST_COMPUTE_NO_STD_TUPLE
 // type_name<> specialization for std::tuple<T...>
 template<class... T>
 struct type_name_trait<std::tuple<T...>>
@@ -181,7 +181,7 @@ struct type_name_trait<std::tuple<T...>>
         return s.str();
     }
 };
-#endif // BOOST_COMPUTE_DETAIL_NO_STD_TUPLE
+#endif // BOOST_COMPUTE_NO_STD_TUPLE
 
 // get<N>() result type specialization for boost::tuple<>
 #define BOOST_COMPUTE_GET_RESULT_TYPE(z, n, unused)                            \

--- a/include/boost/compute/utility/dim.hpp
+++ b/include/boost/compute/utility/dim.hpp
@@ -17,7 +17,7 @@
 namespace boost {
 namespace compute {
 
-#ifndef BOOST_NO_VARIADIC_TEMPLATES
+#ifndef BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 /// The variadic \c dim() function provides a concise syntax for creating
 /// \ref extents objects.
 ///
@@ -61,7 +61,7 @@ BOOST_PP_REPEAT(BOOST_COMPUTE_MAX_ARITY, BOOST_COMPUTE_DETAIL_DEFINE_DIM, ~)
 #undef BOOST_COMPUTE_DETAIL_ASSIGN_DIM
 #undef BOOST_COMPUTE_DETAIL_DEFINE_DIM
 
-#endif // BOOST_NO_VARIADIC_TEMPLATES
+#endif // BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 
 /// \internal_
 template<size_t N>

--- a/include/boost/compute/utility/extents.hpp
+++ b/include/boost/compute/utility/extents.hpp
@@ -16,8 +16,7 @@
 
 #include <boost/compute/config.hpp>
 
-#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST) && \
-    !defined(BOOST_NO_0X_HDR_INITIALIZER_LIST)
+#ifndef BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
 #include <initializer_list>
 #endif
 
@@ -61,8 +60,7 @@ public:
         m_extents.fill(value);
     }
 
-    #if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST) && \
-        !defined(BOOST_NO_0X_HDR_INITIALIZER_LIST)
+    #ifndef BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
     /// Creates an extents object with \p values.
     extents(std::initializer_list<size_t> values)
     {
@@ -70,7 +68,7 @@ public:
 
         std::copy(values.begin(), values.end(), m_extents.begin());
     }
-    #endif
+    #endif // BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
 
     /// Returns the size (i.e. dimensionality) of the extents array.
     size_type size() const

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,3 +1,12 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2013 Kyle Lutz <kyle.r.lutz@gmail.com>
+# 
+#  Distributed under the Boost Software License, Version 1.0
+#  See accompanying file LICENSE_1_0.txt or copy at
+#  http://www.boost.org/LICENSE_1_0.txt
+#
+# ---------------------------------------------------------------------------
+
 include_directories(../include)
 
 set(PERF_BOOST_COMPONENTS system timer chrono program_options)

--- a/perf/perf.py
+++ b/perf/perf.py
@@ -1,5 +1,12 @@
 #!/usr/bin/python
 
+# Copyright (c) 2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+# Distributed under the Boost Software License, Version 1.0
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+#
+# See http://boostorg.github.com/compute for more information.
+
 # driver script for boost.compute benchmarking. will run a
 # benchmark for a given function (e.g. accumulate, sort).
 

--- a/perf/perf_accumulate.cpp
+++ b/perf/perf_accumulate.cpp
@@ -58,7 +58,7 @@ void tune_accumulate(const compute::vector<T>& data,
     const compute::uint_ tpbs[] = { 4, 8, 16, 32, 64, 128, 256, 512, 1024 };
     const compute::uint_ vpts[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
 
-    double min_time = std::numeric_limits<double>::max();
+    double min_time = (std::numeric_limits<double>::max)();
     compute::uint_ best_tpb = 0;
     compute::uint_ best_vpt = 0;
 

--- a/perf/perf_exclusive_scan.cpp
+++ b/perf/perf_exclusive_scan.cpp
@@ -1,3 +1,13 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Benoit
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
 #include <algorithm>
 #include <iostream>
 #include <numeric>

--- a/perf/perf_saxpy.cpp
+++ b/perf/perf_saxpy.cpp
@@ -76,7 +76,7 @@ void tune_saxpy(const compute::vector<T>& x,
     const compute::uint_ tpbs[] = { 4, 8, 16, 32, 64, 128, 256, 512, 1024 };
     const compute::uint_ vpts[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
 
-    double min_time = std::numeric_limits<double>::max();
+    double min_time = (std::numeric_limits<double>::max)();
     compute::uint_ best_tpb = 0;
     compute::uint_ best_vpt = 0;
 

--- a/perf/perf_sort.cpp
+++ b/perf/perf_sort.cpp
@@ -59,7 +59,7 @@ void tune_sort(const std::vector<T>& data,
 
     const compute::uint_ tpbs[] = { 32, 64, 128, 256, 512, 1024 };
 
-    double min_time = std::numeric_limits<double>::max();
+    double min_time = (std::numeric_limits<double>::max)();
     compute::uint_ best_tpb = 0;
 
     for(size_t i = 0; i < sizeof(tpbs) / sizeof(*tpbs); i++){

--- a/perf/perf_tbb_merge.cpp
+++ b/perf/perf_tbb_merge.cpp
@@ -17,7 +17,7 @@ struct ParallelMergeRange {
     Iterator out;               // where to put merged sequence
     bool empty()   const {return (end1-begin1)+(end2-begin2)==0;}
     bool is_divisible() const {
-        return std::min( end1-begin1, end2-begin2 ) > grainsize;
+        return (std::min)( end1-begin1, end2-begin2 ) > grainsize;
     }
     ParallelMergeRange( ParallelMergeRange& r, split ) {
         if( r.end1-r.begin1 < r.end2-r.begin2 ) {

--- a/perf/perf_tbb_merge.cpp
+++ b/perf/perf_tbb_merge.cpp
@@ -1,3 +1,13 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
 #include <algorithm>
 #include <iostream>
 #include <vector>

--- a/perf/perf_thrust_exclusive_scan.cu
+++ b/perf/perf_thrust_exclusive_scan.cu
@@ -1,5 +1,5 @@
 //---------------------------------------------------------------------------//
-// Copyright (c) 2013-2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+// Copyright (c) 2014 Benoit
 //
 // Distributed under the Boost Software License, Version 1.0
 // See accompanying file LICENSE_1_0.txt or copy at

--- a/perf/perfdoc.py
+++ b/perf/perfdoc.py
@@ -1,5 +1,12 @@
 #!/usr/bin/python
 
+# Copyright (c) 2014 Kyle Lutz <kyle.r.lutz@gmail.com>
+# Distributed under the Boost Software License, Version 1.0
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+#
+# See http://boostorg.github.com/compute for more information.
+
 import os
 import sys
 import pylab

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,12 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2013 Kyle Lutz <kyle.r.lutz@gmail.com>
+# 
+#  Distributed under the Boost Software License, Version 1.0
+#  See accompanying file LICENSE_1_0.txt or copy at
+#  http://www.boost.org/LICENSE_1_0.txt
+#
+# ---------------------------------------------------------------------------
+
 include_directories(../include)
 
 set(BOOST_COMPONENTS unit_test_framework)

--- a/test/context_setup.hpp
+++ b/test/context_setup.hpp
@@ -1,3 +1,13 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2013-2014 Denis Demidov
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
 #ifndef BOOST_COMPUTE_TEST_CONTEXT_SETUP_HPP
 #define BOOST_COMPUTE_TEST_CONTEXT_SETUP_HPP
 

--- a/test/extra/CMakeLists.txt
+++ b/test/extra/CMakeLists.txt
@@ -1,3 +1,12 @@
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2015 Kyle Lutz <kyle.r.lutz@gmail.com>
+# 
+#  Distributed under the Boost Software License, Version 1.0
+#  See accompanying file LICENSE_1_0.txt or copy at
+#  http://www.boost.org/LICENSE_1_0.txt
+#
+# ---------------------------------------------------------------------------
+
 # include local test headers
 include_directories(..)
 

--- a/test/opencl_version_check.hpp
+++ b/test/opencl_version_check.hpp
@@ -1,3 +1,13 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2014 Denis Demidov
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
 #ifndef BOOST_COMPUTE_TEST_OPENCL_VERSION_CHECK_HPP
 #define BOOST_COMPUTE_TEST_OPENCL_VERSION_CHECK_HPP
 

--- a/test/test_accumulate.cpp
+++ b/test/test_accumulate.cpp
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(min_and_max)
 
     BOOST_COMPUTE_FUNCTION(int2_, min_and_max, (int2_ accumulator, const int value),
     {
-        return (int2)(min(accumulator.x, value), max(accumulator.y, value));
+        return (int2)((min)(accumulator.x, value), (max)(accumulator.y, value));
     });
 
     int2_ result = boost::compute::accumulate(
@@ -230,12 +230,12 @@ BOOST_AUTO_TEST_CASE(min_max)
     using ::boost::compute::max;
 
     float min_value = boost::compute::accumulate(
-        vec.begin(), vec.end(), std::numeric_limits<float>::max(), min<float>(), queue
+        vec.begin(), vec.end(), (std::numeric_limits<float>::max)(), min<float>(), queue
     );
     BOOST_CHECK_EQUAL(min_value, 0.1f);
 
     float max_value = boost::compute::accumulate(
-        vec.begin(), vec.end(), std::numeric_limits<float>::min(), max<float>(), queue
+        vec.begin(), vec.end(), (std::numeric_limits<float>::min()), max<float>(), queue
     );
     BOOST_CHECK_EQUAL(max_value, 9.6f);
 

--- a/test/test_async_wait.cpp
+++ b/test/test_async_wait.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(empty)
 {
 }
 
-#ifndef BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES
+#ifndef BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 BOOST_AUTO_TEST_CASE(wait_for_copy)
 {
     // wait list
@@ -67,6 +67,6 @@ BOOST_AUTO_TEST_CASE(wait_for_copy)
     // check data on the device
     CHECK_RANGE_EQUAL(int, 8, vector, (1, 2, 3, 4, 5, 6, 7, 8));
 }
-#endif // BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES
+#endif // BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_is_permutation.cpp
+++ b/test/test_is_permutation.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(is_permutation_int)
     bc::vector<bc::int_> vector2(dataset2, dataset2 + 5, queue);
 
     bool result =
-    	bc::is_permutation(vector1.begin(), vector1.begin() + 5,
+        bc::is_permutation(vector1.begin(), vector1.begin() + 5,
                            vector2.begin(), vector2.begin() + 5, queue);
 
     BOOST_VERIFY(result == true);

--- a/test/test_kernel.cpp
+++ b/test/test_kernel.cpp
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(get_work_group_info)
     BOOST_CHECK(work_group_size >= 1);
 }
 
-#ifndef BOOST_NO_VARIADIC_TEMPLATES
+#ifndef BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 BOOST_AUTO_TEST_CASE(kernel_set_args)
 {
     compute::kernel k = compute::kernel::create_with_source(
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(kernel_set_args)
 
     k.set_args(4, 2.4f, 'a');
 }
-#endif
+#endif // BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 
 #ifdef CL_VERSION_1_2
 BOOST_AUTO_TEST_CASE(get_arg_info)

--- a/test/test_next_permutation.cpp
+++ b/test/test_next_permutation.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(next_permutation_int)
     bc::vector<bc::int_> vector(dataset, dataset + 5, queue);
 
     bool result =
-    	bc::next_permutation(vector.begin(), vector.begin() + 5, queue);
+        bc::next_permutation(vector.begin(), vector.begin() + 5, queue);
 
     CHECK_RANGE_EQUAL(int, 5, vector, (1, 3, 4, 5, 2));
     BOOST_VERIFY(result == true);
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(next_permutation_string)
     bc::vector<bc::char_> vector(dataset, dataset + 4, queue);
 
     bool result =
-    	bc::next_permutation(vector.begin(), vector.begin() + 4, queue);
+        bc::next_permutation(vector.begin(), vector.begin() + 4, queue);
 
     CHECK_RANGE_EQUAL(char, 4, vector, ('a', 'a', 'b', 'a'));
     BOOST_VERIFY(result == true);

--- a/test/test_prev_permutation.cpp
+++ b/test/test_prev_permutation.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(prev_permutation_int)
     bc::vector<bc::int_> vector(dataset, dataset + 5, queue);
 
     bool result =
-    	bc::prev_permutation(vector.begin(), vector.begin() + 5, queue);
+        bc::prev_permutation(vector.begin(), vector.begin() + 5, queue);
 
     CHECK_RANGE_EQUAL(int, 5, vector, (1, 3, 2, 5, 4));
     BOOST_VERIFY(result == true);
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(prev_permutation_string)
     bc::vector<bc::char_> vector(dataset, dataset + 4, queue);
 
     bool result =
-    	bc::prev_permutation(vector.begin(), vector.begin() + 4, queue);
+        bc::prev_permutation(vector.begin(), vector.begin() + 4, queue);
 
     CHECK_RANGE_EQUAL(char, 4, vector, ('a', 'b', 'a', 'a'));
     BOOST_VERIFY(result == true);

--- a/test/test_tuple.cpp
+++ b/test/test_tuple.cpp
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(fill_tuple_vector)
     BOOST_CHECK_EQUAL(host_output[4], boost::make_tuple('z', 4, 3.14f));
 }
 
-#ifndef BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES
+#ifndef BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 BOOST_AUTO_TEST_CASE(variadic_tuple)
 {
     BOOST_CHECK_EQUAL(
@@ -124,9 +124,9 @@ BOOST_AUTO_TEST_CASE(variadic_tuple)
         "boost_tuple_char_short_int_float_t"
     );
 }
-#endif // BOOST_COMPUTE_DETAIL_NO_VARIADIC_TEMPLATES
+#endif // BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 
-#ifndef BOOST_COMPUTE_DETAIL_NO_STD_TUPLE
+#ifndef BOOST_COMPUTE_NO_STD_TUPLE
 BOOST_AUTO_TEST_CASE(std_tuple)
 {
     BOOST_CHECK_EQUAL(
@@ -134,6 +134,6 @@ BOOST_AUTO_TEST_CASE(std_tuple)
         "std_tuple_char_short_int_float_t"
     );
 }
-#endif // BOOST_COMPUTE_DETAIL_NO_STD_TUPLE
+#endif // BOOST_COMPUTE_NO_STD_TUPLE
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I fixed some of problems reported in [Boost Inspection Report for 1.59 beta rc1](http://boost.cowic.de/rc/docs-inspect-develop.html#compute). 

* I fixed violations of Boost min/max guidelines, converted tabs into spaces, added missing license information and copyrights (based on who and when created the file).
* I fixed one non-ASCII character in `/example/opencv_convolution.cpp`, but I _DID NOT_ change author name with non-ASCII character/s as I don't think it would be right.
* I added `BOOST_NO_CXX11_VARIADIC_TEMPLATES` macro which replaces deprecated `BOOST_NO_VARIADIC_TEMPLATES`.
* I also moved all `BOOST_NO_*` to `config.hpp`. 
* I used `BOOST_COMPUTE_NO_` prefix for all these macros, but it's not a problem to changed the prefix if different is preferred (for example  `BOOST_COMPUTE_DETAIL_NO_`).
* (!) The last commit removes deprecated Boost macros and update required version of Boost Library to 1.55 (in Boost 1.48 new macros that replaces deprecated ones are not defined, theoretically 1.51 is enough, but IMO 1.55 is currently the most popular one + there are no packages for 1.51). This commit can be removed if we want to keep supporting 1.48 version.  