### PR TITLE
[Travis CI] Add POCL builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,110 +1,299 @@
-language: cpp       
+language: cpp
 
 env:
   global:
-    - OPENCL_REGISTRY=https://www.khronos.org/registry/cl
-    - OPENCL_ROOT=${TRAVIS_BUILD_DIR}/bin/opencl 
+    # Ubuntu version
     - LINUX_DIST=precise
+    - DEPS_DIR=${TRAVIS_BUILD_DIR}/deps
+    # OpenCL
+    - OPENCL_LIB=default
+    - OPENCL_VERSION="10"
+    # Khronos OpenCL ICD
+    - OPENCL_REGISTRY=https://www.khronos.org/registry/cl
+    - OPENCL_ROOT=${DEPS_DIR}/opencl
+    # POCL
+    - POCL_VERSION=master
+    - POCL_LLVM_CONFIG="llvm-config-3.7"
+    - POCL_COMPILER=clang++-3.7
+    # Global build options and C++ flags
     - CMAKE_OPTIONS="-DBOOST_COMPUTE_BUILD_TESTS=ON -DBOOST_COMPUTE_BUILD_EXAMPLES=ON -DBOOST_COMPUTE_BUILD_BENCHMARKS=ON -DBOOST_COMPUTE_USE_OFFLINE_CACHE=ON -DBOOST_COMPUTE_ENABLE_COVERAGE=ON -DBOOST_COMPUTE_HAVE_OPENCV=ON -DBOOST_COMPUTE_THREAD_SAFE=ON"
     - CXX_FLAGS="-Wall -pedantic -Werror -Wno-variadic-macros -Wno-long-long -Wno-shadow -Wno-deprecated-declarations"
-    - ENV_CMAKE_OPTIONS=""
-    - ENV_CXX_FLAGS=""
-    
+
 matrix:
   include:
+    ############################################################################
+    # POCL builds (OpenCL 1.0, 1.1)
+    ############################################################################
+
+    # Trusty, OpenCL 1.0
     - os: linux
       dist: trusty
-      sudo: required
-      compiler: gcc
-      env: 
-        - LINUX_DIST=trusty
-        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
-    - os: linux
-      dist: trusty
-      sudo: required
-      compiler: clang 
-      env: 
-        - LINUX_DIST=trusty    
-        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
-    - os: linux
       sudo: required
       compiler: clang
-      env:      
-        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+      addons:
+        apt:
+          packages: &trusty_pocl_packages
+            - g++-4.8
+            # clang and llvm 3.7 for POCL (llvm-toolchain-trusty-3.7 is not whitelisted)
+            # - clang-3.7
+            # - llvm-3.7
+            # - llvm-3.7-dev (...)
+            # POCL
+            - libltdl-dev
+            - libhwloc-dev
+            - pkg-config
+            - libedit-dev
+            # Boost
+            - libboost-chrono1.55-dev
+            - libboost-date-time1.55-dev
+            - libboost-test1.55-dev
+            - libboost-system1.55-dev
+            - libboost-filesystem1.55-dev
+            - libboost-timer1.55-dev
+            - libboost-program-options1.55-dev
+            - libboost-thread1.55-dev
+            # Misc
+            - python-yaml
+            - lcov
+            - libopencv-dev
+          sources: &trusty_pocl_sources
+            - ubuntu-toolchain-r-test
+            # - llvm-toolchain-trusty-3.7 (not whitelisted yet https://github.com/travis-ci/apt-source-whitelist/issues/199)
+      env:
+       - LINUX_DIST=trusty
+       - OPENCL_LIB=pocl
+       - OPENCL_VERSION="10"
+       - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/pocl/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
     - os: linux
+      dist: trusty
       sudo: required
       compiler: gcc
