### PR TITLE
Events for queue enqueue_map_ methods

### DIFF
--- a/include/boost/compute/command_queue.hpp
+++ b/include/boost/compute/command_queue.hpp
@@ -606,12 +606,15 @@ public:
     #endif // CL_VERSION_1_2
 
     /// Enqueues a command to map \p buffer into the host address space.
+    /// Event associated with map operation is returned through
+    /// \p map_buffer_event parameter.
     ///
     /// \see_opencl_ref{clEnqueueMapBuffer}
     void* enqueue_map_buffer(const buffer &buffer,
                              cl_map_flags flags,
                              size_t offset,
                              size_t size,
+                             event &map_buffer_event,
                              const wait_list &events = wait_list())
     {
         BOOST_ASSERT(m_queue != 0);
@@ -628,7 +631,7 @@ public:
             size,
             events.size(),
             events.get_event_ptr(),
-            0,
+            &map_buffer_event.get(),
             &ret
         );
 
@@ -637,6 +640,17 @@ public:
         }
 
         return pointer;
+    }
+
+    /// \overload
+    void* enqueue_map_buffer(const buffer &buffer,
+                             cl_map_flags flags,
+                             size_t offset,
+                             size_t size,
+                             const wait_list &events = wait_list())
+    {
+        event event_;
+        return enqueue_map_buffer(buffer, flags, offset, size, event_, events);
     }
 
     /// Enqueues a command to unmap \p buffer from the host memory space.

--- a/include/boost/compute/command_queue.hpp
+++ b/include/boost/compute/command_queue.hpp
@@ -944,6 +944,185 @@ public:
         );
     }
 
