### PR TITLE
Add array support to BOOST_COMPUTE_ADAPT_STRUCT()

### DIFF
--- a/include/boost/compute/types/struct.hpp
+++ b/include/boost/compute/types/struct.hpp
@@ -38,6 +38,15 @@ inline std::string adapt_struct_insert_member(T Struct::*, const char *name)
     return s.str();
 }
 
+
+template<class Struct, class T, int N>
+inline std::string adapt_struct_insert_member(T (Struct::*)[N], const char *name)
+{
+    std::stringstream s;
+    s << "    " << type_name<T>() << " " << name << "[" << N << "]" << ";\n";
+    return s.str();
+}
+
 } // end detail namespace
 } // end compute namespace
 } // end boost namespace


### PR DESCRIPTION
This adds support for C-style arrays (e.g. "int array[10]") to the
BOOST_COMPUTE_ADAPT_STRUCT() macro.

Thanks to Fabian Bösch for providing the code.