### PR TITLE
Checking multiple values per thread in find_if()

### DIFF
--- a/include/boost/compute/algorithm/detail/find_if_with_atomics.hpp
+++ b/include/boost/compute/algorithm/detail/find_if_with_atomics.hpp
@@ -21,24 +21,21 @@
 #include <boost/compute/type_traits/type_name.hpp>
 #include <boost/compute/detail/meta_kernel.hpp>
 #include <boost/compute/detail/iterator_range_size.hpp>
+#include <boost/compute/detail/parameter_cache.hpp>
 
 namespace boost {
 namespace compute {
 namespace detail {
 
 template<class InputIterator, class UnaryPredicate>
-inline InputIterator find_if_with_atomics(InputIterator first,
-                                          InputIterator last,
-                                          UnaryPredicate predicate,
-                                          command_queue &queue)
+inline InputIterator find_if_with_atomics_one_vpt(InputIterator first,
+                                                  InputIterator last,
+                                                  UnaryPredicate predicate,
+                                                  const size_t count,
+                                                  command_queue &queue)
 {
     typedef typename std::iterator_traits<InputIterator>::value_type value_type;
     typedef typename std::iterator_traits<InputIterator>::difference_type difference_type;
-
-    size_t count = detail::iterator_range_size(first, last);
-    if(count == 0){
-        return last;
-    }
 
     const context &context = queue.get_context();
 
@@ -60,11 +57,152 @@ inline InputIterator find_if_with_atomics(InputIterator first,
 
     // initialize index to the last iterator's index
     index.write(static_cast<uint_>(count), queue);
-
     queue.enqueue_1d_range_kernel(kernel, 0, count, 0);
 
     // read index and return iterator
     return first + static_cast<difference_type>(index.read(queue));
+}
+
+template<class InputIterator, class UnaryPredicate>
+inline InputIterator find_if_with_atomics_multiple_vpt(InputIterator first,
+                                                       InputIterator last,
+                                                       UnaryPredicate predicate,
+                                                       const size_t count,
+                                                       const uint_ vpt,
+                                                       command_queue &queue)
+{
+    typedef typename std::iterator_traits<InputIterator>::value_type value_type;
+    typedef typename std::iterator_traits<InputIterator>::difference_type difference_type;
+
+    const context &context = queue.get_context();
+    const device &device = queue.get_device();
+
+    detail::meta_kernel k("find_if");
+    size_t index_arg = k.add_arg<uint *>(memory_object::global_memory, "index");
+    size_t count_arg = k.add_arg<const uint>("count");
+    size_t vpt_arg = k.add_arg<const uint>("vpt");
+    atomic_min<uint_> atomic_min_uint;
+
+    // for GPUs reads from global memory are coalesced
+    if(device.type() & device::gpu) {
+        k <<
+            k.decl<const uint_>("lsize") << " = get_local_size(0);\n" <<
+            k.decl<uint_>("id") << " = get_local_id(0) + get_group_id(0) * lsize * vpt;\n" <<
+            k.decl<const uint_>("end") << " = min(" <<
+                    "id + (lsize *" << k.var<uint_>("vpt") << ")," <<
+                    "count" <<
+            ");\n" <<
+
+            // checking if the index is already found
+            "__local uint local_index;\n" <<
+            "if(get_local_id(0) == 0){\n" <<
+            "    local_index = *index;\n " <<
+            "};\n" <<
+            "barrier(CLK_LOCAL_MEM_FENCE);\n" <<
+            "if(local_index < id){\n" <<
+            "    return;\n" <<
+            "}\n" <<
+
+            "while(id < end){\n" <<
+            "    " << k.decl<const value_type>("value") << " = " <<
+                      first[k.var<const uint_>("id")] << ";\n"
+            "    if(" << predicate(k.var<const value_type>("value")) << "){\n" <<
+            "        " << atomic_min_uint(k.var<uint_ *>("index"),
+                                          k.var<uint_>("id")) << ";\n" <<
+            "        return;\n"
+            "    }\n" <<
+            "    id+=lsize;\n" <<
+            "}\n";
+    // for CPUs (and other devices) reads are ordered so the big cache is
+    // efficiently used.
+    } else {
+        k <<
+            k.decl<uint_>("id") << " = get_global_id(0) * " << k.var<uint_>("vpt") << ";\n" <<
+            k.decl<const uint_>("end") << " = min(" <<
+                    "id + " << k.var<uint_>("vpt") << "," <<
+                    "count" <<
+            ");\n" <<
+            "while(id < end && (*index) > id){\n" <<
+            "    " << k.decl<const value_type>("value") << " = " <<
+                      first[k.var<const uint_>("id")] << ";\n"
+            "    if(" << predicate(k.var<const value_type>("value")) << "){\n" <<
+            "        " << atomic_min_uint(k.var<uint_ *>("index"),
+                                          k.var<uint_>("id")) << ";\n" <<
+            "        return;\n" <<
+            "    }\n" <<
+            "    id++;\n" <<
+            "}\n";
+    }
+
+    kernel kernel = k.compile(context);
+
+    scalar<uint_> index(context);
+    kernel.set_arg(index_arg, index.get_buffer());
+    kernel.set_arg(count_arg, static_cast<uint_>(count));
+    kernel.set_arg(vpt_arg, static_cast<uint_>(vpt));
+
+    // initialize index to the last iterator's index
+    index.write(static_cast<uint_>(count), queue);
+
+    const size_t global_wg_size = static_cast<size_t>(
+        std::ceil(float(count) / vpt)
+    );
+    queue.enqueue_1d_range_kernel(kernel, 0, global_wg_size, 0);
+
+    // read index and return iterator
+    return first + static_cast<difference_type>(index.read(queue));
+}
+
+template<class InputIterator, class UnaryPredicate>
+inline InputIterator find_if_with_atomics(InputIterator first,
+                                          InputIterator last,
+                                          UnaryPredicate predicate,
+                                          command_queue &queue)
+{
+    typedef typename std::iterator_traits<InputIterator>::value_type value_type;
+
+    size_t count = detail::iterator_range_size(first, last);
+    if(count == 0){
+        return last;
+    }
+
+    const device &device = queue.get_device();
+
+    // load cached parameters
+    std::string cache_key = std::string("__boost_find_if_with_atomics_")
+        + type_name<value_type>();
+    boost::shared_ptr<parameter_cache> parameters =
+        detail::parameter_cache::get_global_cache(device);
+
+    // for relatively small inputs on GPUs kernel checking one value per thread
+    // (work-item) is more efficient than its multiple values per thread version
+    if(device.type() & device::gpu){
+        const size_t one_vpt_threshold =
+            parameters->get(cache_key, "one_vpt_threshold", 1048576);
+        if(count <= one_vpt_threshold){
+            return find_if_with_atomics_one_vpt(
+                first, last, predicate, count, queue
+            );
+        }
+    }
+
+    // values per thread
+    size_t vpt;
+    if(device.type() & device::gpu){
+        // get vpt parameter
+        vpt = parameters->get(cache_key, "vpt", 32);
+    } else {
+        // for CPUs work is split equally between compute units
+        const size_t max_compute_units =
+            device.get_info<CL_DEVICE_MAX_COMPUTE_UNITS>();
+        vpt = static_cast<size_t>(
+            std::ceil(float(count) / max_compute_units)
+        );
+    }
+
+    return find_if_with_atomics_multiple_vpt(
+        first, last, predicate, count, vpt, queue
+    );
 }
 
 } // end detail namespace


### PR DESCRIPTION
This addresses https://github.com/boostorg/compute/issues/27.

I added `find_if_with_atomics_multiple_vpt()` which checks multiple values per thread. I kept original algorithm (it's renamed to `find_if_with_atomics_one_vpt()`) as I had found out that it's better for small and medium-sized inputs (depends on GPU; by default it's used for buffers with elements or less 1048576, but it's "tunable"). Probably it happens so because its kernel is much simpler. 

`find_if_with_atomics_multiple_vpt()` has two kernels - one for GPUs, one for CPUs or most generally for devices which have relativity big cache per compute unit. In the first reads from global memory are coalesced, in the second one reads from global memory are order so the big cache is efficiently used.

For GPUs default values per thread parameter (vpt) equals 32.  For CPUs work is split equally between compute units.

Below I present performance results for `find` algorithm which directly uses `find_if`. Benchmark `perf_find` checks algorithm performance in the worst case scenario when value we're looking for is the last element of the input.

std::find() on CPU:
```
=== find with stl ===
size,time (ms)
2,0.000224
4,0.000222
8,0.000223
16,0.000227
32,0.000233
64,0.000248
128,0.000276
256,0.000325
512,0.000422
1024,0.000620
2048,0.001021
4096,0.001805
8192,0.003395
16384,0.006668
32768,0.013275
65536,0.026349
131072,0.055138
262144,0.119968
524288,0.241183
1048576,0.519777
2097152,1.379100
4194304,3.389980
8388608,6.701620
16777216,13.807100
33554432,28.022900
```

boost::compute::find() on CPU:

* up to 7x faster

```
device: AMD Phenom(tm) II X3 710 Processor

=== find with compute === [ PROPOSED ]
size,time (ms)
2,0.059621
4,0.059610
8,0.064822
16,0.066171
32,0.067660
64,0.064405
128,0.067676
256,0.066502
512,0.064754
1024,0.074256
2048,0.065423
4096,0.070290
8192,0.063756
16384,0.073174
32768,0.095522
65536,0.084603
131072,0.106276
262144,0.165904
524288,0.295915
1048576,0.507413
2097152,0.907767
4194304,1.724090
8388608,3.737880
16777216,7.384920
33554432,14.449600

=== find with compute === [ MASTER ] 
size,time (ms)
2,0.058339
4,0.055977
8,0.054589
16,0.065270
32,0.066115
64,0.057937
128,0.055955
256,0.055025
512,0.060878
1024,0.066771
2048,0.083266
4096,0.067656
8192,0.115239
16384,0.115189
32768,0.163517
65536,0.266130
131072,0.477942
262144,0.897890
524288,1.767940
1048576,3.457340
2097152,6.816540
4194304,13.590800
8388608,27.148400
16777216,54.304600
33554432,108.861000
```

boost::compute::find() on GPU:

* up to 8% faster for big inputs (when multiple vpt version is used), 
* equally fast for small and medium-sized inputs
* for big inputs (when multiple vpt version is used) it's faster in non-worst-case scenarios as every started thread check if value fulfilling given predicate is already found and if it has lower index than value that will be checked by this thread (because the algorithm should return the first fulfilling the predicate).
```
device: Capeverde [ Radeon HD7770 1GB]

=== find with compute === [ PROPOSED ]
size,time (ms)
2,0.163925
4,0.172390
8,0.163876
16,0.149378
32,0.161240
64,0.163684
128,0.161740
256,0.160055
512,0.154372
1024,0.140492
2048,0.152486
4096,0.161708
8192,0.143643
16384,0.160091
32768,0.160668
65536,0.145711
131072,0.168451
262144,0.179424
524288,0.180423
1048576,0.227733
2097152,0.305461
4194304,0.428461
8388608,0.720791
16777216,1.248160
33554432,2.257180

=== find with compute === [ MASTER ] 
size,time (ms)
2,0.162994
4,0.169244
8,0.171470
16,0.162829
32,0.169513
64,0.160942
128,0.162011
256,0.169082
512,0.161847
1024,0.161064
2048,0.161721
4096,0.159014
8192,0.162864
16384,0.159541
32768,0.170088
65536,0.163592
131072,0.169682
262144,0.176525
524288,0.188048
1048576,0.251718
2097152,0.317693
4194304,0.464674
8388608,0.733724
16777216,1.339440
33554432,2.456310
```

```
***********************************************
What happens when searched value is not placed
at the end of the buffer (worst-cast scenario), but in the middle?
***********************************************

=== find with compute ===  [ PROPOSED ]
size,time (ms)
4194304,0.359969
8388608,0.526133
16777216,0.790212
33554432,1.321340

=== find with compute ===  [ MASTER ] 
size,time (ms)
4194304,0.463821
8388608,0.733334
16777216,1.345700
33554432,2.449840
```