### PR TITLE
Fix for search and search_n algorithm

### DIFF
--- a/include/boost/compute/algorithm/search_n.hpp
+++ b/include/boost/compute/algorithm/search_n.hpp
@@ -92,9 +92,9 @@ private:
 ///
 /// \brief Substring matching algorithm
 ///
-/// Searches for the first occurence of n consecutive occurences of
+/// Searches for the first occurrence of n consecutive occurrences of
 /// value in text [t_first, t_last).
-/// \return Iterator pointing to beginning of first occurence
+/// \return Iterator pointing to beginning of first occurrence
 ///
 /// \param t_first Iterator pointing to start of text
 /// \param t_last Iterator pointing to end of text
@@ -109,9 +109,14 @@ inline TextIterator search_n(TextIterator t_first,
                              ValueType value,
                              command_queue &queue = system::default_queue())
 {
-    vector<uint_> matching_indices(detail::iterator_range_size(t_first, t_last),
-                                    queue.get_context());
+    // there is no need to check if pattern starts at last n - 1 indices
+    vector<uint_> matching_indices(
+        detail::iterator_range_size(t_first, t_last) + 1 - n,
+        queue.get_context()
+    );
 
+    // search_n_kernel puts value 1 at every index in vector where pattern
+    // of n values starts at
     detail::search_n_kernel<TextIterator,
                             vector<uint_>::iterator> kernel;
 
@@ -121,6 +126,10 @@ inline TextIterator search_n(TextIterator t_first,
     vector<uint_>::iterator index = ::boost::compute::find(
         matching_indices.begin(), matching_indices.end(), uint_(1), queue
     );
+
+    // pattern was not found
+    if(index == matching_indices.end())
+        return t_last;
 
     return t_first + detail::iterator_range_size(matching_indices.begin(), index);
 }

--- a/test/test_search.cpp
+++ b/test/test_search.cpp
@@ -24,8 +24,8 @@ namespace bc = boost::compute;
 
 BOOST_AUTO_TEST_CASE(search_int)
 {
-    int data[] = {1, 4, 2, 6, 3, 2, 6, 3, 4, 6};
-    bc::vector<bc::int_> vectort(data, data + 10, queue);
+    int data[] = {1, 4, 2, 6, 3, 2, 6, 3, 4, 6, 6};
+    bc::vector<bc::int_> vectort(data, data + 11, queue);
 
     int datap[] = {2, 6};
     bc::vector<bc::int_> vectorp(datap, datap + 2, queue);
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(search_int)
         bc::search(vectort.begin(), vectort.end(),
                     vectorp.begin(), vectorp.end(), queue);
 
-    BOOST_VERIFY(iter == vectort.begin() + 2);
+    BOOST_CHECK(iter == vectort.begin() + 2);
 
     vectorp[1] = 9;
 
@@ -42,7 +42,16 @@ BOOST_AUTO_TEST_CASE(search_int)
         bc::search(vectort.begin(), vectort.end(),
                     vectorp.begin(), vectorp.end(), queue);
 
-    BOOST_VERIFY(iter == vectort.begin() + 10);
+    BOOST_CHECK(iter == vectort.begin() + 11);
+
+    vectorp[0] = 6;
+    vectorp[1] = 6;
+
+    iter =
+        bc::search(vectort.begin(), vectort.end(),
+                    vectorp.begin(), vectorp.end(), queue);
+
+    BOOST_CHECK(iter == vectort.begin() + 9);
 }
 
 BOOST_AUTO_TEST_CASE(search_string)
@@ -57,7 +66,7 @@ BOOST_AUTO_TEST_CASE(search_string)
         bc::search(vectort.begin(), vectort.end(),
                     vectorp.begin(), vectorp.end(), queue);
 
-    BOOST_VERIFY(iter == vectort.begin() + 2);
+    BOOST_CHECK(iter == vectort.begin() + 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_search_n.cpp
+++ b/test/test_search_n.cpp
@@ -23,18 +23,23 @@ namespace bc = boost::compute;
 
 BOOST_AUTO_TEST_CASE(search_int)
 {
-    int data[] = {1, 2, 2, 2, 3, 2, 2, 2, 4, 6};
-    bc::vector<bc::int_> vectort(data, data + 10, queue);
+    int data[] = {1, 2, 2, 2, 3, 2, 2, 2, 4, 6, 6};
+    bc::vector<bc::int_> vectort(data, data + 11, queue);
 
     bc::vector<bc::int_>::iterator iter =
         bc::search_n(vectort.begin(), vectort.end(), 3, 2, queue);
 
-    BOOST_VERIFY(iter == vectort.begin() + 1);
+    BOOST_CHECK(iter == vectort.begin() + 1);
 
     iter =
         bc::search_n(vectort.begin(), vectort.end(), 5, 2, queue);
 
-    BOOST_VERIFY(iter == vectort.begin() + 10);
+    BOOST_CHECK(iter == vectort.begin() + 11);
+
+    iter =
+        bc::search_n(vectort.begin(), vectort.end(), 2, 6, queue);
+
+    BOOST_CHECK(iter == vectort.begin() + 9);
 }
 
 BOOST_AUTO_TEST_CASE(search_string)
@@ -45,7 +50,7 @@ BOOST_AUTO_TEST_CASE(search_string)
     bc::vector<bc::char_>::iterator iter =
         bc::search_n(vectort.begin(), vectort.end(), 2, 'a', queue);
 
-    BOOST_VERIFY(iter == vectort.begin() + 2);
+    BOOST_CHECK(iter == vectort.begin() + 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This addresses https://github.com/boostorg/compute/issues/245.

I found the bug:

If you analyse [search_n](https://github.com/boostorg/compute/blob/master/include/boost/compute/algorithm/search_n.hpp) (check lines 52, 53, 79), you'll see that it puts 1 or 0 in the first `iterator_range_size(t_first, t_last) + 1 - n` positions (that happens in kernel), but later first occurrence of value 1 is searched in range `[matching_indices.begin(); matching_indices.end())` (line 121). The same bug is in `search`.

I fixed it by reducing the size of `matching_indices` to `iterator_range_size(t_first, t_last) + 1 - n`  and adding if clause for cases when pattern does not occur in input vector.

I also added tests to make sure that the pattern gets found even when it occurs at the end of the input vector.