### PR TITLE
Misc fixes

### DIFF
--- a/include/boost/compute/container/valarray.hpp
+++ b/include/boost/compute/container/valarray.hpp
@@ -79,7 +79,8 @@ public:
     valarray<T>& operator=(const valarray<T> &other)
     {
         if(this != &other){
-            resize(other.size());
+            // change to other's OpenCL context
+            m_buffer = buffer(other.m_buffer.get_context(), other.size() * sizeof(T));
             copy(other.begin(), other.end(), begin());
         }
 
@@ -88,7 +89,7 @@ public:
 
     valarray<T>& operator=(const std::valarray<T> &valarray)
     {
-        resize(valarray.size());
+        m_buffer = buffer(m_buffer.get_context(), valarray.size() * sizeof(T));
         copy(&valarray[0], &valarray[valarray.size()], begin());
 
         return *this;
@@ -342,8 +343,11 @@ BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT(%, modulus,
     { \
         assert \
         valarray<T> result(lhs.size()); \
-        transform(&lhs[0], &lhs[lhs.size()], &rhs[0], \
-            &result[0], op_name<T>()); \
+        transform(buffer_iterator<T>(lhs.get_buffer(), 0), \
+                  buffer_iterator<T>(lhs.get_buffer(), lhs.size()), \
+                  buffer_iterator<T>(rhs.get_buffer(), 0), \
+                  buffer_iterator<T>(result.get_buffer(), 0), \
+                  op_name<T>()); \
         return result; \
     } \
     \
@@ -352,8 +356,10 @@ BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT(%, modulus,
     { \
         assert \
         valarray<T> result(rhs.size()); \
-        transform(&rhs[0], &rhs[rhs.size()], &result[0], \
-            ::boost::compute::bind(op_name<T>(), val, placeholders::_1)); \
+        transform(buffer_iterator<T>(rhs.get_buffer(), 0), \
+                  buffer_iterator<T>(rhs.get_buffer(), rhs.size()), \
+                  buffer_iterator<T>(result.get_buffer(), 0), \
+                  ::boost::compute::bind(op_name<T>(), val, placeholders::_1)); \
         return result; \
     } \
     \
@@ -362,8 +368,10 @@ BOOST_COMPUTE_DEFINE_VALARRAY_COMPOUND_ASSIGNMENT(%, modulus,
     { \
         assert \
         valarray<T> result(lhs.size()); \
-        transform(&lhs[0], &lhs[lhs.size()], &result[0], \
-            ::boost::compute::bind(op_name<T>(), placeholders::_1, val)); \
+        transform(buffer_iterator<T>(lhs.get_buffer(), 0), \
+                  buffer_iterator<T>(lhs.get_buffer(), lhs.size()), \
+                  buffer_iterator<T>(result.get_buffer(), 0), \
+                  ::boost::compute::bind(op_name<T>(), placeholders::_1, val)); \
         return result; \
     }
 
@@ -422,8 +430,11 @@ BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_NO_FP(>>, shift_right)
             " and vector types" \
         ); \
         valarray<char> result(lhs.size()); \
-        transform(&lhs[0], &lhs[lhs.size()], &rhs[0], \
-            &result[0], op_name<T>()); \
+        transform(buffer_iterator<T>(lhs.get_buffer(), 0), \
+                  buffer_iterator<T>(lhs.get_buffer(), lhs.size()), \
+                  buffer_iterator<T>(rhs.get_buffer(), 0), \
+                  buffer_iterator<char>(result.get_buffer(), 0), \
+                  op_name<T>()); \
         return result; \
     } \
     \
@@ -436,8 +447,10 @@ BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_NO_FP(>>, shift_right)
             " and vector types" \
         ); \
         valarray<char> result(rhs.size()); \
-        transform(&rhs[0], &rhs[rhs.size()], &result[0], \
-            ::boost::compute::bind(op_name<T>(), val, placeholders::_1)); \
+        transform(buffer_iterator<T>(rhs.get_buffer(), 0), \
+                  buffer_iterator<T>(rhs.get_buffer(), rhs.size()), \
+                  buffer_iterator<char>(result.get_buffer(), 0), \
+                  ::boost::compute::bind(op_name<T>(), val, placeholders::_1)); \
         return result; \
     } \
     \
@@ -450,8 +463,10 @@ BOOST_COMPUTE_DEFINE_VALARRAY_BINARY_OPERATOR_NO_FP(>>, shift_right)
             " and vector types" \
         ); \
         valarray<char> result(lhs.size()); \
