### PR TITLE
Support for custom comparison function in find_extrema()

### DIFF
--- a/include/boost/compute/algorithm/detail/find_extrema.hpp
+++ b/include/boost/compute/algorithm/detail/find_extrema.hpp
@@ -12,7 +12,7 @@
 #define BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_HPP
 
 #include <boost/compute/detail/iterator_range_size.hpp>
-#include <boost/compute/algorithm/detail/find_extrema_reduce.hpp>
+#include <boost/compute/algorithm/detail/find_extrema_with_reduce.hpp>
 #include <boost/compute/algorithm/detail/find_extrema_with_atomics.hpp>
 #include <boost/compute/algorithm/detail/serial_find_extrema.hpp>
 
@@ -42,10 +42,10 @@ inline InputIterator find_extrema(InputIterator first,
         return serial_find_extrema(first, last, compare, find_minimum, queue);
     }
 
-    // find_extrema_reduce() is used only if requirements are met
-    if(find_extrema_reduce_requirements_met(first, last, queue))
+    // find_extrema_with_reduce() is used only if requirements are met
+    if(find_extrema_with_reduce_requirements_met(first, last, queue))
     {
-        return find_extrema_reduce(first, last, compare, find_minimum, queue);
+        return find_extrema_with_reduce(first, last, compare, find_minimum, queue);
     }
 
     // use serial method for OpenCL version 1.0 due to

