### PR TITLE
CPU-targeted merge sort adapted for sorting by key

### DIFF
--- a/include/boost/compute/algorithm/sort_by_key.hpp
+++ b/include/boost/compute/algorithm/sort_by_key.hpp
@@ -13,8 +13,11 @@
 
 #include <iterator>
 
+#include <boost/utility/enable_if.hpp>
+
 #include <boost/compute/system.hpp>
 #include <boost/compute/command_queue.hpp>
+#include <boost/compute/algorithm/detail/merge_sort_on_cpu.hpp>
 #include <boost/compute/algorithm/detail/insertion_sort.hpp>
 #include <boost/compute/algorithm/detail/radix_sort.hpp>
 #include <boost/compute/algorithm/reverse.hpp>
@@ -26,11 +29,17 @@ namespace compute {
 namespace detail {
 
 template<class KeyIterator, class ValueIterator>
-inline void dispatch_sort_by_key(KeyIterator keys_first,
-                        KeyIterator keys_last,
-                        ValueIterator values_first,
-                        less<typename std::iterator_traits<KeyIterator>::value_type> compare,
-                        command_queue &queue)
+inline void
+dispatch_gpu_sort_by_key(KeyIterator keys_first,
+                         KeyIterator keys_last,
+                         ValueIterator values_first,
+                         less<typename std::iterator_traits<KeyIterator>::value_type> compare,
+                         command_queue &queue,
+                         typename boost::enable_if_c<
+                             is_radix_sortable<
+                                 typename std::iterator_traits<KeyIterator>::value_type
+                             >::value
+                         >::type* = 0)
 {
     size_t count = detail::iterator_range_size(keys_first, keys_last);
 
@@ -47,11 +56,17 @@ inline void dispatch_sort_by_key(KeyIterator keys_first,
 }
 
 template<class KeyIterator, class ValueIterator>
-inline void dispatch_sort_by_key(KeyIterator keys_first,
-                        KeyIterator keys_last,
-                        ValueIterator values_first,
-                        greater<typename std::iterator_traits<KeyIterator>::value_type> compare,
-                        command_queue &queue)
+inline void
+dispatch_gpu_sort_by_key(KeyIterator keys_first,
+                         KeyIterator keys_last,
+                         ValueIterator values_first,
+                         greater<typename std::iterator_traits<KeyIterator>::value_type> compare,
+                         command_queue &queue,
+                         typename boost::enable_if_c<
+                             is_radix_sortable<
+                                 typename std::iterator_traits<KeyIterator>::value_type
+                             >::value
+                         >::type* = 0)
 {
     size_t count = detail::iterator_range_size(keys_first, keys_last);
 
@@ -69,25 +84,35 @@ inline void dispatch_sort_by_key(KeyIterator keys_first,
         // Reverse keys, values for descending order
         ::boost::compute::reverse(keys_first, keys_last, queue);
         ::boost::compute::reverse(values_first, values_first + count, queue);
-
     }
 }
 
 template<class KeyIterator, class ValueIterator, class Compare>
-inline void dispatch_sort_by_key(KeyIterator keys_first,
-                        KeyIterator keys_last,
-                        ValueIterator values_first,
-                        Compare compare,
-                        command_queue &queue)
+inline void dispatch_gpu_sort_by_key(KeyIterator keys_first,
+                                     KeyIterator keys_last,
+                                     ValueIterator values_first,
+                                     Compare compare,
+                                     command_queue &queue)
 {
-
     detail::serial_insertion_sort_by_key(
-        keys_first,
-        keys_last,
-        values_first,
-        compare,
-        queue
-        );
+        keys_first, keys_last, values_first, compare, queue
+    );
+}
+
+template<class KeyIterator, class ValueIterator, class Compare>
+inline void dispatch_sort_by_key(KeyIterator keys_first,
+                                 KeyIterator keys_last,
+                                 ValueIterator values_first,
+                                 Compare compare,
+                                 command_queue &queue)
+{
+    if(queue.get_device().type() & device::gpu) {
+        dispatch_gpu_sort_by_key(keys_first, keys_last, values_first, compare, queue);
+        return;
+    }
+    ::boost::compute::detail::merge_sort_by_key_on_cpu(
+        keys_first, keys_last, values_first, compare, queue
+    );
 }
 
 }
@@ -108,11 +133,8 @@ inline void sort_by_key(KeyIterator keys_first,
                         command_queue &queue = system::default_queue())
 {
     ::boost::compute::detail::dispatch_sort_by_key(
-        keys_first,
-        keys_last,
-        values_first,
-        compare,
-        queue);
+        keys_first, keys_last, values_first, compare, queue
+    );
 }
 
 /// \overload
@@ -124,18 +146,9 @@ inline void sort_by_key(KeyIterator keys_first,
 {
     typedef typename std::iterator_traits<KeyIterator>::value_type key_type;
 
-    size_t count = detail::iterator_range_size(keys_first, keys_last);
-
-    if(count < 32){
-        detail::serial_insertion_sort_by_key(
-            keys_first, keys_last, values_first, less<key_type>(), queue
-        );
-    }
-    else {
-        detail::radix_sort_by_key(
-            keys_first, keys_last, values_first, queue
-        );
-    }
+    ::boost::compute::sort_by_key(
+        keys_first, keys_last, values_first, less<key_type>(), queue
+    );
 }
 
 } // end compute namespace


### PR DESCRIPTION
I modified CPU-targeted merge sort (see https://github.com/boostorg/compute/pull/486), so it can also perform sorting by key.

I also restricted usage of `radix_sort` in `sort_by_key.hpp` to only these situations when type of the keys is "radix sortable" (like it's done in [`sort.hpp`](https://github.com/boostorg/compute/blob/develop/include/boost/compute/algorithm/sort.hpp)). 