-        transform(&lhs[0], &lhs[lhs.size()], &result[0], \
-            ::boost::compute::bind(op_name<T>(), placeholders::_1, val)); \
+        transform(buffer_iterator<T>(lhs.get_buffer(), 0), \
+                  buffer_iterator<T>(lhs.get_buffer(), lhs.size()), \
+                  buffer_iterator<char>(result.get_buffer(), 0), \
+                  ::boost::compute::bind(op_name<T>(), placeholders::_1, val)); \
         return result; \
     }
 

--- a/perf/perf_stl_sort.cpp
+++ b/perf/perf_stl_sort.cpp
@@ -9,6 +9,7 @@
 //---------------------------------------------------------------------------//
 
 #include <algorithm>
+#include <iostream>
 
 #include "perf.hpp"
 

--- a/perf/perf_thrust_accumulate.cu
+++ b/perf/perf_thrust_accumulate.cu
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <iostream>
 
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>

--- a/perf/perf_thrust_exclusive_scan.cu
+++ b/perf/perf_thrust_exclusive_scan.cu
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <iostream>
 
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>

--- a/perf/perf_thrust_partial_sum.cu
+++ b/perf/perf_thrust_partial_sum.cu
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <iostream>
 
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>

--- a/perf/perf_thrust_partition.cu
+++ b/perf/perf_thrust_partition.cu
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <iostream>
 
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>

--- a/perf/perf_thrust_reduce_by_key.cu
+++ b/perf/perf_thrust_reduce_by_key.cu
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <iostream>
 
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>

--- a/perf/perf_thrust_reverse.cu
+++ b/perf/perf_thrust_reverse.cu
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <iostream>
 
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>

--- a/perf/perf_thrust_reverse_copy.cu
+++ b/perf/perf_thrust_reverse_copy.cu
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <iostream>
 
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>

--- a/perf/perf_thrust_rotate.cu
+++ b/perf/perf_thrust_rotate.cu
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <iostream>
 
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>

--- a/perf/perf_thrust_sort.cu
+++ b/perf/perf_thrust_sort.cu
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <iostream>
 
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>

--- a/perf/perf_thrust_unique.cu
+++ b/perf/perf_thrust_unique.cu
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <iostream>
 
 #include <thrust/copy.h>
 #include <thrust/device_vector.h>

--- a/test/quirks.hpp
+++ b/test/quirks.hpp
@@ -58,4 +58,11 @@ inline bool supports_image_samplers(const boost::compute::device &device)
     return true;
 }
 
+// returns true if the device supports image samplers.
+inline bool supports_destructor_callback(const boost::compute::device &device)
+{
+    // clSetMemObjectDestructorCallback is unimplemented in POCL
+    return !is_pocl_device(device);
+}
+
 #endif // BOOST_COMPUTE_TEST_QUIRKS_HPP

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -20,6 +20,7 @@
 #include <future>
 #endif // BOOST_COMPUTE_USE_CPP11
 
+#include "quirks.hpp"
 #include "context_setup.hpp"
 
 namespace bc = boost::compute;
@@ -122,6 +123,11 @@ destructor_callback_function(cl_mem memobj, void *user_data)
 BOOST_AUTO_TEST_CASE(destructor_callback)
 {
     REQUIRES_OPENCL_VERSION(1,2);
+
+    if(!supports_destructor_callback(device))
+    {
+        return;
+    }
 
     bool invoked = false;
     {


### PR DESCRIPTION
This PR fixes:

* missing <iostream> includes in some benchmarks
* valarray binary operators (they didn't work on POCL)
* buffer test, now destructor callback test is not run for POCL devices (POCL does not support clSetMemObjectDestructorCallback)

After those commits Boost.Compute works with POCL + OpenCL 1.1 headers (all tests pass for me).