--- a/include/boost/compute/algorithm/detail/find_extrema.hpp
+++ b/include/boost/compute/algorithm/detail/find_extrema.hpp
@@ -20,10 +20,11 @@ namespace boost {
 namespace compute {
 namespace detail {
 
-template<class InputIterator>
+template<class InputIterator, class Compare>
 inline InputIterator find_extrema(InputIterator first,
                                   InputIterator last,
-                                  char sign,
+                                  Compare compare,
+                                  const bool find_minimum,
                                   command_queue &queue)
 {
     size_t count = iterator_range_size(first, last);
@@ -37,23 +38,23 @@ inline InputIterator find_extrema(InputIterator first,
 
     // use serial method for small inputs
     // and when device is a CPU
-    if(count < 64 || (device.type() & device::cpu)){
-        return serial_find_extrema(first, last, sign, queue);
+    if(count < 512 || (device.type() & device::cpu)){
+        return serial_find_extrema(first, last, compare, find_minimum, queue);
     }
 
     // find_extrema_reduce() is used only if requirements are met
     if(find_extrema_reduce_requirements_met(first, last, queue))
     {
-        return find_extrema_reduce(first, last, sign, queue);
+        return find_extrema_reduce(first, last, compare, find_minimum, queue);
     }
 
     // use serial method for OpenCL version 1.0 due to
     // problems with atomic_cmpxchg()
     #ifndef CL_VERSION_1_1
-        return serial_find_extrema(first, last, sign, queue);
+        return serial_find_extrema(first, last, compare, find_minimum, queue);
     #endif
 
-    return find_extrema_with_atomics(first, last, sign, queue);
+    return find_extrema_with_atomics(first, last, compare, find_minimum, queue);
 }
 
 } // end detail namespace

--- a/include/boost/compute/algorithm/detail/find_extrema_with_reduce.hpp
+++ b/include/boost/compute/algorithm/detail/find_extrema_with_reduce.hpp
@@ -8,8 +8,8 @@
 // See http://boostorg.github.com/compute for more information.
 //---------------------------------------------------------------------------//
 
-#ifndef BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_REDUCE_HPP
-#define BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_REDUCE_HPP
+#ifndef BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_WITH_REDUCE_HPP
+#define BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_WITH_REDUCE_HPP
 
 #include <algorithm>
 #include <vector>
@@ -31,9 +31,9 @@ namespace compute {
 namespace detail {
 
 template<class InputIterator>
-bool find_extrema_reduce_requirements_met(InputIterator first,
-                                          InputIterator last,
-                                          command_queue &queue)
+bool find_extrema_with_reduce_requirements_met(InputIterator first,
+                                               InputIterator last,
+                                               command_queue &queue)
 {
     typedef typename std::iterator_traits<InputIterator>::value_type input_type;
 
@@ -74,15 +74,15 @@ bool find_extrema_reduce_requirements_met(InputIterator first,
 }
 
 template<class InputIterator, class ResultIterator, class Compare>
-inline size_t find_extrema_reduce(InputIterator first,
-                                  size_t count,
-                                  ResultIterator result,
-                                  vector<uint_>::iterator result_idx,
-                                  size_t work_groups_no,
-                                  size_t work_group_size,
-                                  Compare compare,
-                                  const bool find_minimum,
-                                  command_queue &queue)
+inline size_t find_extrema_with_reduce(InputIterator first,
+                                       size_t count,
+                                       ResultIterator result,
+                                       vector<uint_>::iterator result_idx,
+                                       size_t work_groups_no,
+                                       size_t work_group_size,
+                                       Compare compare,
+                                       const bool find_minimum,
+                                       command_queue &queue)
 {
     typedef typename std::iterator_traits<InputIterator>::value_type input_type;
 
@@ -202,7 +202,7 @@ uint_ find_extrema_final(InputIterator candidates,
     vector<uint_> result_idx(1, context);
 
     // get extremum from among the candidates
-    find_extrema_reduce(
+    find_extrema_with_reduce(
         candidates, count, result.begin(), result_idx.begin(),
         1, work_group_size, compare, find_minimum, queue
     );
@@ -275,11 +275,11 @@ uint_ find_extrema_final(InputIterator candidates,
 }
 
 template<class InputIterator, class Compare>
-InputIterator find_extrema_reduce(InputIterator first,
-                                  InputIterator last,
-                                  Compare compare,
-                                  const bool find_minimum,
-                                  command_queue &queue)
+InputIterator find_extrema_with_reduce(InputIterator first,
+                                       InputIterator last,
+                                       Compare compare,
+                                       const bool find_minimum,
+                                       command_queue &queue)
 {
     typedef typename std::iterator_traits<InputIterator>::difference_type difference_type;
     typedef typename std::iterator_traits<InputIterator>::value_type input_type;
@@ -293,7 +293,7 @@ InputIterator find_extrema_reduce(InputIterator first,
 
     const size_t count = detail::iterator_range_size(first, last);
 
-    std::string cache_key = std::string("__boost_find_extrema_reduce_")
+    std::string cache_key = std::string("__boost_find_extrema_with_reduce_")
         + type_name<input_type>();
 
     // load parameters
@@ -317,7 +317,7 @@ InputIterator find_extrema_reduce(InputIterator first,
     vector<uint_> candidates_idx(work_groups_no, context);
 
     // find extremum candidates and their indices
-    find_extrema_reduce(
+    find_extrema_with_reduce(
         first, count, candidates.begin(), candidates_idx.begin(),
         work_groups_no, work_group_size, compare, find_minimum, queue
      );
@@ -335,4 +335,4 @@ InputIterator find_extrema_reduce(InputIterator first,
 } // end compute namespace
 } // end boost namespace
 
-#endif // BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_REDUCE_HPP
+#endif // BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_WITH_REDUCE_HPP

--- a/include/boost/compute/algorithm/max_element.hpp
+++ b/include/boost/compute/algorithm/max_element.hpp
@@ -13,6 +13,7 @@
 
 #include <boost/compute/system.hpp>
 #include <boost/compute/command_queue.hpp>
+#include <boost/compute/functional.hpp>
 #include <boost/compute/algorithm/detail/find_extrema.hpp>
 
 namespace boost {
@@ -21,14 +22,50 @@ namespace compute {
 /// Returns an iterator pointing to the element in the range
 /// [\p first, \p last) with the maximum value.
 ///
+/// \param first first element in the input range
+/// \param last last element in the input range
+/// \param compare comparison function object which returns ​true if the first
+///        argument is less than (i.e. is ordered before) the second.
+/// \param queue command queue to perform the operation
+///
+/// For example, to find \c int2 value with maximum first component in given vector:
+/// \code
+/// // comparison function object
+/// BOOST_COMPUTE_FUNCTION(bool, compare_first, (const int2_ &a, const int2_ &b),
+/// {
+///     return a.x < b.x;
+/// });
+///
+/// // create vector
+/// boost::compute::vector<uint2_> data = ...
+///
+/// boost::compute::vector<uint2_>::iterator max =
+///     boost::compute::max_element(data.begin(), data.end(), compare_first, queue);
+/// \endcode
+///
 /// \see min_element()
+template<class InputIterator, class Compare>
+inline InputIterator
+max_element(InputIterator first,
+            InputIterator last,
+            Compare compare,
+            command_queue &queue = system::default_queue())
+{
+    return detail::find_extrema(first, last, compare, false, queue);
+}
+
+///\overload
 template<class InputIterator>
 inline InputIterator
 max_element(InputIterator first,
             InputIterator last,
             command_queue &queue = system::default_queue())
 {
-    return detail::find_extrema(first, last, '>', queue);
+    typedef typename std::iterator_traits<InputIterator>::value_type value_type;
+
+    return ::boost::compute::max_element(
+        first, last, ::boost::compute::less<value_type>(), queue
+    );
 }
 
 } // end compute namespace

--- a/include/boost/compute/algorithm/min_element.hpp
+++ b/include/boost/compute/algorithm/min_element.hpp
@@ -13,22 +13,59 @@
 
 #include <boost/compute/system.hpp>
 #include <boost/compute/command_queue.hpp>
+#include <boost/compute/functional.hpp>
 #include <boost/compute/algorithm/detail/find_extrema.hpp>
 
 namespace boost {
 namespace compute {
 
 /// Returns an iterator pointing to the element in range
-/// [\p first, \p last) with the minumum value.
+/// [\p first, \p last) with the minimum value.
+///
+/// \param first first element in the input range
+/// \param last last element in the input range
+/// \param compare comparison function object which returns ​true if the first
+///        argument is less than (i.e. is ordered before) the second.
+/// \param queue command queue to perform the operation
+///
+/// For example, to find \c int2 value with minimum first component in given vector:
+/// \code
+/// // comparison function object
+/// BOOST_COMPUTE_FUNCTION(bool, compare_first, (const int2_ &a, const int2_ &b),
+/// {
+///     return a.x < b.x;
+/// });
+///
+/// // create vector
+/// boost::compute::vector<uint2_> data = ...
+///
+/// boost::compute::vector<uint2_>::iterator min =
+///     boost::compute::min_element(data.begin(), data.end(), compare_first, queue);
+/// \endcode
 ///
 /// \see max_element()
+template<class InputIterator, class Compare>
+inline InputIterator
+min_element(InputIterator first,
+            InputIterator last,
+            Compare compare,
+            command_queue &queue = system::default_queue())
+{
+    return detail::find_extrema(first, last, compare, true, queue);
+}
+
+///\overload
 template<class InputIterator>
 inline InputIterator
 min_element(InputIterator first,
             InputIterator last,
             command_queue &queue = system::default_queue())
 {
-    return detail::find_extrema(first, last, '<', queue);
+    typedef typename std::iterator_traits<InputIterator>::value_type value_type;
+
+    return ::boost::compute::min_element(
+            first, last, ::boost::compute::less<value_type>(), queue
+    );
 }
 
 } // end compute namespace

--- a/include/boost/compute/algorithm/minmax_element.hpp
+++ b/include/boost/compute/algorithm/minmax_element.hpp
@@ -25,8 +25,31 @@ namespace compute {
 /// element and the second pointing to the maximum element in the range
 /// [\p first, \p last).
 ///
+/// \param first first element in the input range
+/// \param last last element in the input range
+/// \param compare comparison function object which returns ​true if the first
+///        argument is less than (i.e. is ordered before) the second.
+/// \param queue command queue to perform the operation
+///
 /// \see max_element(), min_element()
-template<class InputIterator>
+template<class InputIterator, class Compare>
+inline std::pair<InputIterator, InputIterator>
+minmax_element(InputIterator first,
+               InputIterator last,
+               Compare compare,
+               command_queue &queue = system::default_queue())
+{
+    if(first == last){
+        // empty range
+        return std::make_pair(first, first);
+    }
+
+    return std::make_pair(min_element(first, last, compare, queue),
+                          max_element(first, last, compare, queue));
+}
+
+///\overload
+template<class InputIterator, class Compare>
 inline std::pair<InputIterator, InputIterator>
 minmax_element(InputIterator first,
                InputIterator last,

--- a/perf/perf_bolt_max_element.cpp
+++ b/perf/perf_bolt_max_element.cpp
@@ -42,15 +42,28 @@ int main(int argc, char *argv[])
     // transfer data to the device
     bolt::cl::copy(host_vec.begin(), host_vec.end(), device_vec.begin());
 
-    size_t max = 0;
+    bolt::cl::device_vector<int>::iterator max_iter = device_vec.begin();
     perf_timer t;
     for(size_t trial = 0; trial < PERF_TRIALS; trial++){
         t.start();
-        max = *bolt::cl::max_element(device_vec.begin(), device_vec.end());
+        max_iter = bolt::cl::max_element(device_vec.begin(), device_vec.end());
         t.stop();
     }
+
+    int device_max = *max_iter;
     std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
-    std::cout << "max: " << max << std::endl;
+    std::cout << "max: " << device_max << std::endl;
+
+    // verify max is correct
+    int host_max = *std::max_element(host_vec.begin(), host_vec.end());
+    if(device_max != host_max){
+        std::cout << "ERROR: "
+                  << "device_max (" << device_max << ") "
+                  << "!= "
+                  << "host_max (" << host_max << ")"
+                  << std::endl;
+        return -1;
+    }
 
     return 0;
 }

--- a/perf/perf_max_element.cpp
+++ b/perf/perf_max_element.cpp
@@ -47,26 +47,26 @@ int main(int argc, char *argv[])
         queue
     );
 
-    size_t max = 0;
+    boost::compute::vector<int>::iterator max = device_vector.begin();
     perf_timer t;
     for(size_t trial = 0; trial < PERF_TRIALS; trial++){
         t.start();
-        max = *boost::compute::max_element(
+        max = boost::compute::max_element(
             device_vector.begin(), device_vector.end(), queue
         );
         queue.finish();
         t.stop();
     }
+
+    int device_max = max.read(queue);
     std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;
-    std::cout << "max: " << max << std::endl;
+    std::cout << "max: " << device_max << std::endl;
 
     // verify max is correct
-    size_t host_max = *std::max_element(host_vector.begin(),
-                                   host_vector.end()
-                                   );
-    if(max != host_max){
+    int host_max = *std::max_element(host_vector.begin(), host_vector.end());
+    if(device_max != host_max){
         std::cout << "ERROR: "
-                  << "device_max (" << max << ") "
+                  << "device_max (" << device_max << ") "
                   << "!= "
                   << "host_max (" << host_max << ")"
                   << std::endl;

--- a/test/test_extrema.cpp
+++ b/test/test_extrema.cpp
@@ -39,6 +39,40 @@ BOOST_AUTO_TEST_CASE(int_min_max)
     BOOST_CHECK_EQUAL(*max_iter, 15);
 }
 
+BOOST_AUTO_TEST_CASE(int2_min_max_custom_comparision_function)
+{
+    using boost::compute::int2_;
+
+    boost::compute::vector<int2_> vector(context);
+    vector.push_back(int2_(1, 10), queue);
+    vector.push_back(int2_(2, -100), queue);
+    vector.push_back(int2_(3, 30), queue);
+    vector.push_back(int2_(4, 20), queue);
+    vector.push_back(int2_(5, 5), queue);
+    vector.push_back(int2_(6, -80), queue);
+    vector.push_back(int2_(7, 21), queue);
+    vector.push_back(int2_(8, -5), queue);
+
+    BOOST_COMPUTE_FUNCTION(bool, compare_second, (const int2_ a, const int2_ b),
+    {
+        return a.y < b.y;
+    });
+
+    boost::compute::vector<int2_>::iterator min_iter =
+        boost::compute::min_element(
+            vector.begin(), vector.end(), compare_second, queue
+         );
+    BOOST_CHECK(min_iter == vector.begin() + 1);
+    BOOST_CHECK_EQUAL(*min_iter, int2_(2, -100));
+
+    boost::compute::vector<int2_>::iterator max_iter =
+        boost::compute::max_element(
+            vector.begin(), vector.end(), compare_second, queue
+        );
+    BOOST_CHECK(max_iter == vector.begin() + 2);
+    BOOST_CHECK_EQUAL(*max_iter, int2_(3, 30));
+}
+
 BOOST_AUTO_TEST_CASE(iota_min_max)
 {
     boost::compute::vector<int> vector(5000);


### PR DESCRIPTION
This resolves https://github.com/boostorg/compute/issues/460.

[1] I fixed perf_max_element benchmark. It needed a fix because `max_element` was called in this way:

```cpp
max = *boost::compute::max_element(device_vector.begin(), device_vector.end(), queue);
```
It includes reading found maximum from device memory using `*` dereference operator (it's very inefficient way to read data as it includes creating command queue which takes almost 2 ms). Now execution time does not contain time of reading maximum value from memory.

[2] I added support for custom comparison function in `find_extrema()` (therefore for `max_element()`, `min_element()` and `minmax_element()` functions).

[3] I renamed `find_extema_reduce()` to `find_extrema_with_reduce()` so it matches naming convention.


Benchmark results on GPU (AMD Radeon HD7770 1GB /  Capeverde):
```
=== max_element with compute === [ MASTER ]
size,time (ms)
2,0.130710
4,0.131326
8,0.115282
16,0.130115
32,0.130315
64,0.214163
128,0.212712
256,0.202653
512,0.214832
1024,0.202007
2048,0.204027
4096,0.210289
8192,0.216632
16384,0.204227
32768,0.184873
65536,0.210868
131072,0.238884
262144,0.257263
524288,0.246357
1048576,0.273122
2097152,0.338420
4194304,0.486059
8388608,0.754712
16777216,1.285120
33554432,2.315750

=== max_element with compute === [ PROPOSED - less<input_type> ]
size,time (ms)
2,0.136226
2,0.136226
8,0.116484
16,0.120873
32,0.143008
64,0.142799
128,0.127439
256,0.134189
512,0.208293
1024,0.209421
2048,0.210098
4096,0.213982
8192,0.217343
16384,0.212064
32768,0.201985
65536,0.225200
131072,0.240630
262144,0.259257
524288,0.248761
1048576,0.285929
2097152,0.337838
4194304,0.490419
8388608,0.767009
16777216,1.299080
33554432,2.317440


=== max_element with compute === [ PROPOSED - Custom comparison function identical to less<input_type> ]
2,0.142715
4,0.137454
8,0.140237
16,0.136328
32,0.139495
64,0.147547
128,0.151114
256,0.167200
512,0.307548
1024,0.309549
2048,0.314838
4096,0.325505
8192,0.307371
16384,0.309083
32768,0.307153
65536,0.316564
131072,0.307099
262144,0.306305
524288,0.304013
1048576,0.324055
2097152,0.382526
4194304,0.531185
8388608,0.799406
16777216,1.337700
33554432,2.356150
```