### PR TITLE
Update tests compile options in Jamfile.v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - POCL_COMPILER=clang++-3.7
     # Global build options and C++ flags
     - CMAKE_OPTIONS="-DBOOST_COMPUTE_BUILD_TESTS=ON -DBOOST_COMPUTE_BUILD_EXAMPLES=ON -DBOOST_COMPUTE_BUILD_BENCHMARKS=ON -DBOOST_COMPUTE_USE_OFFLINE_CACHE=ON -DBOOST_COMPUTE_ENABLE_COVERAGE=ON -DBOOST_COMPUTE_HAVE_OPENCV=ON -DBOOST_COMPUTE_THREAD_SAFE=ON"
-    - CXX_FLAGS="-Wall -pedantic -Werror -Wno-variadic-macros -Wno-long-long -Wno-shadow -Wno-deprecated-declarations"
+    - CXX_FLAGS="-Wall -pedantic -Werror -Wno-variadic-macros -Wno-long-long -Wno-shadow"
     # Misc
     - RUN_TESTS=true
 

--- a/example/opencl_test.cpp
+++ b/example/opencl_test.cpp
@@ -8,6 +8,62 @@
 // See http://boostorg.github.com/compute for more information.
 //---------------------------------------------------------------------------//
 
+// See boost/compute/detail/diagnostic.hpp
+// GCC
+#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 402
+#define BOOST_COMPUTE_GCC_DIAG_STR(s) #s
+#define BOOST_COMPUTE_GCC_DIAG_JOINSTR(x,y) BOOST_COMPUTE_GCC_DIAG_STR(x ## y)
+# define BOOST_COMPUTE_GCC_DIAG_DO_PRAGMA(x) _Pragma (#x)
+# define BOOST_COMPUTE_GCC_DIAG_PRAGMA(x) BOOST_COMPUTE_GCC_DIAG_DO_PRAGMA(GCC diagnostic x)
+# if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 406
+#  define BOOST_COMPUTE_GCC_DIAG_OFF(x) BOOST_COMPUTE_GCC_DIAG_PRAGMA(push) \
+      BOOST_COMPUTE_GCC_DIAG_PRAGMA(ignored BOOST_COMPUTE_GCC_DIAG_JOINSTR(-W,x))
+#  define BOOST_COMPUTE_GCC_DIAG_ON(x) BOOST_COMPUTE_GCC_DIAG_PRAGMA(pop)
+# else
+#  define BOOST_COMPUTE_GCC_DIAG_OFF(x) \
+      BOOST_COMPUTE_GCC_DIAG_PRAGMA(ignored BOOST_COMPUTE_GCC_DIAG_JOINSTR(-W,x))
+#  define BOOST_COMPUTE_GCC_DIAG_ON(x) \
+      BOOST_COMPUTE_GCC_DIAG_PRAGMA(warning BOOST_COMPUTE_GCC_DIAG_JOINSTR(-W,x))
+# endif
+#else // Ensure these macros do nothing for other compilers.
+# define BOOST_COMPUTE_GCC_DIAG_OFF(x)
+# define BOOST_COMPUTE_GCC_DIAG_ON(x)
+#endif
+
+// Clang
+#ifdef __clang__
+#  define BOOST_COMPUTE_CLANG_DIAG_STR(s) # s
+// stringize s to "no-sign-compare"
+#  define BOOST_COMPUTE_CLANG_DIAG_JOINSTR(x,y) BOOST_COMPUTE_CLANG_DIAG_STR(x ## y)
+//  join -W with no-unused-variable to "-Wno-sign-compare"
+#  define BOOST_COMPUTE_CLANG_DIAG_DO_PRAGMA(x) _Pragma (#x)
+// _Pragma is unary operator  #pragma ("")
+#  define BOOST_COMPUTE_CLANG_DIAG_PRAGMA(x) \
+      BOOST_COMPUTE_CLANG_DIAG_DO_PRAGMA(clang diagnostic x)
+#  define BOOST_COMPUTE_CLANG_DIAG_OFF(x) BOOST_COMPUTE_CLANG_DIAG_PRAGMA(push) \
+      BOOST_COMPUTE_CLANG_DIAG_PRAGMA(ignored BOOST_COMPUTE_CLANG_DIAG_JOINSTR(-W,x))
+// For example: #pragma clang diagnostic ignored "-Wno-sign-compare"
+#  define BOOST_COMPUTE_CLANG_DIAG_ON(x) BOOST_COMPUTE_CLANG_DIAG_PRAGMA(pop)
+// For example: #pragma clang diagnostic warning "-Wno-sign-compare"
+#else // Ensure these macros do nothing for other compilers.
+#  define BOOST_COMPUTE_CLANG_DIAG_OFF(x)
+#  define BOOST_COMPUTE_CLANG_DIAG_ON(x)
+#  define BOOST_COMPUTE_CLANG_DIAG_PRAGMA(x)
+#endif
+
+// MSVC
+#if defined(_MSC_VER)
+#  define BOOST_COMPUTE_MSVC_DIAG_DO_PRAGMA(x) __pragma(x)
+#  define BOOST_COMPUTE_MSVC_DIAG_PRAGMA(x) \
+          BOOST_COMPUTE_MSVC_DIAG_DO_PRAGMA(warning(x))
+#  define BOOST_COMPUTE_MSVC_DIAG_OFF(x) BOOST_COMPUTE_MSVC_DIAG_PRAGMA(push) \
+          BOOST_COMPUTE_MSVC_DIAG_PRAGMA(disable: x)
+#  define BOOST_COMPUTE_MSVC_DIAG_ON(x) BOOST_COMPUTE_MSVC_DIAG_PRAGMA(pop)
+#else // Ensure these macros do nothing for other compilers.
+#  define BOOST_COMPUTE_MSVC_DIAG_OFF(x)
+#  define BOOST_COMPUTE_MSVC_DIAG_ON(x)
+#endif
+
 #include <iostream>
 
 // include the proper opencl header for the system
