### PR TITLE
Configure documentation to use boost paths.

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -106,6 +106,6 @@ boostbook standalone
     :
       compute
     :
-      <xsl:param>html.stylesheet=boostbook.css
       <dependency>autodoc
+      <format>html:<xsl:param>boost.root=../../../..
     ;


### PR DESCRIPTION
Thie fixes the stylesheet and navigation images at http://www.boost.org/doc/libs/master/libs/compute/doc/html/index.html