-      env: 
-        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"   
+      addons:
+        apt:
+          packages: *trusty_pocl_packages
+          sources: *trusty_pocl_sources
+      env:
+       - LINUX_DIST=trusty
+       - OPENCL_LIB=pocl
+       - OPENCL_VERSION="10"
+       - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/pocl/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+    # Trusty, OpenCL 1.1
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: clang
+      addons:
+        apt:
+          packages: *trusty_pocl_packages
+          sources: *trusty_pocl_sources
+      env:
+       - LINUX_DIST=trusty
+       - OPENCL_LIB=pocl
+       - OPENCL_VERSION="11"
+       - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/pocl/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+      addons:
+        apt:
+          packages: *trusty_pocl_packages
+          sources: *trusty_pocl_sources
+      env:
+       - LINUX_DIST=trusty
+       - OPENCL_LIB=pocl
+       - OPENCL_VERSION="11"
+       - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/pocl/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+
+    ############################################################################
+    # Khronos ICD builds (without running tests) (OpenCL 1.2, 2.0)
+    ############################################################################
+
+    # Precise, OpenCL 1.2, Travis CI container-based infrastructure
+    - os: linux
+      sudo: false
+      compiler: clang
+      addons:
+       apt:
+         packages: &precise_icd_packages
+           - g++-4.8
+           # Boost
+           - libboost-chrono1.55-dev
+           - libboost-date-time1.55-dev
+           - libboost-test1.55-dev
+           - libboost-system1.55-dev
+           - libboost-filesystem1.55-dev
+           - libboost-timer1.55-dev
+           - libboost-program-options1.55-dev
+           - libboost-thread1.55-dev
+           # Misc
+           - python-yaml
+           - lcov
+           - libopencv-dev
+         sources: &precise_icd_sources
+           - ubuntu-toolchain-r-test
+           - llvm-toolchain-precise-3.7
+           - boost-latest
+      env:
+        - OPENCL_LIB=khronos-icd
+        - OPENCL_VERSION="12"
+        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+    - os: linux
+      sudo: false
+      compiler: gcc
+      addons:
+        apt:
+          packages: *precise_icd_packages
+          sources: *precise_icd_sources
+      env:
+        - OPENCL_LIB=khronos-icd
+        - OPENCL_VERSION="12"
+        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+    # Precise, OpenCL 2.0, Travis CI container-based infrastructure
+    - os: linux
+      sudo: false
+      compiler: clang
+      addons:
+        apt:
+          packages: *precise_icd_packages
+          sources: *precise_icd_sources
+      env:
+        - OPENCL_LIB=khronos-icd
+        - OPENCL_VERSION="20"
+        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+    - os: linux
+      sudo: false
+      compiler: gcc
+      addons:
+        apt:
+          packages: *precise_icd_packages
+          sources: *precise_icd_sources
+      env:
+        - OPENCL_LIB=khronos-icd
+        - OPENCL_VERSION="20"
+        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+
+    ############################################################################
+    # OSX
+    ############################################################################
     - os: osx
       compiler: clang
-      env: 
-        - ENV_CXX_FLAGS="-Wno-c99-extensions"     
+      env:
+        - ENV_CXX_FLAGS="-Wno-c99-extensions"
+
   allow_failures:
     - os: osx
-    
+
 before_install:
-    - if [ ${TRAVIS_OS_NAME} == "linux" ] && [ ${LINUX_DIST} == "trusty" ]; then
-        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test;
-        sudo add-apt-repository -y ppa:boost-latest/ppa;
-        sudo apt-get update -qq -y;
-        sudo apt-get install -qq libboost-chrono1.55-dev libboost-date-time1.55-dev libboost-test1.55-dev libboost-system1.55-dev libboost-filesystem1.55-dev libboost-timer1.55-dev libboost-program-options1.55-dev libboost-thread1.55-dev python-yaml lcov libopencv-dev g++-4.8;
+    # Install recent cmake
+    - |
+      if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+        CMAKE_URL="http://www.cmake.org/files/v3.4/cmake-3.4.3-Linux-x86_64.tar.gz"
+        mkdir -p ${DEPS_DIR}/cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/cmake
+        export PATH=${DEPS_DIR}/cmake/bin:${PATH}
       fi
