### PR TITLE
Update tests compile options in Jamfile.v2

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -10,7 +10,18 @@ project
     : source-location .
     : requirements
         <define>BOOST_ALL_NO_LIB=1
-        <cxxflags>-Wno-deprecated-declarations
+        <toolset>gcc:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in CL/cl.h
+        <toolset>clang:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in CL/cl.h
+        <toolset>darwin:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in CL/cl.h
+        <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
+        <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
+        <toolset>msvc:<define>NOMINMAX
+        <toolset>msvc:<cxxflags>/wd4003 # Not enough actual parameters for a BOOST_PP macro
+        <toolset>msvc:<cxxflags>/wd4244 # Warning C4244: 'initializing': conversion from 'double' to 'int', possible loss of data
+        <toolset>msvc:<cxxflags>/wd4305 # Warning C4305: 'initializing': truncation from 'double' to 'float'
+        <toolset>msvc:<cxxflags>/wd4800 # Warning C4800: 'uint32_t' : forcing value to bool 'true' or 'false' (performance warning)
+        <toolset>msvc:<cxxflags>/wd4838 # Warning C4838: conversion from 'double' to 'float' requires a narrowing conversion
+        <toolset>msvc:<cxxflags>/wd4996 # Deprecated declarations in CL/cl.h
         <library>/boost/test//boost_unit_test_framework
     ;
 


### PR DESCRIPTION
This is a fast fix for https://github.com/boostorg/compute/issues/563 (+ I've suppressed some other warning for MSVC that are just annoying) . 

I'll later remove lines

```
<toolset>gcc:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in CL/cl.h
<toolset>clang:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in CL/cl.h
<toolset>darwin:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in CL/cl.h
<toolset>msvc:<cxxflags>/wd4996 # Deprecated declarations in CL/cl.h
```
and suppress deprecated declarations warning (related to CL/cl.h) in the code.