@@ -24,6 +80,11 @@
 // the boost.compute apis (which depend on a working opencl implementation).
 int main()
 {
+    // Suppress deprecated declarations warning
+    BOOST_COMPUTE_MSVC_DIAG_OFF(4996); // MSVC
+    BOOST_COMPUTE_GCC_DIAG_OFF(deprecated-declarations); // GCC
+    BOOST_COMPUTE_CLANG_DIAG_OFF(deprecated-declarations); // Clang
+
     // query number of opencl platforms
     cl_uint num_platforms = 0;
     cl_int ret = clGetPlatformIDs(0, NULL, &num_platforms);
@@ -95,6 +156,10 @@ int main()
         delete[] devices;
     }
     delete[] platforms;
+
+    BOOST_COMPUTE_CLANG_DIAG_ON(deprecated-declarations); // Clang
+    BOOST_COMPUTE_GCC_DIAG_ON(deprecated-declarations); // GCC
+    BOOST_COMPUTE_MSVC_DIAG_OFF(4996); // MSVC
 
     return 0;
 }

--- a/include/boost/compute/command_queue.hpp
+++ b/include/boost/compute/command_queue.hpp
@@ -30,6 +30,7 @@
 #include <boost/compute/utility/wait_list.hpp>
 #include <boost/compute/detail/get_object_info.hpp>
 #include <boost/compute/detail/assert_cl_success.hpp>