+    /// Enqueues a command to map \p image into the host address space.
+    ///
+    /// Event associated with map operation is returned through
+    /// \p map_image_event parameter.
+    ///
+    /// \see_opencl_ref{clEnqueueMapImage}
+    void* enqueue_map_image(const image_object &image,
+                            cl_map_flags flags,
+                            const size_t *origin,
+                            const size_t *region,
+                            size_t &output_row_pitch,
+                            size_t &output_slice_pitch,
+                            event &map_image_event,
+                            const wait_list &events = wait_list())
+    {
+        BOOST_ASSERT(m_queue != 0);
+        BOOST_ASSERT(image.get_context() == this->get_context());
+
+        cl_int ret = 0;
+        void *pointer = clEnqueueMapImage(
+            m_queue,
+            image.get(),
+            CL_TRUE,
+            flags,
+            origin,
+            region,
+            &output_row_pitch,
+            &output_slice_pitch,
+            events.size(),
+            events.get_event_ptr(),
+            &map_image_event.get(),
+            &ret
+        );
+
+        if(ret != CL_SUCCESS){
+            BOOST_THROW_EXCEPTION(opencl_error(ret));
+        }
+
+        return pointer;
+    }
+
+    /// \overload
+    void* enqueue_map_image(const image_object &image,
+                            cl_map_flags flags,
+                            const size_t *origin,
+                            const size_t *region,
+                            size_t &output_row_pitch,
+                            size_t &output_slice_pitch,
+                            const wait_list &events = wait_list())
+    {
+        event event_;
+        return enqueue_map_image(
+            image, flags, origin, region,
+            output_row_pitch, output_slice_pitch, event_, events
+        );
+    }
+
+    /// \overload
+    template<size_t N>
+    void* enqueue_map_image(image_object& image,
+                            cl_map_flags flags,
+                            const extents<N> origin,
+                            const extents<N> region,
+                            size_t &output_row_pitch,
+                            size_t &output_slice_pitch,
+                            event &map_image_event,
+                            const wait_list &events = wait_list())
+    {
+        BOOST_ASSERT(image.get_context() == this->get_context());
+
+        size_t origin3[3] = { 0, 0, 0 };
+        size_t region3[3] = { 1, 1, 1 };
+
+        std::copy(origin.data(), origin.data() + N, origin3);
+        std::copy(region.data(), region.data() + N, region3);
+
+        return enqueue_map_image(
+            image, flags, origin3, region3,
+            output_row_pitch, output_slice_pitch, map_image_event, events
+        );
+    }
+
+    /// \overload
+    template<size_t N>
+    void* enqueue_map_image(image_object& image,
+                            cl_map_flags flags,
+                            const extents<N> origin,
+                            const extents<N> region,
+                            size_t &output_row_pitch,
+                            size_t &output_slice_pitch,
+                            const wait_list &events = wait_list())
+    {
+        event event_;
+        return enqueue_map_image(
+            image, flags, origin, region,
+            output_row_pitch, output_slice_pitch, event_, events
+        );
+    }
+
+    /// Enqueues a command to map \p image into the host address space.
+    /// Map operation is performed asynchronously. The pointer to the mapped
+    /// region cannot be used until the map operation has completed.
+    ///
+    /// Event associated with map operation is returned through
+    /// \p map_image_event parameter.
+    ///
+    /// \see_opencl_ref{clEnqueueMapImage}
+    void* enqueue_map_image_async(const image_object &image,
+                                  cl_map_flags flags,
+                                  const size_t *origin,
+                                  const size_t *region,
+                                  size_t &output_row_pitch,
+                                  size_t &output_slice_pitch,
+                                  event &map_image_event,
+                                  const wait_list &events = wait_list())
+    {
+        BOOST_ASSERT(m_queue != 0);
+        BOOST_ASSERT(image.get_context() == this->get_context());
+
+        cl_int ret = 0;
+        void *pointer = clEnqueueMapImage(
+            m_queue,
+            image.get(),
+            CL_FALSE,
+            flags,
+            origin,
+            region,
+            &output_row_pitch,
+            &output_slice_pitch,
+            events.size(),
+            events.get_event_ptr(),
+            &map_image_event.get(),
+            &ret
+        );
+
+        if(ret != CL_SUCCESS){
+            BOOST_THROW_EXCEPTION(opencl_error(ret));
+        }
+
+        return pointer;
+    }
+
+    /// \overload
+    template<size_t N>
+    void* enqueue_map_image_async(image_object& image,
+                                  cl_map_flags flags,
+                                  const extents<N> origin,
+                                  const extents<N> region,
+                                  size_t &output_row_pitch,
+                                  size_t &output_slice_pitch,
+                                  event &map_image_event,
+                                  const wait_list &events = wait_list())
+    {
+        BOOST_ASSERT(image.get_context() == this->get_context());
+
+        size_t origin3[3] = { 0, 0, 0 };
+        size_t region3[3] = { 1, 1, 1 };
+
+        std::copy(origin.data(), origin.data() + N, origin3);
+        std::copy(region.data(), region.data() + N, region3);
+
+        return enqueue_map_image_async(
+            image, flags, origin3, region3,
+            output_row_pitch, output_slice_pitch, map_image_event, events
+        );
+    }
+
+    /// Enqueues a command to unmap \p image from the host memory space.
+    ///
+    /// \see_opencl_ref{clEnqueueUnmapMemObject}
+    event enqueue_unmap_image(const image_object &image,
+                              void *mapped_ptr,
+                              const wait_list &events = wait_list())
+    {
+        BOOST_ASSERT(image.get_context() == this->get_context());
+
+        return enqueue_unmap_mem_object(image.get(), mapped_ptr, events);
+    }
+
     /// Enqueues a command to copy data from \p src_image to \p dst_image.
     ///
     /// \see_opencl_ref{clEnqueueCopyImage}

--- a/include/boost/compute/command_queue.hpp
+++ b/include/boost/compute/command_queue.hpp
@@ -358,6 +358,53 @@ public:
             BOOST_THROW_EXCEPTION(opencl_error(ret));
         }
     }
+
+    /// Enqueues a command to read a rectangular region from \p buffer to
+    /// host memory. The copy will be performed asynchronously.
+    ///
+    /// \see_opencl_ref{clEnqueueReadBufferRect}
+    ///
+    /// \opencl_version_warning{1,1}
+    event enqueue_read_buffer_rect_async(const buffer &buffer,
+                                         const size_t buffer_origin[3],
+                                         const size_t host_origin[3],
+                                         const size_t region[3],
+                                         size_t buffer_row_pitch,
+                                         size_t buffer_slice_pitch,
+                                         size_t host_row_pitch,
+                                         size_t host_slice_pitch,
+                                         void *host_ptr,
+                                         const wait_list &events = wait_list())
+    {
+        BOOST_ASSERT(m_queue != 0);
+        BOOST_ASSERT(buffer.get_context() == this->get_context());
+        BOOST_ASSERT(host_ptr != 0);
+
+        event event_;
+
+        cl_int ret = clEnqueueReadBufferRect(
+            m_queue,
+            buffer.get(),
+            CL_FALSE,
+            buffer_origin,
+            host_origin,
+            region,
+            buffer_row_pitch,
+            buffer_slice_pitch,
+            host_row_pitch,
+            host_slice_pitch,
+            host_ptr,
+            events.size(),
+            events.get_event_ptr(),
+            &event_.get()
+        );
+
+        if(ret != CL_SUCCESS){
+            BOOST_THROW_EXCEPTION(opencl_error(ret));
+        }
+
+        return event_;
+    }
     #endif // CL_VERSION_1_1
 
     /// Enqueues a command to write data from host memory to \p buffer.
