### PR TITLE
Update Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,110 @@
-language: cpp
-compiler:
-    - gcc
-    - clang
+language: cpp       
+
+env:
+  global:
+    - OPENCL_REGISTRY=https://www.khronos.org/registry/cl
+    - OPENCL_ROOT=${TRAVIS_BUILD_DIR}/bin/opencl 
+    - LINUX_DIST=precise
+    - CMAKE_OPTIONS="-DBOOST_COMPUTE_BUILD_TESTS=ON -DBOOST_COMPUTE_BUILD_EXAMPLES=ON -DBOOST_COMPUTE_BUILD_BENCHMARKS=ON -DBOOST_COMPUTE_USE_OFFLINE_CACHE=ON -DBOOST_COMPUTE_ENABLE_COVERAGE=ON -DBOOST_COMPUTE_HAVE_OPENCV=ON -DBOOST_COMPUTE_THREAD_SAFE=ON"
+    - CXX_FLAGS="-Wall -pedantic -Werror -Wno-variadic-macros -Wno-long-long -Wno-shadow -Wno-deprecated-declarations"
+    - ENV_CMAKE_OPTIONS=""
+    - ENV_CXX_FLAGS=""
+    
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+      env: 
+        - LINUX_DIST=trusty
+        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: clang 
+      env: 
+        - LINUX_DIST=trusty    
+        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+    - os: linux
+      sudo: required
+      compiler: clang
+      env:      
+        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+    - os: linux
+      sudo: required
+      compiler: gcc
+      env: 
+        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"   
+    - os: osx
+      compiler: clang
+      env: 
+        - ENV_CXX_FLAGS="-Wno-c99-extensions"     
+  allow_failures:
+    - os: osx
+    
 before_install:
-    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers libboost-chrono1.48-dev libboost-date-time1.48-dev libboost-test1.48-dev libboost-system1.48-dev libboost-filesystem1.48-dev libboost-timer1.48-dev libboost-program-options1.48-dev libboost-thread1.48-dev python-yaml lcov libopencv-dev g++-4.8
+    - if [ ${TRAVIS_OS_NAME} == "linux" ] && [ ${LINUX_DIST} == "trusty" ]; then
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test;
+        sudo add-apt-repository -y ppa:boost-latest/ppa;
+        sudo apt-get update -qq -y;
+        sudo apt-get install -qq libboost-chrono1.55-dev libboost-date-time1.55-dev libboost-test1.55-dev libboost-system1.55-dev libboost-filesystem1.55-dev libboost-timer1.55-dev libboost-program-options1.55-dev libboost-thread1.55-dev python-yaml lcov libopencv-dev g++-4.8;
+      fi
+    - if [ ${TRAVIS_OS_NAME} == "linux" ] && [ ${LINUX_DIST} == "precise" ]; then
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test;
+        sudo apt-get update -qq -y;
+        sudo apt-get install -qq libboost-chrono1.48-dev libboost-date-time1.48-dev libboost-test1.48-dev libboost-system1.48-dev libboost-filesystem1.48-dev libboost-timer1.48-dev libboost-program-options1.48-dev libboost-thread1.48-dev python-yaml lcov libopencv-dev g++-4.8;
+      fi  
+    - if [ ${TRAVIS_OS_NAME} == "osx" ]; then
+        brew update;
+        brew outdated boost || brew upgrade boost;
+        brew outdated cmake || brew upgrade cmake;
+        brew install lcov homebrew/science/opencv;      
+      fi
     - gem install coveralls-lcov
     - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+    # combine global build options with os/compiler-dependent options
+    - export CMAKE_OPTIONS=${CMAKE_OPTIONS}" "${ENV_CMAKE_OPTIONS}
+    - export CXX_FLAGS=${CXX_FLAGS}" "${ENV_CXX_FLAGS}
+    
+install:
+    # fglrx does not work: https://github.com/travis-ci/travis-ci/issues/5221,
+    # so we build our own linkable .so file.
+    # Thanks to clSPARSE for providing opencl-icd build script.
+    - if [ ${TRAVIS_OS_NAME} == "linux" ]; then
+        mkdir -p ${OPENCL_ROOT};
+        pushd ${OPENCL_ROOT};
+        travis_retry wget --no-check-certificate ${OPENCL_REGISTRY}/specs/opencl-icd-1.2.11.0.tgz;
+        tar -xf opencl-icd-1.2.11.0.tgz;
+        mv ./icd/* .;
+        mkdir -p inc/CL;
+        pushd inc/CL;
+        travis_retry wget -r -w 1 -np -nd -nv -A h,hpp --no-check-certificate https://www.khronos.org/registry/cl/api/1.2/;
+        travis_retry wget -w 1 -np -nd -nv -A h,hpp --no-check-certificate https://www.khronos.org/registry/cl/api/2.1/cl.hpp;
+        popd;
+        mkdir -p lib;
+        pushd lib;
+        cmake -G "Unix Makefiles" ..;
+        make;
+        cp ../bin/libOpenCL.so .;
+        popd;
+        mv inc/ include/;
+        popd;
+      fi
+    
 script:
     - mkdir -p build
     - cd build
-    - cmake -DBOOST_COMPUTE_BUILD_TESTS=ON -DBOOST_COMPUTE_BUILD_EXAMPLES=ON -DBOOST_COMPUTE_BUILD_BENCHMARKS=ON -DBOOST_COMPUTE_USE_OFFLINE_CACHE=ON -DBOOST_COMPUTE_ENABLE_COVERAGE=ON -DBOOST_COMPUTE_HAVE_OPENCV=ON -DBOOST_COMPUTE_THREAD_SAFE=ON -DCMAKE_CXX_FLAGS="-Wall -pedantic -Werror -Wno-variadic-macros -Wno-long-long -Wno-shadow" ..
-    - make -j4
-    - ./example/list_devices
-    - ctest --output-on-failure
-    - ctest --output-on-failure
+    - echo ${CMAKE_OPTIONS}
+    - echo ${CXX_FLAGS}
+    - cmake ${CMAKE_OPTIONS} -DCMAKE_CXX_FLAGS=${CXX_FLAGS} ..
+    - make -j4    
+    - if [ ${TRAVIS_OS_NAME} == "osx" ]; then
+        ./example/list_devices;
+        ctest --output-on-failure;
+        ctest --output-on-failure;
+      fi
+    
 after_success:
     - lcov --directory test --base-directory ../include/boost/compute/ --capture --output-file coverage.info
     - lcov --remove coverage.info '/usr*' -o coverage.info

--- a/perf/perf_fill.cpp
+++ b/perf/perf_fill.cpp
@@ -8,6 +8,8 @@
 // See http://boostorg.github.com/compute for more information.
 //---------------------------------------------------------------------------//
 
+#include <iostream>
+
 #include <boost/compute/system.hpp>
 #include <boost/compute/algorithm/fill.hpp>
 #include <boost/compute/container/vector.hpp>


### PR DESCRIPTION
- disable running tests in linux build as fglrx does not work,
- use OpenCL-ICD to in linux build (now we can at least build tests), 
- enable OSX build 
 - currently it's allowed to fail as there are many ``Invalid Work Group Size`` errors, some are legit, some are very weird
 - only clang as building with gcc gives ``Undefined symbols for architecture x86_64:`` errors I don't know how to fix (see https://travis-ci.org/boostorg/compute/jobs/107840912#L3677)

I'll later try POCL drivers + linux. I don't know if we can use Intel OpenCL driver as it works only on Intel CPU (Core, Xeon etc.) and I'm not sure if builds always run on machine with Xeon CPU.