### PR TITLE
Timber OSX fixes

### DIFF
--- a/include/boost/compute/algorithm/detail/find_extrema_with_reduce.hpp
+++ b/include/boost/compute/algorithm/detail/find_extrema_with_reduce.hpp
@@ -103,22 +103,24 @@ inline void find_extrema_with_reduce(InputIterator input,
     k <<
         // Work item global id
         k.decl<const uint_>("gid") << " = get_global_id(0);\n" <<
-        "if(gid >= count) {\n    return;\n}\n" <<
 
         // Index of element that will be read from input buffer
         k.decl<uint_>("idx") << " = gid;\n" <<
 
         k.decl<input_type>("acc") << ";\n" <<
-        // Real index of currently best element
-        "#ifdef BOOST_COMPUTE_USE_INPUT_IDX\n" <<
-        k.decl<input_type>("acc_idx") << " = " << input_idx[k.var<uint_>("idx")] << ";\n" <<
-        "#else\n" <<
-        k.decl<uint_>("acc_idx") << " = idx;\n" <<
-        "#endif\n" <<
+        k.decl<uint_>("acc_idx") << ";\n" <<
+        "if(gid < count) {\n" <<
+            // Real index of currently best element
+            "#ifdef BOOST_COMPUTE_USE_INPUT_IDX\n" <<
+            k.var<uint_>("acc_idx") << " = " << input_idx[k.var<uint_>("idx")] << ";\n" <<
+            "#else\n" <<
+            k.var<uint_>("acc_idx") << " = idx;\n" <<
+            "#endif\n" <<
 
-        // Init accumulator with first[get_global_id(0)]
-        "acc = " << input[k.var<uint_>("idx")] << ";\n" <<
-        "idx += get_global_size(0);\n" <<
+            // Init accumulator with first[get_global_id(0)]
+            "acc = " << input[k.var<uint_>("idx")] << ";\n" <<
+            "idx += get_global_size(0);\n" <<
+        "}\n" <<
 
         k.decl<bool>("compare_result") << ";\n" <<
         k.decl<bool>("equal") << ";\n\n" <<

--- a/include/boost/compute/types/fundamental.hpp
+++ b/include/boost/compute/types/fundamental.hpp
@@ -58,7 +58,7 @@ public:
 
     explicit vector_type(const Scalar scalar)
     {
-        for(int i = 0; i < N; i++)
+        for(size_t i = 0; i < N; i++)
             m_value[i] = scalar;
     }
 

--- a/test/test_extents.cpp
+++ b/test/test_extents.cpp
@@ -46,9 +46,9 @@ BOOST_AUTO_TEST_CASE(subscript_operator)
     BOOST_CHECK_EQUAL(xyz[1], size_t(0));
     BOOST_CHECK_EQUAL(xyz[2], size_t(0));
 
-    xyz[0] = 10;
-    xyz[1] = 20;
-    xyz[2] = 30;
+    xyz[0] = size_t(10);
+    xyz[1] = size_t(20);
+    xyz[2] = size_t(30);
     BOOST_CHECK_EQUAL(xyz[0], size_t(10));
     BOOST_CHECK_EQUAL(xyz[1], size_t(20));
     BOOST_CHECK_EQUAL(xyz[2], size_t(30));
@@ -88,9 +88,9 @@ BOOST_AUTO_TEST_CASE(copy_to_vector)
 
     std::vector<size_t> vec(3);
     std::copy(exts.begin(), exts.end(), vec.begin());
-    BOOST_CHECK_EQUAL(vec[0], 4);
-    BOOST_CHECK_EQUAL(vec[1], 5);
-    BOOST_CHECK_EQUAL(vec[2], 6);
+    BOOST_CHECK_EQUAL(vec[0], size_t(4));
+    BOOST_CHECK_EQUAL(vec[1], size_t(5));
+    BOOST_CHECK_EQUAL(vec[2], size_t(6));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_image1d.cpp
+++ b/test/test_image1d.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(fill_image1d)
 
     compute::image1d img(context, 64, format);
 
-    BOOST_CHECK_EQUAL(img.width(), 64);
+    BOOST_CHECK_EQUAL(img.width(), size_t(64));
     BOOST_CHECK(img.size() == compute::dim(64));
     BOOST_CHECK(img.format() == format);
 
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(fill_image1d)
     // read value of first pixel
     compute::uchar_ first_pixel = 0;
     queue.enqueue_read_image(img, compute::dim(0), compute::dim(1), &first_pixel);
-    BOOST_CHECK_EQUAL(first_pixel, 128);
+    BOOST_CHECK_EQUAL(first_pixel, compute::uchar_(128));
 }
 #endif // CL_VERSION_1_2
 

--- a/test/test_image2d.cpp
+++ b/test/test_image2d.cpp
@@ -42,8 +42,8 @@ boost::compute::image2d img(context, 640, 480, rgba8);
         // verify image has been created and format is correct
         BOOST_CHECK(img.get() != cl_mem());
         BOOST_CHECK(img.format() == rgba8);
