### PR TITLE
Minor fixes related to Boost Inspection Report (1.60 develop)

### DIFF
--- a/include/boost/compute/algorithm/detail/binary_find.hpp
+++ b/include/boost/compute/algorithm/detail/binary_find.hpp
@@ -114,11 +114,11 @@ inline InputIterator binary_find(InputIterator first,
         }
 
         // Make sure that first and last stay within the input range
-        search_last = std::min(search_last, last);
-        search_last = std::max(search_last, first);
+        search_last = (std::min)(search_last, last);
+        search_last = (std::max)(search_last, first);
 
-        search_first = std::max(search_first, first);
-        search_first = std::min(search_first, last);
+        search_first = (std::max)(search_first, first);
+        search_first = (std::min)(search_first, last);
 
         count = iterator_range_size(search_first, search_last);
     }

--- a/include/boost/compute/algorithm/max_element.hpp
+++ b/include/boost/compute/algorithm/max_element.hpp
@@ -24,7 +24,7 @@ namespace compute {
 ///
 /// \param first first element in the input range
 /// \param last last element in the input range
-/// \param compare comparison function object which returns ​true if the first
+/// \param compare comparison function object which returns true if the first
 ///        argument is less than (i.e. is ordered before) the second.
 /// \param queue command queue to perform the operation
 ///

--- a/include/boost/compute/algorithm/min_element.hpp
+++ b/include/boost/compute/algorithm/min_element.hpp
@@ -24,7 +24,7 @@ namespace compute {
 ///
 /// \param first first element in the input range
 /// \param last last element in the input range
-/// \param compare comparison function object which returns ​true if the first
+/// \param compare comparison function object which returns true if the first
 ///        argument is less than (i.e. is ordered before) the second.
 /// \param queue command queue to perform the operation
 ///

--- a/include/boost/compute/algorithm/minmax_element.hpp
+++ b/include/boost/compute/algorithm/minmax_element.hpp
@@ -27,7 +27,7 @@ namespace compute {
 ///
 /// \param first first element in the input range
 /// \param last last element in the input range
-/// \param compare comparison function object which returns ​true if the first
+/// \param compare comparison function object which returns true if the first
 ///        argument is less than (i.e. is ordered before) the second.
 /// \param queue command queue to perform the operation
 ///


### PR DESCRIPTION
See http://boost.cowic.de/rc/docs-inspect-develop.html#compute

It fixes:
```
boost/compute/algorithm/detail/binary_find.hpp: *M* violation of Boost min/max guidelines on line 117, *M* violation of Boost min/max guidelines on line 118, *M* violation of Boost min/max guidelines on line 120, *M* violation of Boost min/max guidelines on line 121
boost/compute/algorithm/max_element.hpp:
    (line 27) Non-ASCII: /// \param compare comparison function object which returns ​true if the firs
boost/compute/algorithm/min_element.hpp:
    (line 27) Non-ASCII: /// \param compare comparison function object which returns ​true if the firs
boost/compute/algorithm/minmax_element.hpp:
    (line 30) Non-ASCII: /// \param compare comparison function object which returns ​true if the firs
```

If I remember correctly there was a decision that macros will be fix after merging into Boost C++ Libraries, so this pull request does not include commit fixing deprecated macros problem (but it's waiting).