### PR TITLE
program::create_with_source_file doesn't fail with bad input

### DIFF
--- a/include/boost/compute/program.hpp
+++ b/include/boost/compute/program.hpp
@@ -394,6 +394,10 @@ public:
         // open file stream
         std::ifstream stream(file.c_str());
 
+        if(stream.fail()){
+          BOOST_THROW_EXCEPTION(std::ios_base::failure("failed to create stream."));
+        }
+
         // read source
         std::string source(
             (std::istreambuf_iterator<char>(stream)),

--- a/test/test_program.cpp
+++ b/test/test_program.cpp
@@ -55,6 +55,16 @@ BOOST_AUTO_TEST_CASE(program_source)
     BOOST_CHECK_EQUAL(std::string(source), program.source());
 }
 
+BOOST_AUTO_TEST_CASE(program_source_no_file)
+{
+    // create program from a non-existant source file
+    // and verifies it throws.
+    BOOST_CHECK_THROW(boost::compute::program program =
+                      boost::compute::program::create_with_source
+                      (std::string(), context),
+                      std::ios_base::failure);
+}
+
 BOOST_AUTO_TEST_CASE(create_kernel)
 {
     boost::compute::program program =

--- a/test/test_program.cpp
+++ b/test/test_program.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(program_source_no_file)
     // create program from a non-existant source file
     // and verifies it throws.
     BOOST_CHECK_THROW(boost::compute::program program =
-                      boost::compute::program::create_with_source
+                      boost::compute::program::create_with_source_file
                       (std::string(), context),
                       std::ios_base::failure);
 }


### PR DESCRIPTION
Calling boost::compute::program::create_with_source_file silently creates a program if the input filename is incorrect.  Even program.build() succeeds.  This patch throws std::ios_base::failure if stream.fail() is true.  This seems preferable to something else failing way downstream because of a typo in the filename.

I added a test, but didn't actually test it since I'm using this outside the standard boost build system.  I think it should work, but it's easy to figure out what it does.  It simply tries to create a program from a source file, where the filename is an empty string.  The test verifies that this throws.