### PR TITLE
Fix and improve binary_find

### DIFF
--- a/perf/perf_binary_find.cpp
+++ b/perf/perf_binary_find.cpp
@@ -52,6 +52,10 @@ int main(int argc, char *argv[])
         device_vector.begin(), device_vector.end(), _1 < 20, queue
     );
 
+    // just to be sure everything is finished before measuring execution time
+    // of binary_find algorithm
+    queue.finish();
+
     perf_timer t;
     for(size_t trial = 0; trial < PERF_TRIALS; trial++){
         t.start();

--- a/test/test_binary_search.cpp
+++ b/test/test_binary_search.cpp
@@ -15,6 +15,7 @@
 
 #include <boost/compute/command_queue.hpp>
 #include <boost/compute/algorithm/binary_search.hpp>
+#include <boost/compute/algorithm/fill.hpp>
 #include <boost/compute/algorithm/lower_bound.hpp>
 #include <boost/compute/algorithm/upper_bound.hpp>
 #include <boost/compute/container/vector.hpp>
@@ -23,8 +24,22 @@
 
 BOOST_AUTO_TEST_CASE(binary_search_int)
 {
-    int data[] = { 1, 2, 2, 2, 4, 4, 5, 7 };
-    boost::compute::vector<int> vector(data, data + 8, queue);
+    // test data = { 1, ..., 2, ..., 4, 4, 5, 7, ..., 9, ..., 10 }
+    boost::compute::vector<int> vector(size_t(4096), int(1), queue);
+    boost::compute::vector<int>::iterator first = vector.begin() + 128;
+    boost::compute::vector<int>::iterator last = first + (1024 - 128);
+    boost::compute::fill(first, last, int(2), queue);
+    last.write(4, queue); last++;
+    last.write(4, queue); last++;
+    last.write(5, queue); last++;
+    first = last;
+    last = first + 127;
+    boost::compute::fill(first, last, 7, queue);
+    first = last;
+    last = vector.end() - 1;
+    boost::compute::fill(first, last, 9, queue);
+    last.write(10, queue);
+    queue.finish();
 
     BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(0), queue) == false);
     BOOST_CHECK(boost::compute::binary_search(vector.begin(), vector.end(), int(1), queue) == true);
@@ -39,29 +54,49 @@ BOOST_AUTO_TEST_CASE(binary_search_int)
 
 BOOST_AUTO_TEST_CASE(range_bounds_int)
 {
-    int data[] = { 1, 2, 2, 2, 3, 3, 4, 5 };
-    boost::compute::vector<int> vector(data, data + 8, queue);
+    // test data = { 1, ..., 2, ..., 4, 4, 5, 7, ..., 9, ..., 10 }
+    boost::compute::vector<int> vector(size_t(4096), int(1), queue);
+    boost::compute::vector<int>::iterator first = vector.begin() + 128;
+    boost::compute::vector<int>::iterator last = first + (1024 - 128);
+    boost::compute::fill(first, last, int(2), queue);
+    last.write(4, queue); last++; // 1024
+    last.write(4, queue); last++; // 1025
+    last.write(5, queue); last++; // 1026
+    first = last;
+    last = first + 127;
+    boost::compute::fill(first, last, 7, queue);
+    first = last;
+    last = vector.end() - 1;
+    boost::compute::fill(first, last, 9, queue);
+    last.write(10, queue);
+    queue.finish();
 
     BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(0), queue) == vector.begin());
     BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(0), queue) == vector.begin());
 
     BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(1), queue) == vector.begin());
-    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(1), queue) == vector.begin() + 1);
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(1), queue) == vector.begin() + 128);
 
-    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(2), queue) == vector.begin() + 1);
-    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(2), queue) == vector.begin() + 4);
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(2), queue) == vector.begin() + 128);
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(2), queue) == vector.begin() + 1024);
 
-    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(3), queue) == vector.begin() + 4);
-    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(3), queue) == vector.begin() + 6);
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(4), queue) == vector.begin() + 1024);
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(4), queue) == vector.begin() + 1026);
 
-    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(4), queue) == vector.begin() + 6);
-    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(4), queue) == vector.begin() + 7);
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(5), queue) == vector.begin() + 1026);
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(5), queue) == vector.begin() + 1027);
 
-    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(5), queue) == vector.begin() + 7);
-    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(5), queue) == vector.end());
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(6), queue) == vector.begin() + 1027);
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(6), queue) == vector.begin() + 1027);
 
-    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(6), queue) == vector.end());
-    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(6), queue) == vector.end());
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(7), queue) == vector.begin() + 1027);
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(7), queue) == vector.begin() + (1027 + 127));
+
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(9), queue) == vector.begin() + (1027 + 127));
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(9), queue) == vector.end() - 1);
+
+    BOOST_CHECK(boost::compute::lower_bound(vector.begin(), vector.end(), int(10), queue) == vector.end() - 1);
+    BOOST_CHECK(boost::compute::upper_bound(vector.begin(), vector.end(), int(10), queue) == vector.end());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This fixes binary_find algorithm. There was a bug which resulted in iterators going out of range and causing errors. Thanks to StreamComputing for reporting this.

Unfortunately, binary_search test could not find those errors as the test data was too small and binary_find kernel was not used (while loop condition was false from the beginning). I fixed that in the first commit. You can check that tests fails on this commit (binary_find is fixed in the next one).

I also improved performance of binary_find. The kernel was compiled in every while loop iteration, now it's compiled only once.

```
=== binary_find with compute === [ MASTER ]
size,time (ms)
2,0.151978
4,0.224376
8,0.224038
16,0.223790
32,0.224597
64,0.233016
128,0.225822
256,0.333630
512,0.320126
1024,0.314016
2048,0.336053
4096,0.319131
8192,0.338581
16384,0.319498
32768,0.471885
65536,0.471218
131072,0.500875
262144,0.502241
524288,0.471816
1048576,0.504494
2097152,0.505633
4194304,0.625844
8388608,0.649150
16777216,0.652294
33554432,0.612243

=== binary_find with compute === [ NEW ]
size,time (ms)
2,0.188248
4,0.200487
8,0.188612
16,0.197525
32,0.188116
64,0.186364
128,0.189061
256,0.315787
512,0.311341
1024,0.308369
2048,0.310370
4096,0.312330
8192,0.313158
16384,0.390791
32768,0.394320
65536,0.452234
131072,0.393403
262144,0.394118
524288,0.392044
1048576,0.298422 
2097152,0.392095
4194304,0.460290
8388608,0.460898
16777216,0.461379
33554432,0.460215
```
Do not pay attention to artefacts like `1048576,0.298422` (compared to `524288,0.392044`), they occur due to input data randomness - when after while loop in binary_find `search_first == search_last` and `find_if` is not executed.