@@ -473,6 +520,53 @@ public:
         if(ret != CL_SUCCESS){
             BOOST_THROW_EXCEPTION(opencl_error(ret));
         }
+    }
+
+    /// Enqueues a command to write a rectangular region from host memory
+    /// to \p buffer. The copy is performed asynchronously.
+    ///
+    /// \see_opencl_ref{clEnqueueWriteBufferRect}
+    ///
+    /// \opencl_version_warning{1,1}
+    event enqueue_write_buffer_rect_async(const buffer &buffer,
+                                          const size_t buffer_origin[3],
+                                          const size_t host_origin[3],
+                                          const size_t region[3],
+                                          size_t buffer_row_pitch,
+                                          size_t buffer_slice_pitch,
+                                          size_t host_row_pitch,
+                                          size_t host_slice_pitch,
+                                          void *host_ptr,
+                                          const wait_list &events = wait_list())
+    {
+        BOOST_ASSERT(m_queue != 0);
+        BOOST_ASSERT(buffer.get_context() == this->get_context());
+        BOOST_ASSERT(host_ptr != 0);
+
+        event event_;
+
+        cl_int ret = clEnqueueWriteBufferRect(
+            m_queue,
+            buffer.get(),
+            CL_FALSE,
+            buffer_origin,
+            host_origin,
+            region,
+            buffer_row_pitch,
+            buffer_slice_pitch,
+            host_row_pitch,
+            host_slice_pitch,
+            host_ptr,
+            events.size(),
+            events.get_event_ptr(),
+            &event_.get()
+        );
+
+        if(ret != CL_SUCCESS){
+            BOOST_THROW_EXCEPTION(opencl_error(ret));
+        }
+
+        return event_;
     }
     #endif // CL_VERSION_1_1
 
@@ -651,6 +745,46 @@ public:
     {
         event event_;
         return enqueue_map_buffer(buffer, flags, offset, size, event_, events);
+    }
+
+    /// Enqueues a command to map \p buffer into the host address space.
+    /// Map operation is performed asynchronously. The pointer to the mapped
+    /// region cannot be used until the map operation has completed.
+    ///
+    /// Event associated with map operation is returned through
+    /// \p map_buffer_event parameter.
+    ///
+    /// \see_opencl_ref{clEnqueueMapBuffer}
+    void* enqueue_map_buffer_async(const buffer &buffer,
+                                   cl_map_flags flags,
+                                   size_t offset,
+                                   size_t size,
+                                   event &map_buffer_event,
+                                   const wait_list &events = wait_list())
+    {
+        BOOST_ASSERT(m_queue != 0);
+        BOOST_ASSERT(offset + size <= buffer.size());
+        BOOST_ASSERT(buffer.get_context() == this->get_context());
+
+        cl_int ret = 0;
+        void *pointer = clEnqueueMapBuffer(
+            m_queue,
+            buffer.get(),
+            CL_FALSE,
+            flags,
+            offset,
+            size,
+            events.size(),
+            events.get_event_ptr(),
+            &map_buffer_event.get(),
+            &ret
+        );
+
+        if(ret != CL_SUCCESS){
+            BOOST_THROW_EXCEPTION(opencl_error(ret));
+        }
+
+        return pointer;
     }
 
     /// Enqueues a command to unmap \p buffer from the host memory space.


### PR DESCRIPTION
This addresses https://github.com/boostorg/compute/issues/365 (https://github.com/boostorg/compute/pull/496 only partiality fixed that issue). Now `enqueue_map_buffer()` returns associated event through non-const parameter `map_buffer_event` (there is also overload without this parameter).
 
I also added missing enqueue_map_image method (with test in `test_image2d.cpp`) and asynchronous versions for enqueue_map_buffer(), enqueue_read_buffer_rect() and enqueue_write_buffer_rect().

