### PR TITLE
fix a few instances where the device type is not used as a bit mask

### DIFF
--- a/include/boost/compute/system.hpp
+++ b/include/boost/compute/system.hpp
@@ -226,11 +226,11 @@ private:
                     continue;
 
                 if (type && matches(std::string("GPU"), type))
-                    if (device.type() != device::gpu)
+                    if (!(device.type() & device::gpu))
                         continue;
 
                 if (type && matches(std::string("CPU"), type))
-                    if (device.type() != device::cpu)
+                    if (!(device.type() & device::cpu))
                         continue;
 
                 if (platform && !matches(device.platform().name(), platform))
@@ -247,7 +247,7 @@ private:
         for(size_t i = 0; i < devices_.size(); i++){
             const device& device = devices_[i];
 
-            if(device.type() == device::gpu){
+            if(device.type() & device::gpu){
                 return device;
             }
         }
@@ -256,7 +256,7 @@ private:
         for(size_t i = 0; i < devices_.size(); i++){
             const device& device = devices_[i];
 
-            if(device.type() == device::cpu){
+            if(device.type() & device::cpu){
                 return device;
             }
         }

--- a/test/test_command_queue.cpp
+++ b/test/test_command_queue.cpp
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(write_buffer_rect)
     // skip this test on AMD GPUs due to a buggy implementation
     // of the clEnqueueWriteBufferRect() function
     if(device.vendor() == "Advanced Micro Devices, Inc." &&
-       device.type() == boost::compute::device::gpu){
+       device.type() & boost::compute::device::gpu){
         std::cerr << "skipping write_buffer_rect test on AMD GPU" << std::endl;
         return;
     }


### PR DESCRIPTION
See https://github.com/boostorg/compute/issues/505