+#include <boost/compute/detail/diagnostic.hpp>
 #include <boost/compute/utility/extents.hpp>
 
 namespace boost {
@@ -135,9 +136,12 @@ public:
         } else
         #endif
         {
+            // Suppress deprecated declarations warning
+            BOOST_COMPUTE_DISABLE_DEPRECATED_DECLARATIONS();
             m_queue = clCreateCommandQueue(
                 context, device.id(), properties, &error
             );
+            BOOST_COMPUTE_ENABLE_DEPRECATED_DECLARATIONS();
         }
 
         if(!m_queue){
@@ -1532,7 +1536,10 @@ public:
         } else
         #endif // CL_VERSION_1_2
         {
+            // Suppress deprecated declarations warning
+            BOOST_COMPUTE_DISABLE_DEPRECATED_DECLARATIONS();
             ret = clEnqueueBarrier(m_queue);
+            BOOST_COMPUTE_ENABLE_DEPRECATED_DECLARATIONS();
         }
 
         if(ret != CL_SUCCESS){
@@ -1576,7 +1583,10 @@ public:
         } else
         #endif
         {
+            // Suppress deprecated declarations warning
+            BOOST_COMPUTE_DISABLE_DEPRECATED_DECLARATIONS();
             ret = clEnqueueMarker(m_queue, &event_.get());
+            BOOST_COMPUTE_ENABLE_DEPRECATED_DECLARATIONS();
         }
 
         if(ret != CL_SUCCESS){

--- a/include/boost/compute/detail/diagnostic.hpp
+++ b/include/boost/compute/detail/diagnostic.hpp
@@ -1,0 +1,112 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2016 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#ifndef BOOST_COMPUTE_DETAIL_DIAGNOSTIC_HPP
+#define BOOST_COMPUTE_DETAIL_DIAGNOSTIC_HPP
+
+// Macros for suppressing warnings for GCC version 4.6 or later. Usage:
+//
+//   BOOST_COMPUTE_BOOST_COMPUTE_GCC_DIAG_OFF(sign-compare);
+//   if(a < b){
+//   BOOST_COMPUTE_BOOST_COMPUTE_GCC_DIAG_ON(sign-compare);
+//
+// Source: https://svn.boost.org/trac/boost/wiki/Guidelines/WarningsGuidelines
+#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 402
+#define BOOST_COMPUTE_GCC_DIAG_STR(s) #s
+#define BOOST_COMPUTE_GCC_DIAG_JOINSTR(x,y) BOOST_COMPUTE_GCC_DIAG_STR(x ## y)
+# define BOOST_COMPUTE_GCC_DIAG_DO_PRAGMA(x) _Pragma (#x)
+# define BOOST_COMPUTE_GCC_DIAG_PRAGMA(x) BOOST_COMPUTE_GCC_DIAG_DO_PRAGMA(GCC diagnostic x)
+# if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 406
+#  define BOOST_COMPUTE_GCC_DIAG_OFF(x) BOOST_COMPUTE_GCC_DIAG_PRAGMA(push) \
+      BOOST_COMPUTE_GCC_DIAG_PRAGMA(ignored BOOST_COMPUTE_GCC_DIAG_JOINSTR(-W,x))
+#  define BOOST_COMPUTE_GCC_DIAG_ON(x) BOOST_COMPUTE_GCC_DIAG_PRAGMA(pop)
+# else
+#  define BOOST_COMPUTE_GCC_DIAG_OFF(x) \
+      BOOST_COMPUTE_GCC_DIAG_PRAGMA(ignored BOOST_COMPUTE_GCC_DIAG_JOINSTR(-W,x))
+#  define BOOST_COMPUTE_GCC_DIAG_ON(x) \
+      BOOST_COMPUTE_GCC_DIAG_PRAGMA(warning BOOST_COMPUTE_GCC_DIAG_JOINSTR(-W,x))
+# endif
+#else // Ensure these macros do nothing for other compilers.
+# define BOOST_COMPUTE_GCC_DIAG_OFF(x)
+# define BOOST_COMPUTE_GCC_DIAG_ON(x)
+#endif
+
+// Macros for suppressing warnings for Clang.
+//
+//   BOOST_COMPUTE_BOOST_COMPUTE_CLANG_DIAG_OFF(sign-compare);
+//   if(a < b){
+//   BOOST_COMPUTE_BOOST_COMPUTE_CLANG_DIAG_ON(sign-compare);
+//
+// Source: https://svn.boost.org/trac/boost/wiki/Guidelines/WarningsGuidelines
+#ifdef __clang__
+#  define BOOST_COMPUTE_CLANG_DIAG_STR(s) # s
+// stringize s to "no-sign-compare"
+#  define BOOST_COMPUTE_CLANG_DIAG_JOINSTR(x,y) BOOST_COMPUTE_CLANG_DIAG_STR(x ## y)
+//  join -W with no-unused-variable to "-Wno-sign-compare"
+#  define BOOST_COMPUTE_CLANG_DIAG_DO_PRAGMA(x) _Pragma (#x)
+// _Pragma is unary operator  #pragma ("")
+#  define BOOST_COMPUTE_CLANG_DIAG_PRAGMA(x) \
+      BOOST_COMPUTE_CLANG_DIAG_DO_PRAGMA(clang diagnostic x)
+#  define BOOST_COMPUTE_CLANG_DIAG_OFF(x) BOOST_COMPUTE_CLANG_DIAG_PRAGMA(push) \
+      BOOST_COMPUTE_CLANG_DIAG_PRAGMA(ignored BOOST_COMPUTE_CLANG_DIAG_JOINSTR(-W,x))
+// For example: #pragma clang diagnostic ignored "-Wno-sign-compare"
+#  define BOOST_COMPUTE_CLANG_DIAG_ON(x) BOOST_COMPUTE_CLANG_DIAG_PRAGMA(pop)
+// For example: #pragma clang diagnostic warning "-Wno-sign-compare"
+#else // Ensure these macros do nothing for other compilers.
+#  define BOOST_COMPUTE_CLANG_DIAG_OFF(x)
+#  define BOOST_COMPUTE_CLANG_DIAG_ON(x)
+#  define BOOST_COMPUTE_CLANG_DIAG_PRAGMA(x)
+#endif
+
+// Macros for suppressing warnings for MSVC. Usage:
+//
+//   BOOST_COMPUTE_BOOST_COMPUTE_MSVC_DIAG_OFF(4018); //sign-compare
+//   if(a < b){
+//   BOOST_COMPUTE_BOOST_COMPUTE_MSVC_DIAG_ON(4018);
+//
+#if defined(_MSC_VER)
+#  define BOOST_COMPUTE_MSVC_DIAG_DO_PRAGMA(x) __pragma(x)
+#  define BOOST_COMPUTE_MSVC_DIAG_PRAGMA(x) \
+          BOOST_COMPUTE_MSVC_DIAG_DO_PRAGMA(warning(x))
+#  define BOOST_COMPUTE_MSVC_DIAG_OFF(x) BOOST_COMPUTE_MSVC_DIAG_PRAGMA(push) \
+          BOOST_COMPUTE_MSVC_DIAG_PRAGMA(disable: x)
+#  define BOOST_COMPUTE_MSVC_DIAG_ON(x) BOOST_COMPUTE_MSVC_DIAG_PRAGMA(pop)
+#else // Ensure these macros do nothing for other compilers.
+#  define BOOST_COMPUTE_MSVC_DIAG_OFF(x)
+#  define BOOST_COMPUTE_MSVC_DIAG_ON(x)
+#endif
+
+// Macros for suppressing warnings for GCC, Clang and MSVC. Usage:
+//
+//   BOOST_COMPUTE_DIAG_OFF(sign-compare, sign-compare, 4018);
+//   if(a < b){
+//   BOOST_COMPUTE_DIAG_ON(sign-compare, sign-compare, 4018);
+//
+#if defined(_MSC_VER) // MSVC
+#  define BOOST_COMPUTE_DIAG_OFF(gcc, clang, msvc) BOOST_COMPUTE_MSVC_DIAG_OFF(msvc)
+#  define BOOST_COMPUTE_DIAG_ON(gcc, clang, msvc) BOOST_COMPUTE_MSVC_DIAG_ON(msvc)
+#elif defined(__clang__) // Clang
+#  define BOOST_COMPUTE_DIAG_OFF(gcc, clang, msvc) BOOST_COMPUTE_CLANG_DIAG_OFF(clang)
+#  define BOOST_COMPUTE_DIAG_ON(gcc, clang, msvc) BOOST_COMPUTE_CLANG_DIAG_ON(clang)
+#elif defined(__GNUC__) // GCC/G++
+#  define BOOST_COMPUTE_DIAG_OFF(gcc, clang, msvc) BOOST_COMPUTE_GCC_DIAG_OFF(gcc)
+#  define BOOST_COMPUTE_DIAG_ON(gcc, clang, msvc) BOOST_COMPUTE_GCC_DIAG_ON(gcc)
+#else // Ensure these macros do nothing for other compilers.
+#  define BOOST_COMPUTE_DIAG_OFF(gcc, clang, msvc)
+#  define BOOST_COMPUTE_DIAG_ON(gcc, clang, msvc)
+#endif
+
+#define BOOST_COMPUTE_DISABLE_DEPRECATED_DECLARATIONS() \
+    BOOST_COMPUTE_DIAG_OFF(deprecated-declarations, deprecated-declarations, 4996)
+#define BOOST_COMPUTE_ENABLE_DEPRECATED_DECLARATIONS() \
+    BOOST_COMPUTE_DIAG_ON(deprecated-declarations, deprecated-declarations, 4996);
+
+
+#endif /* BOOST_COMPUTE_DETAIL_DIAGNOSTIC_HPP */

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -10,9 +10,6 @@ project
     : source-location .
     : requirements
         <define>BOOST_ALL_NO_LIB=1
-        <toolset>gcc:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in OpenCL headers
-        <toolset>clang:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in OpenCL headers
-        <toolset>darwin:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in OpenCL headers
         <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
         <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
         <toolset>msvc:<define>NOMINMAX
@@ -21,7 +18,6 @@ project
         <toolset>msvc:<cxxflags>/wd4305 # Warning C4305: 'initializing': truncation from 'double' to 'float'
         <toolset>msvc:<cxxflags>/wd4800 # Warning C4800: 'uint32_t' : forcing value to bool 'true' or 'false' (performance warning)
         <toolset>msvc:<cxxflags>/wd4838 # Warning C4838: conversion from 'double' to 'float' requires a narrowing conversion
-        <toolset>msvc:<cxxflags>/wd4996 # Deprecated declarations in OpenCL headers
         <library>/boost/test//boost_unit_test_framework
     ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -10,7 +10,18 @@ project
     : source-location .
     : requirements
         <define>BOOST_ALL_NO_LIB=1
-        <cxxflags>-Wno-deprecated-declarations
+        <toolset>gcc:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in OpenCL headers
+        <toolset>clang:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in OpenCL headers
+        <toolset>darwin:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in OpenCL headers
+        <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
+        <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
+        <toolset>msvc:<define>NOMINMAX
+        <toolset>msvc:<cxxflags>/wd4003 # Not enough actual parameters for a BOOST_PP macro
+        <toolset>msvc:<cxxflags>/wd4244 # Warning C4244: 'initializing': conversion from 'double' to 'int', possible loss of data
+        <toolset>msvc:<cxxflags>/wd4305 # Warning C4305: 'initializing': truncation from 'double' to 'float'
+        <toolset>msvc:<cxxflags>/wd4800 # Warning C4800: 'uint32_t' : forcing value to bool 'true' or 'false' (performance warning)
+        <toolset>msvc:<cxxflags>/wd4838 # Warning C4838: conversion from 'double' to 'float' requires a narrowing conversion
+        <toolset>msvc:<cxxflags>/wd4996 # Deprecated declarations in OpenCL headers
         <library>/boost/test//boost_unit_test_framework
     ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -34,6 +34,7 @@ rule test_all
             <link>shared:<define>BOOST_TEST_DYN_LINK=1
             <host-os>linux:<linkflags>"-lOpenCL"
             <host-os>darwin:<linkflags>"-framework OpenCL"
+            <host-os>freebsd:<linkflags>"-lOpenCL"
         ] ;
     }
 

