### PR TITLE
Modify mersenne_twister_engine to copy its states.

### DIFF
--- a/include/boost/compute/random/mersenne_twister_engine.hpp
+++ b/include/boost/compute/random/mersenne_twister_engine.hpp
@@ -55,6 +55,8 @@ public:
     /// Creates a new mersenne_twister_engine object as a copy of \p other.
     mersenne_twister_engine(const mersenne_twister_engine<T> &other)
         : m_context(other.m_context),
+          m_state_index(other.m_state_index),
+          m_program(other.m_program),
           m_state_buffer(other.m_state_buffer)
     {
     }
@@ -64,6 +66,9 @@ public:
     {
         if(this != &other){
             m_context = other.m_context;
+            m_state_index = other.m_state_index;
+            m_program = other.m_program;
+            m_state_buffer = other.m_state_buffer;
         }
 
         return *this;

--- a/test/test_mersenne_twister_engine.cpp
+++ b/test/test_mersenne_twister_engine.cpp
@@ -63,4 +63,58 @@ BOOST_AUTO_TEST_CASE(discard_uint)
     );
 }
 
+BOOST_AUTO_TEST_CASE(copy_ctor)
+{
+    using boost::compute::uint_;
+
+    boost::compute::mt19937 rng(queue);
+    boost::compute::mt19937 rng_copy(rng);
+
+    boost::compute::vector<uint_> vector(10, context);
+
+    rng_copy.generate(vector.begin(), vector.end(), queue);
+
+    CHECK_RANGE_EQUAL(
+        uint_, 10, vector,
+        (uint_(3499211612),
+         uint_(581869302),
+         uint_(3890346734),
+         uint_(3586334585),
+         uint_(545404204),
+         uint_(4161255391),
+         uint_(3922919429),
+         uint_(949333985),
+         uint_(2715962298),
+         uint_(1323567403))
+    );
+}
+
+BOOST_AUTO_TEST_CASE(assign_op)
+{
+    using boost::compute::uint_;
+
+    boost::compute::mt19937 rng(queue);
+    boost::compute::mt19937 rng_copy(queue);
+
+    boost::compute::vector<uint_> vector(10, context);
+
+    rng_copy.discard(5, queue);
+	rng_copy = rng;
+    rng_copy.generate(vector.begin(), vector.end(), queue);
+
+    CHECK_RANGE_EQUAL(
+        uint_, 10, vector,
+        (uint_(3499211612),
+         uint_(581869302),
+         uint_(3890346734),
+         uint_(3586334585),
+         uint_(545404204),
+         uint_(4161255391),
+         uint_(3922919429),
+         uint_(949333985),
+         uint_(2715962298),
+         uint_(1323567403))
+    );
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The copy ctor and assign op of compute::mersenne_twister_engine does not copy its states. So copied engine causes "Invalid Program" error.
This modification solves this problem.