### PR TITLE
Fix install destination of headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,4 +109,4 @@ install(
 )
 
 # install header files
-install(DIRECTORY include/boost DESTINATION include/compute)
+install(DIRECTORY include/boost DESTINATION include)


### PR DESCRIPTION
Without this fix the headers get, at least on my system, installed to `/usr/include/compute/boost/compute` instead of `/usr/include/boost/compute`.