### PR TITLE
Fix incorrect count update in rngs

### DIFF
--- a/include/boost/compute/random/linear_congruential_engine.hpp
+++ b/include/boost/compute/random/linear_congruential_engine.hpp
@@ -102,7 +102,7 @@ public:
     /// \overload
     void seed(command_queue &queue)
     {
-        seed(default_seed);
+        seed(default_seed, queue);
     }
 
     /// Generates random numbers and stores them to the range [\p first, \p last).

--- a/include/boost/compute/random/linear_congruential_engine.hpp
+++ b/include/boost/compute/random/linear_congruential_engine.hpp
@@ -11,6 +11,8 @@
 #ifndef BOOST_COMPUTE_RANDOM_LINEAR_CONGRUENTIAL_ENGINE_HPP
 #define BOOST_COMPUTE_RANDOM_LINEAR_CONGRUENTIAL_ENGINE_HPP
 
+#include <algorithm>
+
 #include <boost/compute/types.hpp>
 #include <boost/compute/buffer.hpp>
 #include <boost/compute/kernel.hpp>
@@ -118,7 +120,7 @@ public:
         for(;;){
             size_t count = 0;
             if(size > threads){
-                count = threads;
+                count = (std::min)(static_cast<size_t>(threads), size - offset);
             }
             else {
                 count = size;

--- a/include/boost/compute/random/mersenne_twister_engine.hpp
+++ b/include/boost/compute/random/mersenne_twister_engine.hpp
@@ -11,6 +11,8 @@
 #ifndef BOOST_COMPUTE_RANDOM_MERSENNE_TWISTER_ENGINE_HPP
 #define BOOST_COMPUTE_RANDOM_MERSENNE_TWISTER_ENGINE_HPP
 
+#include <algorithm>
+
 #include <boost/compute/types.hpp>
 #include <boost/compute/buffer.hpp>
 #include <boost/compute/kernel.hpp>
@@ -111,7 +113,7 @@ public:
         for(;;){
             size_t count = 0;
             if(size > n){
-                count = n;
+                count = (std::min)(static_cast<size_t>(n), size - offset);
             }
             else {
                 count = size;

--- a/include/boost/compute/random/threefry_engine.hpp
+++ b/include/boost/compute/random/threefry_engine.hpp
@@ -11,6 +11,8 @@
 #ifndef BOOST_COMPUTE_RANDOM_THREEFRY_HPP
 #define BOOST_COMPUTE_RANDOM_THREEFRY_HPP
 
+#include <algorithm>
+
 #include <boost/compute/types.hpp>
 #include <boost/compute/buffer.hpp>
 #include <boost/compute/kernel.hpp>
@@ -247,7 +249,7 @@ public:
             size_t count = 0;
             size_t size = size_ctr/2;
             if(size > threads){
-                count = threads;
+                count = (std::min)(static_cast<size_t>(threads), size - offset);
             }
             else {
                 count = size;
@@ -282,7 +284,7 @@ public:
             size_t count = 0;
             size_t size = size_ctr/2;
             if(size > threads){
-                count = threads;
+                count = (std::min)(static_cast<size_t>(threads), size - offset);
             }
             else {
                 count = size;


### PR DESCRIPTION
In `generate` methods in `mersenne_twister_engine`, `linear_congruential_engine` and `threefry_engine` classes there are incorrect updates of count variables. They leads to assigning out-of-range in used kernels. (`#include <algorithm> ` is added for `std::min`.)

In `linear_congruential_engine` there is incorrect `seed` method call: there is no `seed` method with just one parameter of type result_type.