-    - if [ ${TRAVIS_OS_NAME} == "linux" ] && [ ${LINUX_DIST} == "precise" ]; then
-        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test;
-        sudo apt-get update -qq -y;
-        sudo apt-get install -qq libboost-chrono1.48-dev libboost-date-time1.48-dev libboost-test1.48-dev libboost-system1.48-dev libboost-filesystem1.48-dev libboost-timer1.48-dev libboost-program-options1.48-dev libboost-thread1.48-dev python-yaml lcov libopencv-dev g++-4.8;
-      fi  
-    - if [ ${TRAVIS_OS_NAME} == "osx" ]; then
-        brew update;
-        brew outdated boost || brew upgrade boost;
-        brew outdated cmake || brew upgrade cmake;
-        brew install lcov homebrew/science/opencv;      
+
+    # Install dependencies
+    - |
+      # POCL dependencies for Trusty
+      # llvm-toolchain-trusty-3.7 is not whitelisted yet https://github.com/travis-ci/apt-source-whitelist/issues/199
+      if [[ ${LINUX_DIST} == "trusty" && ${OPENCL_LIB} == "pocl" ]]; then
+        sudo add-apt-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main"
+        travis_retry wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | travis_retry sudo apt-key add -
+        sudo apt-get update -qq -
+        sudo apt-get install -qq -y clang-3.7 libclang-common-3.7-dev libclang-3.7-dev libclang1-3.7 libllvm3.7 lldb-3.7 llvm-3.7 llvm-3.7-dev llvm-3.7-runtime clang-modernize-3.7 clang-format-3.7 lldb-3.7-dev
+      # OSX
+      elif [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
+        brew update
+        brew outdated boost || brew upgrade boost
+        brew outdated cmake || brew upgrade cmake
+        brew install lcov homebrew/science/opencv
       fi
     - gem install coveralls-lcov
     - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
-    # combine global build options with os/compiler-dependent options
+
+    # Combine global build options with OS/compiler-dependent options
     - export CMAKE_OPTIONS=${CMAKE_OPTIONS}" "${ENV_CMAKE_OPTIONS}
     - export CXX_FLAGS=${CXX_FLAGS}" "${ENV_CXX_FLAGS}
-    
+
 install:
+    ############################################################################
+    # Download OpenCL headers (and cl.hpp)
+    ############################################################################
+    - |
+      if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
+        mkdir -p ${OPENCL_ROOT}/include/CL
+        pushd ${OPENCL_ROOT}/include/CL
+        travis_retry git clone --depth 1 https://github.com/KhronosGroup/OpenCL-Headers.git -b opencl${OPENCL_VERSION}
+        mv ./OpenCL-Headers/* .
+        travis_retry wget -w 1 -np -nd -nv -A h,hpp --no-check-certificate https://www.khronos.org/registry/cl/api/2.1/cl.hpp
+        popd
+      fi
+
+    ############################################################################
+    # Build and install POCL https://github.com/pocl/pocl
+    ############################################################################
+    - |
+      if [[ ${TRAVIS_OS_NAME} == "linux" && ${OPENCL_LIB} == "pocl" ]]; then
+        if [[ "${POCL_VERSION}" == "master" ]]; then
+          travis_retry git clone --depth 1 https://github.com/pocl/pocl.git
+          cd pocl
+        else
+          travis_retry wget --no-check-certificate http://pocl.sourceforge.net/downloads/${POCL_VERSION}.tar.gz
+          tar -xf ${POCL_VERSION}.tar.gz
+          cd ${POCL_VERSION}
+        fi
+        mkdir build
+        cd build
+        cmake -DDIRECT_LINKAGE=ON -DENABLE_ICD=OFF -DCMAKE_CXX_COMPILER=/usr/bin/${POCL_COMPILER} -DWITH_LLVM_CONFIG=/usr/bin/${POCL_LLVM_CONFIG} -DCMAKE_INSTALL_PREFIX=${OPENCL_ROOT}/pocl/ ..
+        make install
+        cd ../..
+      fi
+
+    ############################################################################
     # fglrx does not work: https://github.com/travis-ci/travis-ci/issues/5221,
     # so we build our own linkable .so file.
     # Thanks to clSPARSE for providing opencl-icd build script.
-    - if [ ${TRAVIS_OS_NAME} == "linux" ]; then
-        mkdir -p ${OPENCL_ROOT};
-        pushd ${OPENCL_ROOT};
-        travis_retry wget --no-check-certificate ${OPENCL_REGISTRY}/specs/opencl-icd-1.2.11.0.tgz;
-        tar -xf opencl-icd-1.2.11.0.tgz;
-        mv ./icd/* .;
-        mkdir -p inc/CL;
-        pushd inc/CL;
-        travis_retry wget -r -w 1 -np -nd -nv -A h,hpp --no-check-certificate https://www.khronos.org/registry/cl/api/1.2/;
-        travis_retry wget -w 1 -np -nd -nv -A h,hpp --no-check-certificate https://www.khronos.org/registry/cl/api/2.1/cl.hpp;
-        popd;
-        mkdir -p lib;
-        pushd lib;
-        cmake -G "Unix Makefiles" ..;
-        make;
-        cp ../bin/libOpenCL.so .;
-        popd;
-        mv inc/ include/;
-        popd;
+    ############################################################################
+    - |
+      if [[ ${TRAVIS_OS_NAME} == "linux" && ${OPENCL_LIB} == "khronos-icd" ]]; then
+        mkdir -p ${OPENCL_ROOT}
+        pushd ${OPENCL_ROOT}
+        travis_retry git clone --depth 1 https://github.com/KhronosGroup/OpenCL-ICD-Loader.git
+        mv ./OpenCL-ICD-Loader/* .
+        mkdir -p inc/CL
+        pushd inc/CL
+        travis_retry git clone --depth 1 https://github.com/KhronosGroup/OpenCL-Headers.git
+        mv ./OpenCL-Headers/* .
+        popd
+        mkdir -p lib
+        pushd lib
+        cmake -G "Unix Makefiles" ..
+        make
+        cp ./bin/libOpenCL.so .
+        popd
+        popd
       fi
-    
+
 script:
+    ############################################################################
+    # Build Boost.Compute tests, benchmarks and examples
+    ############################################################################
     - mkdir -p build
     - cd build
     - echo ${CMAKE_OPTIONS}
     - echo ${CXX_FLAGS}
     - cmake ${CMAKE_OPTIONS} -DCMAKE_CXX_FLAGS=${CXX_FLAGS} ..
-    - make -j4    
-    - if [ ${TRAVIS_OS_NAME} == "osx" ]; then
-        ./example/list_devices;
-        ctest --output-on-failure;
-        ctest --output-on-failure;
+    - make -j4
+    - |
+      if [[ ${TRAVIS_OS_NAME} == "osx" || ${OPENCL_LIB} == "pocl" ]]; then
+        # print OpenCL devices
+        ./example/list_devices
+        # run tests and examples
+        ctest --output-on-failure
+        ctest --output-on-failure
       fi
-    
+
 after_success:
     - lcov --directory test --base-directory ../include/boost/compute/ --capture --output-file coverage.info
     - lcov --remove coverage.info '/usr*' -o coverage.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
     # Global build options and C++ flags
     - CMAKE_OPTIONS="-DBOOST_COMPUTE_BUILD_TESTS=ON -DBOOST_COMPUTE_BUILD_EXAMPLES=ON -DBOOST_COMPUTE_BUILD_BENCHMARKS=ON -DBOOST_COMPUTE_USE_OFFLINE_CACHE=ON -DBOOST_COMPUTE_ENABLE_COVERAGE=ON -DBOOST_COMPUTE_HAVE_OPENCV=ON -DBOOST_COMPUTE_THREAD_SAFE=ON"
     - CXX_FLAGS="-Wall -pedantic -Werror -Wno-variadic-macros -Wno-long-long -Wno-shadow -Wno-deprecated-declarations"
+    # Misc
+    - RUN_TESTS=true
 
 matrix:
   include:
@@ -109,13 +111,85 @@ matrix:
     # Khronos ICD builds (without running tests) (OpenCL 1.2, 2.0)
     ############################################################################
 
-    # Precise, OpenCL 1.2, Travis CI container-based infrastructure
+    # # Precise, OpenCL 1.2, Travis CI container-based infrastructure
+    # - os: linux
+    #   sudo: false
+    #   compiler: clang
+    #   addons:
+    #    apt:
+    #      packages: &precise_icd_packages
+    #        - g++-4.8
+    #        # Boost
+    #        - libboost-chrono1.55-dev
+    #        - libboost-date-time1.55-dev
+    #        - libboost-test1.55-dev
+    #        - libboost-system1.55-dev
+    #        - libboost-filesystem1.55-dev
+    #        - libboost-timer1.55-dev
+    #        - libboost-program-options1.55-dev
+    #        - libboost-thread1.55-dev
+    #        # Misc
+    #        - python-yaml
+    #        - lcov
+    #        - libopencv-dev
+    #      sources: &precise_icd_sources
+    #        - ubuntu-toolchain-r-test
+    #        - llvm-toolchain-precise-3.7
+    #        - boost-latest
+    #   env:
+    #     - RUN_TEST=false
+    #     - OPENCL_LIB=khronos-icd
+    #     - OPENCL_VERSION="12"
+    #     - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+    # - os: linux
+    #   sudo: false
+    #   compiler: gcc
+    #   addons:
+    #     apt:
+    #       packages: *precise_icd_packages
+    #       sources: *precise_icd_sources
+    #   env:
+    #     - RUN_TEST=false
+    #     - OPENCL_LIB=khronos-icd
+    #     - OPENCL_VERSION="12"
+    #     - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+    # # Precise, OpenCL 2.0, Travis CI container-based infrastructure
+    # - os: linux
+    #   sudo: false
+    #   compiler: clang
+    #   addons:
+    #     apt:
+    #       packages: *precise_icd_packages
+    #       sources: *precise_icd_sources
+    #   env:
+    #     - RUN_TEST=false
+    #     - OPENCL_LIB=khronos-icd
+    #     - OPENCL_VERSION="20"
+    #     - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+    # - os: linux
+    #   sudo: false
+    #   compiler: gcc
+    #   addons:
+    #     apt:
+    #       packages: *precise_icd_packages
+    #       sources: *precise_icd_sources
+    #   env:
+    #     - RUN_TEST=false
+    #     - OPENCL_LIB=khronos-icd
+    #     - OPENCL_VERSION="20"
+    #     - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+
+    ############################################################################
+    # AMD APP SDK builds (v2.9.1 -> OpenCL 1.2, v3.0 -> OpenCL 2.0)
+    ############################################################################
+
+    # Precise, AMD APP SDK v2.9.1, Travis CI container-based infrastructure
     - os: linux
       sudo: false
       compiler: clang
       addons:
        apt:
-         packages: &precise_icd_packages
+         packages: &precise_amdappsdk_packages
            - g++-4.8
            # Boost
            - libboost-chrono1.55-dev
@@ -130,48 +204,52 @@ matrix:
            - python-yaml
            - lcov
            - libopencv-dev
-         sources: &precise_icd_sources
+         sources: &precise_amdappsdk_sources
            - ubuntu-toolchain-r-test
            - llvm-toolchain-precise-3.7
            - boost-latest
       env:
-        - OPENCL_LIB=khronos-icd
+        - OPENCL_LIB=amdappsdk
         - OPENCL_VERSION="12"
-        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+        - AMDAPPSDK_VERSION=291 # OpenCL 1.2
+        - ENV_CMAKE_OPTIONS="-DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
     - os: linux
       sudo: false
       compiler: gcc
       addons:
         apt:
-          packages: *precise_icd_packages
-          sources: *precise_icd_sources
+          packages: *precise_amdappsdk_packages
+          sources: *precise_amdappsdk_sources
       env:
-        - OPENCL_LIB=khronos-icd
+        - OPENCL_LIB=amdappsdk
         - OPENCL_VERSION="12"
-        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
-    # Precise, OpenCL 2.0, Travis CI container-based infrastructure
+        - AMDAPPSDK_VERSION=291 # OpenCL 1.2
+        - ENV_CMAKE_OPTIONS="-DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+    # Precise, AMD APP SDK v3.0, OpenCL 2.0, Travis CI container-based infrastructure
     - os: linux
       sudo: false
       compiler: clang
       addons:
         apt:
-          packages: *precise_icd_packages
-          sources: *precise_icd_sources
+          packages: *precise_amdappsdk_packages
+          sources: *precise_amdappsdk_sources
       env:
-        - OPENCL_LIB=khronos-icd
+        - OPENCL_LIB=amdappsdk
         - OPENCL_VERSION="20"
-        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+        - AMDAPPSDK_VERSION=300 # OpenCL 2.0
+        - ENV_CMAKE_OPTIONS="-DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
     - os: linux
       sudo: false
       compiler: gcc
       addons:
         apt:
-          packages: *precise_icd_packages
-          sources: *precise_icd_sources
+          packages: *precise_amdappsdk_packages
+          sources: *precise_amdappsdk_sources
       env:
-        - OPENCL_LIB=khronos-icd
+        - OPENCL_LIB=amdappsdk
         - OPENCL_VERSION="20"
-        - ENV_CMAKE_OPTIONS="-DOPENCL_LIBRARIES=${OPENCL_ROOT}/lib/libOpenCL.so -DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
+        - AMDAPPSDK_VERSION=300 # OpenCL 2.0
+        - ENV_CMAKE_OPTIONS="-DOPENCL_INCLUDE_DIRS=${OPENCL_ROOT}/include"
 
     ############################################################################
     # OSX
@@ -226,7 +304,7 @@ install:
         pushd ${OPENCL_ROOT}/include/CL
         travis_retry git clone --depth 1 https://github.com/KhronosGroup/OpenCL-Headers.git -b opencl${OPENCL_VERSION}
         mv ./OpenCL-Headers/* .
-        travis_retry wget -w 1 -np -nd -nv -A h,hpp --no-check-certificate https://www.khronos.org/registry/cl/api/2.1/cl.hpp
+        travis_retry wget -w 1 -np -nd -nv -A h,hpp --no-check-certificate ${OPENCL_REGISTRY}/api/2.1/cl.hpp;
         popd
       fi
 
@@ -275,6 +353,25 @@ install:
         popd
       fi
 
+    ############################################################################
+    # Install AMD APP SDK
+    # Thanks to JuliaGPU https://github.com/JuliaGPU/OpenCL.jl
+    ############################################################################
+    - |
+      if [[ ${TRAVIS_OS_NAME} == "linux" && ${OPENCL_LIB} == "amdappsdk" ]]; then
+        mkdir -p ${OPENCL_ROOT}
+        bash .travis/amd_sdk.sh ${AMDAPPSDK_VERSION}
+        tar -xjf AMD-SDK.tar.bz2
+        AMDAPPSDK=${OPENCL_ROOT}/AMDAPPSDK
+        export OPENCL_VENDOR_PATH=${AMDAPPSDK}/etc/OpenCL/vendors
+        mkdir -p ${OPENCL_VENDOR_PATH}
+        sh AMD-APP-SDK*.sh --tar -xf -C ${AMDAPPSDK}
+        echo libamdocl64.so > ${OPENCL_VENDOR_PATH}/amdocl64.icd
+        export LD_LIBRARY_PATH=${AMDAPPSDK}/lib/x86_64:${LD_LIBRARY_PATH}
+        chmod +x ${AMDAPPSDK}/bin/x86_64/clinfo
+        ${AMDAPPSDK}/bin/x86_64/clinfo
+      fi
+
 script:
     ############################################################################
     # Build Boost.Compute tests, benchmarks and examples
@@ -286,7 +383,7 @@ script:
     - cmake ${CMAKE_OPTIONS} -DCMAKE_CXX_FLAGS=${CXX_FLAGS} ..
     - make -j4
     - |
-      if [[ ${TRAVIS_OS_NAME} == "osx" || ${OPENCL_LIB} == "pocl" ]]; then
+      if [[ ${RUN_TESTS} == "true" ]]; then
         # print OpenCL devices
         ./example/list_devices
         # run tests and examples

--- a/.travis/amd_sdk.sh
+++ b/.travis/amd_sdk.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Original script from https://github.com/gregvw/amd_sdk/
+
+# Location from which get nonce and file name from
+URL="http://developer.amd.com/tools-and-sdks/opencl-zone/opencl-tools-sdks/amd-accelerated-parallel-processing-app-sdk/"
+URLDOWN="http://developer.amd.com/amd-license-agreement-appsdk/"
+
+NONCE1_STRING='name="amd_developer_central_downloads_page_nonce"'
+FILE_STRING='name="f"'
+POSTID_STRING='name="post_id"'
+NONCE2_STRING='name="amd_developer_central_nonce"'
+
+#AMD APP SDK v3.0:
+if [[ $1 == "300" ]]; then
+  echo "AMD APP SDK v3.0"
+  FORM=`wget -qO - $URL | sed -n '/download-2/,/64-bit/p'`
+else
+#AMD APP SDK v2.9.1:
+  echo "AMD APP SDK v2.9.1"
+  FORM=`wget -qO - $URL | sed -n '/download-5/,/64-bit/p'`
+fi
+
+# Get nonce from form
+NONCE1=`echo $FORM | awk -F ${NONCE1_STRING} '{print $2}'`
+NONCE1=`echo $NONCE1 | awk -F'"' '{print $2}'`
+echo $NONCE1
+
+# get the postid
+POSTID=`echo $FORM | awk -F ${POSTID_STRING} '{print $2}'`
+POSTID=`echo $POSTID | awk -F'"' '{print $2}'`
+echo $POSTID
+
+# get file name
+FILE=`echo $FORM | awk -F ${FILE_STRING} '{print $2}'`
+FILE=`echo $FILE | awk -F'"' '{print $2}'`
+echo $FILE
+
+FORM=`wget -qO - $URLDOWN --post-data "amd_developer_central_downloads_page_nonce=${NONCE1}&f=${FILE}&post_id=${POSTID}"`
+
+NONCE2=`echo $FORM | awk -F ${NONCE2_STRING} '{print $2}'`
+NONCE2=`echo $NONCE2 | awk -F'"' '{print $2}'`
+echo $NONCE2
+
+wget --content-disposition --trust-server-names $URLDOWN --post-data "amd_developer_central_nonce=${NONCE2}&f=${FILE}" -O AMD-SDK.tar.bz2;

--- a/test/quirks.hpp
+++ b/test/quirks.hpp
@@ -58,10 +58,24 @@ inline bool supports_image_samplers(const boost::compute::device &device)
     return true;
 }
 
-// returns true if the device supports image samplers.
+// returns true if the device supports clSetMemObjectDestructorCallback
 inline bool supports_destructor_callback(const boost::compute::device &device)
 {
-    // clSetMemObjectDestructorCallback is unimplemented in POCL
+    // unimplemented in POCL
+    return !is_pocl_device(device);
+}
+
+// returns true if the device supports clCompileProgram
+inline bool supports_compile_program(const boost::compute::device &device)
+{
+    // unimplemented in POCL
+    return !is_pocl_device(device);
+}
+
+// returns true if the device supports clLinkProgram
+inline bool supports_link_program(const boost::compute::device &device)
+{
+    // unimplemented in POCL
     return !is_pocl_device(device);
 }
 

--- a/test/test_program.cpp
+++ b/test/test_program.cpp
@@ -21,6 +21,7 @@
 #include <boost/compute/program.hpp>
 #include <boost/compute/utility/source.hpp>
 
+#include "quirks.hpp"
 #include "context_setup.hpp"
 
 namespace compute = boost::compute;
@@ -141,6 +142,10 @@ boost::compute::program foo_program =
 BOOST_AUTO_TEST_CASE(compile_and_link)
 {
     REQUIRES_OPENCL_VERSION(1,2);
+
+    if(!supports_compile_program(device) || !supports_link_program(device)) {
+        return;
+    }
 
     // create the library program
     const char library_source[] = BOOST_COMPUTE_STRINGIZE_SOURCE(


### PR DESCRIPTION
This PR adds POCL builds and updates Khronos ICD builds (new ICD, builds moved to Travis CI container-based infrastructure).

* I wasn't able to build POCL on Precise (container-based infrastructure) due to `lrt` (real time clock library) related error, so POCL is on Trusty.
* I used direct linkage and because POCL lacks some OpenCL 1.2 runtime functions OpenCL 1.0 and 1.1 headers are used in POCL builds .  
* clang 3.7 is used in POCL builds , but not in Boost.Compute build due to this https://svn.boost.org/trac/boost/ticket/11664 error.
* OpenCL 1.2 and 2.0 headers are used in Khronos ICD builds.

After this PR there'll be 8 Linux builds and 1 OSX build:

* 14.04 (Trusty), POCL, clang 3.5/gcc 4.8, OpenCL 1.0/1.1, build + tests
* 12.04 (Precise, container-based infrastructure), Khronos ICD, clang 3.4/gcc 4.8, OpenCL 1.2/2.0, only build
* OSX, clang, build + tests, allowed to fail