### PR TITLE
Vector with custom allocator fix

### DIFF
--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -19,6 +19,7 @@
 #include <boost/compute/algorithm/fill.hpp>
 #include <boost/compute/algorithm/find.hpp>
 #include <boost/compute/algorithm/remove.hpp>
+#include <boost/compute/allocator/pinned_allocator.hpp>
 #include <boost/compute/container/vector.hpp>
 
 #include "check_macros.hpp"
@@ -189,6 +190,22 @@ BOOST_AUTO_TEST_CASE(move_ctor)
       CHECK_RANGE_EQUAL(int, 4, a, (11, 12, 13, 14));
 
       bc::vector<int> b(std::move(a));
+      BOOST_CHECK(a.size() == 0);
+      BOOST_CHECK(a.get_buffer().get() == 0);
+      BOOST_CHECK_EQUAL(b.size(), size_t(4));
+      CHECK_RANGE_EQUAL(int, 4, b, (11, 12, 13, 14));
+}
+
+BOOST_AUTO_TEST_CASE(move_ctor_custom_alloc)
+{
+      int data[] = { 11, 12, 13, 14 };
+      bc::vector<int, bc::pinned_allocator<int> > a(data, data + 4, queue);
+      BOOST_CHECK_EQUAL(a.size(), size_t(4));
+      CHECK_RANGE_EQUAL(int, 4, a, (11, 12, 13, 14));
+
+      bc::vector<int, bc::pinned_allocator<int> > b(std::move(a));
+      BOOST_CHECK(a.size() == 0);
+      BOOST_CHECK(a.get_buffer().get() == 0);
       BOOST_CHECK_EQUAL(b.size(), size_t(4));
       CHECK_RANGE_EQUAL(int, 4, b, (11, 12, 13, 14));
 }

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -347,4 +347,92 @@ BOOST_AUTO_TEST_CASE(resize_throw_exception)
     CHECK_RANGE_EQUAL(int, 8, vec, (1, 2, 3, 4, 5, 6, 7, 8));
 }
 
+BOOST_AUTO_TEST_CASE(copy_ctor_custom_alloc)
+{
+    int data[] = { 11, 12, 13, 14 };
+    bc::vector<int, bc::pinned_allocator<int> > a(data, data + 4, queue);
+    BOOST_CHECK_EQUAL(a.size(), size_t(4));
+    CHECK_RANGE_EQUAL(int, 4, a, (11, 12, 13, 14));
+
+    bc::vector<int, bc::pinned_allocator<int> > b(a, queue);
+    BOOST_CHECK_EQUAL(b.size(), size_t(4));
+    CHECK_RANGE_EQUAL(int, 4, b, (11, 12, 13, 14));
+}
+
+BOOST_AUTO_TEST_CASE(copy_ctor_different_alloc)
+{
+    int data[] = { 11, 12, 13, 14 };
+    bc::vector<int> a(data, data + 4, queue);
+    BOOST_CHECK_EQUAL(a.size(), size_t(4));
+    CHECK_RANGE_EQUAL(int, 4, a, (11, 12, 13, 14));
+
+    bc::vector<int, bc::pinned_allocator<int> > b(a, queue);
+    BOOST_CHECK_EQUAL(b.size(), size_t(4));
+    CHECK_RANGE_EQUAL(int, 4, b, (11, 12, 13, 14));
+
+    std::vector<int> host_vector;
+    host_vector.push_back(1);
+    host_vector.push_back(9);
+    host_vector.push_back(7);
+    host_vector.push_back(9);
+
+    bc::vector<int, bc::pinned_allocator<int> > c(host_vector, queue);
+    BOOST_CHECK_EQUAL(c.size(), size_t(4));
+    CHECK_RANGE_EQUAL(int, 4, c, (1, 9, 7, 9));
+}
+
+BOOST_AUTO_TEST_CASE(assignment_operator)
+{
+    int adata[] = { 11, 12, 13, 14 };
+    bc::vector<int> a(adata, adata + 4, queue);
+    BOOST_CHECK_EQUAL(a.size(), size_t(4));
+    CHECK_RANGE_EQUAL(int, 4, a, (11, 12, 13, 14));
+
+    bc::vector<int> b = a;
+    BOOST_CHECK_EQUAL(b.size(), size_t(4));
+    CHECK_RANGE_EQUAL(int, 4, b, (11, 12, 13, 14));
+
+    bc::vector<int, bc::pinned_allocator<int> > c = b;
+    BOOST_CHECK_EQUAL(c.size(), size_t(4));
+    CHECK_RANGE_EQUAL(int, 4, c, (11, 12, 13, 14));
+
+    int ddata[] = { 21, 22, 23 };
+    bc::vector<int, bc::pinned_allocator<int> > d(ddata, ddata + 3, queue);
+    BOOST_CHECK_EQUAL(d.size(), size_t(3));
+    CHECK_RANGE_EQUAL(int, 3, d, (21, 22, 23));
+
+    a = d;
+    BOOST_CHECK_EQUAL(a.size(), size_t(3));
+    CHECK_RANGE_EQUAL(int, 3, a, (21, 22, 23));
+
+    std::vector<int> host_vector;
+    host_vector.push_back(1);
+    host_vector.push_back(9);
+    host_vector.push_back(7);
+    host_vector.push_back(9);
+
+    d = host_vector;
+    BOOST_CHECK_EQUAL(d.size(), size_t(4));
+    CHECK_RANGE_EQUAL(int, 4, d, (1, 9, 7, 9));
+}
+
+BOOST_AUTO_TEST_CASE(swap_ctor_custom_alloc)
+{
+    int adata[] = { 11, 12, 13, 14 };
+    bc::vector<int, bc::pinned_allocator<int> > a(adata, adata + 4, queue);
+    BOOST_CHECK_EQUAL(a.size(), size_t(4));
+    CHECK_RANGE_EQUAL(int, 4, a, (11, 12, 13, 14));
+
+    int bdata[] = { 21, 22, 23 };
+    bc::vector<int, bc::pinned_allocator<int> > b(bdata, bdata + 3, queue);
+    BOOST_CHECK_EQUAL(b.size(), size_t(3));
+    CHECK_RANGE_EQUAL(int, 3, b, (21, 22, 23));
+
+    a.swap(b);
+    BOOST_CHECK_EQUAL(a.size(), size_t(3));
+    CHECK_RANGE_EQUAL(int, 3, a, (21, 22, 23));
+    BOOST_CHECK_EQUAL(b.size(), size_t(4));
+    CHECK_RANGE_EQUAL(int, 4, b, (11, 12, 13, 14));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
See https://github.com/boostorg/compute/issues/523. 

In the first commit I added test for vector's move constructor when custom allocator is used (in that case `boost::computer::pinned_allocator<T>`).  You can checkout to this commit and see that test fails on `BOOST_CHECK(a.size() == 0)` and `BOOST_CHECK(a.get_buffer().get() == 0)` as the copy constructor is used instead of the move ctor.  It also crashes because of some memory access violation that I can not locate right now.

Second commit adds more tests for vector when used with custom allocator.

The last commit includes fixes @pisto presented in https://github.com/boostorg/compute/issues/523 + I added `queue` parameter to copy constructor and a copy constructor for situations when different allocators are used.


