### PR TITLE
Fix OpenCL 2.0 test cases in test_fill and test_svm_ptr

### DIFF
--- a/test/quirks.hpp
+++ b/test/quirks.hpp
@@ -28,8 +28,17 @@ inline bool is_pocl_device(const boost::compute::device &device)
 // AMD platforms have a bug when using struct assignment. this affects
 // algorithms like fill() when used with pairs/tuples.
 //
-// see: http://devgurus.amd.com/thread/166622
+// see: https://community.amd.com/thread/166622
 inline bool bug_in_struct_assignment(const boost::compute::device &device)
+{
+    return boost::compute::detail::is_amd_device(device);
+}
+
+// clEnqueueSVMMemcpy() operation does not work on AMD devices. This affects
+// copy() algorithm.
+//
+// see: https://community.amd.com/thread/190585
+inline bool bug_in_svmmemcpy(const boost::compute::device &device)
 {
     return boost::compute::detail::is_amd_device(device);
 }

--- a/test/test_copy.cpp
+++ b/test/test_copy.cpp
@@ -29,6 +29,7 @@
 #include <boost/compute/container/vector.hpp>
 #include <boost/compute/iterator/detail/swizzle_iterator.hpp>
 
+#include "quirks.hpp"
 #include "check_macros.hpp"
 #include "context_setup.hpp"
 
@@ -284,6 +285,11 @@ BOOST_AUTO_TEST_CASE(check_copy_type)
 BOOST_AUTO_TEST_CASE(copy_svm_ptr)
 {
     REQUIRES_OPENCL_VERSION(2, 0);
+
+    if(bug_in_svmmemcpy(device)){
+        std::cerr << "skipping copy_svm_ptr test case" << std::endl;
+        return;
+    }
 
     int data[] = { 1, 3, 2, 4 };
 


### PR DESCRIPTION
See #528.

I replaced broken `enqueue_svm_memcpy()` operations with map, copying and unmap in `test_fill.cpp` and `test_svm_ptr.cpp`.

I also added required `-cl-std=CL2.0` build option in `sum_svm_kernel` test case ([clBuildProgram](https://www.khronos.org/registry/cl/sdk/2.0/docs/man/xhtml/clBuildProgram.html): *Applications are required to specify the –cl-std=CL2.0 option if they want to compile or build their programs with OpenCL C 2.0.*").

This branch is based on develop, because otherwise there are conflicts.