### PR TITLE
Fix missing includes.

### DIFF
--- a/test/test_copy.cpp
+++ b/test/test_copy.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <sstream>
 #include <iterator>
+#include <iostream>
 
 #include <boost/compute/svm.hpp>
 #include <boost/compute/system.hpp>

--- a/test/test_svm_ptr.cpp
+++ b/test/test_svm_ptr.cpp
@@ -11,6 +11,8 @@
 #define BOOST_TEST_MODULE TestSvmPtr
 #include <boost/test/unit_test.hpp>
 
+#include <iostream>
+
 #include <boost/compute/core.hpp>
 #include <boost/compute/svm.hpp>
 #include <boost/compute/container/vector.hpp>


### PR DESCRIPTION
see [compute - test_svm_ptr](http://www.boost.org/development/tests/develop/developer/output/Flast-FreeBSD10-gcc-5-2-0~gnu++11-boost-bin-v2-libs-compute-test-test_svm_ptr-test-gcc-5-2-0-debug.html) and [compute - test_copy](http://www.boost.org/development/tests/develop/developer/output/Flast-FreeBSD10-gcc-5-2-0~gnu++11-boost-bin-v2-libs-compute-test-test_copy-test-gcc-5-2-0-debug.html)