--- a/test/test_command_queue.cpp
+++ b/test/test_command_queue.cpp
@@ -21,6 +21,7 @@
 #include <boost/compute/container/vector.hpp>
 #include <boost/compute/utility/dim.hpp>
 #include <boost/compute/utility/source.hpp>
+#include <boost/compute/detail/diagnostic.hpp>
 
 #include "check_macros.hpp"
 #include "context_setup.hpp"
@@ -145,8 +146,11 @@ BOOST_AUTO_TEST_CASE(construct_from_cl_command_queue)
     } else
 #endif // CL_VERSION_2_0
     {
+        // Suppress deprecated declarations warning
+        BOOST_COMPUTE_DISABLE_DEPRECATED_DECLARATIONS();
         cl_queue =
             clCreateCommandQueue(context, device.id(), 0, 0);
+        BOOST_COMPUTE_ENABLE_DEPRECATED_DECLARATIONS();
     }
     BOOST_VERIFY(cl_queue);
 


### PR DESCRIPTION
This is a fast fix for https://github.com/boostorg/compute/issues/563 (+ I've suppressed some other warning for MSVC that are just annoying) . 

I'll later remove lines

```
<toolset>gcc:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in CL/cl.h
<toolset>clang:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in CL/cl.h
<toolset>darwin:<cxxflags>-Wno-deprecated-declarations # Deprecated declarations in CL/cl.h
<toolset>msvc:<cxxflags>/wd4996 # Deprecated declarations in CL/cl.h
```
and suppress deprecated declarations warning (related to CL/cl.h) in the code.