### PR TITLE
Include Reduce by key in algorithm.hpp meta-header

### DIFF
--- a/include/boost/compute/algorithm.hpp
+++ b/include/boost/compute/algorithm.hpp
@@ -63,6 +63,7 @@
 #include <boost/compute/algorithm/prev_permutation.hpp>
 #include <boost/compute/algorithm/random_shuffle.hpp>
 #include <boost/compute/algorithm/reduce.hpp>
+#include <boost/compute/algorithm/reduce_by_key.hpp>
 #include <boost/compute/algorithm/remove.hpp>
 #include <boost/compute/algorithm/remove_if.hpp>
 #include <boost/compute/algorithm/replace.hpp>


### PR DESCRIPTION
I forgot to add reduce by key in algorithm.hpp meta-header, this is a fix for that.