### PR TITLE
Runtime OpenCL version check in tests

### DIFF
--- a/perf/perf_bolt_saxpy.cpp
+++ b/perf/perf_bolt_saxpy.cpp
@@ -29,7 +29,7 @@ BOLT_FUNCTOR(saxpy_functor,
             return _a * x + y;
         };
     };
-);
+)
 
 int main(int argc, char *argv[])
 {

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -164,6 +164,8 @@ BOOST_AUTO_TEST_CASE(destructor_templated_callback)
 
 BOOST_AUTO_TEST_CASE(create_subbuffer)
 {
+    REQUIRES_OPENCL_VERSION(1, 1);
+
     size_t base_addr_align = device.get_info<CL_DEVICE_MEM_BASE_ADDR_ALIGN>() / 8;
     size_t multiplier = 16;
     size_t buffer_size = base_addr_align * multiplier;

--- a/test/test_command_queue.cpp
+++ b/test/test_command_queue.cpp
@@ -137,13 +137,17 @@ BOOST_AUTO_TEST_CASE(kernel_profiling)
 BOOST_AUTO_TEST_CASE(construct_from_cl_command_queue)
 {
     // create cl_command_queue
+    cl_command_queue cl_queue;
 #ifdef CL_VERSION_2_0
-    cl_command_queue cl_queue =
-      clCreateCommandQueueWithProperties(context, device.id(), 0, 0);
-#else
-    cl_command_queue cl_queue =
-      clCreateCommandQueue(context, device.id(), 0, 0);
-#endif
+    if (device.check_version(2, 0)){ // runtime check
+        cl_queue =
+            clCreateCommandQueueWithProperties(context, device.id(), 0, 0);
+    } else
+#endif // CL_VERSION_2_0
+    {
+        cl_queue =
+            clCreateCommandQueue(context, device.id(), 0, 0);
+    }
     BOOST_VERIFY(cl_queue);
 
     // create boost::compute::command_queue
@@ -160,6 +164,8 @@ BOOST_AUTO_TEST_CASE(construct_from_cl_command_queue)
 #ifdef CL_VERSION_1_1
 BOOST_AUTO_TEST_CASE(write_buffer_rect)
 {
+    REQUIRES_OPENCL_VERSION(1, 1);
+
     // skip this test on AMD GPUs due to a buggy implementation
     // of the clEnqueueWriteBufferRect() function
     if(device.vendor() == "Advanced Micro Devices, Inc." &&

--- a/test/test_copy.cpp
+++ b/test/test_copy.cpp
@@ -283,6 +283,8 @@ BOOST_AUTO_TEST_CASE(check_copy_type)
 #ifdef CL_VERSION_2_0
 BOOST_AUTO_TEST_CASE(copy_svm_ptr)
 {
+    REQUIRES_OPENCL_VERSION(2, 0);
+
     int data[] = { 1, 3, 2, 4 };
 
     compute::svm_ptr<int> ptr = compute::svm_alloc<int>(context, 4);

--- a/test/test_fill.cpp
+++ b/test/test_fill.cpp
@@ -290,6 +290,8 @@ BOOST_AUTO_TEST_CASE(fill_clone_buffer)
 #ifdef CL_VERSION_2_0
 BOOST_AUTO_TEST_CASE(fill_svm_buffer)
 {
+    REQUIRES_OPENCL_VERSION(2, 0);
+
     bc::svm_ptr<int> ptr = bc::svm_alloc<int>(context, 16);
     bc::fill_n(ptr, 16, 42, queue);
 

--- a/test/test_image1d.cpp
+++ b/test/test_image1d.cpp
@@ -30,6 +30,8 @@ BOOST_AUTO_TEST_CASE(image1d_get_supported_formats)
 #ifdef CL_VERSION_1_2
 BOOST_AUTO_TEST_CASE(fill_image1d)
 {
+    REQUIRES_OPENCL_VERSION(1, 2); // device OpenCL version check
+
     // single-channel unsigned char
     compute::image_format format(CL_R, CL_UNSIGNED_INT8);
 

--- a/test/test_image2d.cpp
+++ b/test/test_image2d.cpp
@@ -123,6 +123,8 @@ BOOST_AUTO_TEST_CASE(clone_image)
 #ifdef CL_VERSION_1_2
 BOOST_AUTO_TEST_CASE(fill_image)
 {
+    REQUIRES_OPENCL_VERSION(1, 2); // device OpenCL version check
+
     compute::image_format format(CL_RGBA, CL_UNSIGNED_INT8);
 
     if(!compute::image2d::is_supported_format(format, context)){

--- a/test/test_pipe.cpp
+++ b/test/test_pipe.cpp
@@ -25,6 +25,8 @@ BOOST_AUTO_TEST_CASE(empty)
 #ifdef CL_VERSION_2_0
 BOOST_AUTO_TEST_CASE(create_pipe)
 {
+    REQUIRES_OPENCL_VERSION(2, 0);
+
     compute::pipe pipe(context, 16 * sizeof(float), 128);
     BOOST_CHECK_EQUAL(pipe.get_info<CL_PIPE_PACKET_SIZE>(), 64);
     BOOST_CHECK_EQUAL(pipe.get_info<CL_PIPE_MAX_PACKETS>(), 128);

--- a/test/test_svm_ptr.cpp
+++ b/test/test_svm_ptr.cpp
@@ -28,12 +28,16 @@ BOOST_AUTO_TEST_CASE(empty)
 #ifdef CL_VERSION_2_0
 BOOST_AUTO_TEST_CASE(alloc)
 {
+    REQUIRES_OPENCL_VERSION(2, 0);
+
     compute::svm_ptr<int> ptr = compute::svm_alloc<int>(context, 8);
     compute::svm_free(context, ptr);
 }
 
 BOOST_AUTO_TEST_CASE(sum_svm_kernel)
 {
+    REQUIRES_OPENCL_VERSION(2, 0);
+
     const char source[] = BOOST_COMPUTE_STRINGIZE_SOURCE(
         __kernel void sum_svm_mem(__global const int *ptr, __global int *result)
         {

--- a/test/test_user_event.cpp
+++ b/test/test_user_event.cpp
@@ -20,6 +20,8 @@ BOOST_AUTO_TEST_CASE(empty){}
 #ifdef CL_VERSION_1_1
 BOOST_AUTO_TEST_CASE(user_event)
 {
+    REQUIRES_OPENCL_VERSION(1, 1);
+
     boost::compute::user_event event(context);
     BOOST_CHECK(event.get() != cl_event());
     BOOST_CHECK(event.status() != CL_COMPLETE);


### PR DESCRIPTION
I installed AMD APP SKD 3.0 which has OpenCL 2.0 `cl.h` (`CL_VERSION_2_0` macro is defined in it) and since my GPU does not support OpenCL 2.0 I got errors with some tests. 

I fixed it by adding runtime OpenCL version check in those tests. I did the same with tests that require OpenCL 1.1 or 1.2. Now you can have `cl.h` defining `CL_VERSION_2_0` and OpenCL 1.0 device and tests should pass.