-        BOOST_CHECK_EQUAL(img.width(), 640);
-        BOOST_CHECK_EQUAL(img.height(), 480);
+        BOOST_CHECK_EQUAL(img.width(), size_t(640));
+        BOOST_CHECK_EQUAL(img.height(), size_t(480));
     }
     catch(compute::opencl_error &e){
         if(e.error_code() == CL_IMAGE_FORMAT_NOT_SUPPORTED){

--- a/test/test_kernel.cpp
+++ b/test/test_kernel.cpp
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(get_arg_info)
 
     compute::kernel kernel = program.create_kernel("sum_kernel");
 
-    BOOST_CHECK_EQUAL(kernel.get_info<CL_KERNEL_NUM_ARGS>(), 3);
+    BOOST_CHECK_EQUAL(kernel.get_info<CL_KERNEL_NUM_ARGS>(), compute::uint_(3));
 
     BOOST_CHECK_EQUAL(kernel.get_arg_info<std::string>(0, CL_KERNEL_ARG_TYPE_NAME), "int*");
     BOOST_CHECK_EQUAL(kernel.get_arg_info<std::string>(0, CL_KERNEL_ARG_NAME), "input");

--- a/test/test_scatter_if.cpp
+++ b/test/test_scatter_if.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(scatter_if_int)
 
     int stencil_data[] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
 
-    bc::vector<uint> stencil(stencil_data, stencil_data + 10, queue);
+    bc::vector<bc::uint_> stencil(stencil_data, stencil_data + 10, queue);
 
     bc::vector<int> output(input.size(), -1, queue);
 
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(scatter_if_constant_indices)
 
     int stencil_data[] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
     bc::buffer stencil_buffer(context,
-                              10 * sizeof(int),
+                              10 * sizeof(bc::uint_),
                               bc::buffer::read_only | bc::buffer::use_host_ptr,
                               stencil_data);
 
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(scatter_if_function)
     bc::vector<int> map(map_data, map_data + 10, queue);
 
     int stencil_data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    bc::vector<uint> stencil(stencil_data, stencil_data + 10, queue);
+    bc::vector<bc::uint_> stencil(stencil_data, stencil_data + 10, queue);
 
     bc::vector<int> output(input.size(), -1, queue);
 

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(erase)
     int data[] = { 1, 2, 5, 7, 9 };
     bc::vector<int> vector(data, data + 5, queue);
     queue.finish();
-    BOOST_CHECK_EQUAL(vector.size(), 5);
+    BOOST_CHECK_EQUAL(vector.size(), size_t(5));
 
     vector.erase(vector.begin() + 1, queue);
     BOOST_CHECK_EQUAL(vector.size(), size_t(4));
@@ -343,7 +343,7 @@ BOOST_AUTO_TEST_CASE(resize_throw_exception)
     );
 
     // ensure vector data is still the same
-    BOOST_CHECK_EQUAL(vec.size(), 8);
+    BOOST_CHECK_EQUAL(vec.size(), size_t(8));
     CHECK_RANGE_EQUAL(int, 8, vec, (1, 2, 3, 4, 5, 6, 7, 8));
 }
 

--- a/test/test_wait_list.cpp
+++ b/test/test_wait_list.cpp
@@ -29,7 +29,7 @@ namespace compute = boost::compute;
 BOOST_AUTO_TEST_CASE(create_wait_list)
 {
     compute::wait_list events;
-    BOOST_CHECK_EQUAL(events.size(), 0);
+    BOOST_CHECK_EQUAL(events.size(), size_t(0));
     BOOST_CHECK_EQUAL(events.empty(), true);
     BOOST_CHECK(events.get_event_ptr() == 0);
 }
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(insert_future)
 
     // add future event to the wait list
     events.insert(future);
-    BOOST_CHECK_EQUAL(events.size(), 1);
+    BOOST_CHECK_EQUAL(events.size(), size_t(1));
     BOOST_CHECK(events.get_event_ptr() != 0);
 
     // wait for copy to complete
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(insert_future)
 
     // clear the event list
     events.clear();
-    BOOST_CHECK_EQUAL(events.size(), 0);
+    BOOST_CHECK_EQUAL(events.size(), size_t(0));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
These are the changes I think should fix some of the problems encountered [here](http://www.boost.org/development/tests/develop/developer/compute.html) on Timber OSX.

The first and the third commits are obvious.  They fix: [warning: comparison between signed and unsigned integer expressions](http://www.boost.org/development/tests/develop/output/timber-osx-compute-darwin-5-3-0-warnings.html#test_image2d) (there is one exception, I can't locate the bug in `test_fill`) and [test_scatter_if fail](http://www.boost.org/development/tests/develop/developer/output/timber-osx-boost-bin-v2-libs-compute-test-test_scatter_if-test-darwin-5-3-0-debug.html).

The second and the forth commits should fix [test_extrema fail](http://www.boost.org/development/tests/develop/developer/output/timber-osx-boost-bin-v2-libs-compute-test-test_extrema-test-darwin-5-3-0-debug.html) and [test_reduce_by_key fail](http://www.boost.org/development/tests/develop/developer/output/timber-osx-boost-bin-v2-libs-compute-test-test_reduce_by_key-test-darwin-5-3-0-debug.html). I think SIGABRT may be caused by the wrong barrier usage (my mistakes; see commits ). It's hard to see those bugs, because they don't show up and don't have any side-effect on most of the GPUs (I'm sure about AMD GPUs with official AMD APP and drivers). I hope they'll help with Timber OSX.