### PR TITLE
Fix overlooked violation of the Boost min/max guidelines

### DIFF
--- a/test/test_accumulate.cpp
+++ b/test/test_accumulate.cpp
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(min_max)
     BOOST_CHECK_EQUAL(min_value, 0.1f);
 
     float max_value = boost::compute::accumulate(
-        vec.begin(), vec.end(), (std::numeric_limits<float>::min()), max<float>(), queue
+        vec.begin(), vec.end(), (std::numeric_limits<float>::min)(), max<float>(), queue
     );
     BOOST_CHECK_EQUAL(max_value, 9.6f);
 


### PR DESCRIPTION
This fixes violation of the Boost min/max guidelines I missed in https://github.com/boostorg/compute/pull/480. 

There is new Boost Inspection Report (28.07): http://boost.cowic.de/rc/docs-inspect-develop.html#compute. 
