### PR TITLE
Fix compilation errors on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -256,13 +256,24 @@ matrix:
     ############################################################################
     # OSX
     ############################################################################
+    # OSX build with running tests
     - os: osx
       compiler: clang
       env:
         - ENV_CXX_FLAGS="-Wno-c99-extensions"
+        - RUN_TESTS=true
+    # OSX build without running tests
+    - os: osx
+      compiler: clang
+      env:
+        - ENV_CXX_FLAGS="-Wno-c99-extensions"
+        - RUN_TESTS=false
 
   allow_failures:
-    - os: osx
+    - os: osx # OSX build with running tests is allowed to fail
+      env:
+        - ENV_CXX_FLAGS="-Wno-c99-extensions"
+        - RUN_TESTS=true
 
 before_install:
     # Install recent cmake

--- a/include/boost/compute/algorithm/detail/merge_with_merge_path.hpp
+++ b/include/boost/compute/algorithm/detail/merge_with_merge_path.hpp
@@ -147,8 +147,8 @@ merge_with_merge_path(InputIterator1 first1,
                       Compare comp,
                       command_queue &queue = system::default_queue())
 {
-   typedef typename
-       std::iterator_traits<OutputIterator>::difference_type result_difference_type;
+    typedef typename
+        std::iterator_traits<OutputIterator>::difference_type result_difference_type;
 
     size_t tile_size = 1024;
 
@@ -163,12 +163,12 @@ merge_with_merge_path(InputIterator1 first1,
     tiling_kernel.tile_size = static_cast<unsigned int>(tile_size);
     tiling_kernel.set_range(first1, last1, first2, last2,
                             tile_a.begin()+1, tile_b.begin()+1, comp);
-    fill_n(tile_a.begin(), 1, 0, queue);
-    fill_n(tile_b.begin(), 1, 0, queue);
+    fill_n(tile_a.begin(), 1, uint_(0), queue);
+    fill_n(tile_b.begin(), 1, uint_(0), queue);
     tiling_kernel.exec(queue);
 
-    fill_n(tile_a.end()-1, 1, count1, queue);
-    fill_n(tile_b.end()-1, 1, count2, queue);
+    fill_n(tile_a.end()-1, 1, static_cast<uint_>(count1), queue);
+    fill_n(tile_b.end()-1, 1, static_cast<uint_>(count2), queue);
 
     // Merge
     serial_merge_kernel merge_kernel;

--- a/include/boost/compute/algorithm/includes.hpp
+++ b/include/boost/compute/algorithm/includes.hpp
@@ -130,12 +130,12 @@ inline bool includes(InputIterator1 first1,
     tiling_kernel.tile_size = static_cast<unsigned int>(tile_size);
     tiling_kernel.set_range(first1, last1, first2, last2,
                             tile_a.begin()+1, tile_b.begin()+1);
-    fill_n(tile_a.begin(), 1, 0, queue);
-    fill_n(tile_b.begin(), 1, 0, queue);
+    fill_n(tile_a.begin(), 1, uint_(0), queue);
+    fill_n(tile_b.begin(), 1, uint_(0), queue);
     tiling_kernel.exec(queue);
 
-    fill_n(tile_a.end()-1, 1, count1, queue);
-    fill_n(tile_b.end()-1, 1, count2, queue);
+    fill_n(tile_a.end()-1, 1, static_cast<uint_>(count1), queue);
+    fill_n(tile_b.end()-1, 1, static_cast<uint_>(count2), queue);
 
     vector<uint_> result((count1+count2+tile_size-1)/tile_size, queue.get_context());
 

--- a/include/boost/compute/iterator/strided_iterator.hpp
+++ b/include/boost/compute/iterator/strided_iterator.hpp
@@ -50,7 +50,7 @@ public:
 template<class IndexExpr, class Stride>
 struct stride_expr
 {
-    stride_expr(const IndexExpr &expr, Stride stride)
+    stride_expr(const IndexExpr &expr, const Stride &stride)
         : m_index_expr(expr),
           m_stride(stride)
     {
@@ -61,13 +61,15 @@ struct stride_expr
 };
 
 template<class IndexExpr, class Stride>
-inline stride_expr<IndexExpr, Stride> make_stride_expr(const IndexExpr &expr, Stride stride)
+inline stride_expr<IndexExpr, Stride> make_stride_expr(const IndexExpr &expr,
+                                                       const Stride &stride)
 {
     return stride_expr<IndexExpr, Stride>(expr, stride);
 }
 
 template<class IndexExpr, class Stride>
-inline meta_kernel& operator<<(meta_kernel &kernel, const stride_expr<IndexExpr, Stride> &expr)
+inline meta_kernel& operator<<(meta_kernel &kernel,
+                               const stride_expr<IndexExpr, Stride> &expr)
 {
     // (expr.m_stride * (expr.m_index_expr))
     return kernel << "(" << static_cast<ulong_>(expr.m_stride)
@@ -80,8 +82,8 @@ struct strided_iterator_index_expr
     typedef typename std::iterator_traits<Iterator>::value_type result_type;
 
     strided_iterator_index_expr(const Iterator &input_iter,
-                                  const Stride &stride,
-                                  const IndexExpr &index_expr)
+                                const Stride &stride,
+                                const IndexExpr &index_expr)
         : m_input_iter(input_iter),
           m_stride(stride),
           m_index_expr(index_expr)
@@ -96,8 +98,8 @@ struct strided_iterator_index_expr
 template<class Iterator, class Stride, class IndexExpr>
 inline meta_kernel& operator<<(meta_kernel &kernel,
                                const strided_iterator_index_expr<Iterator,
-                                                                   Stride,
-                                                                   IndexExpr> &expr)
+                                                                 Stride,
+                                                                 IndexExpr> &expr)
 {
     return kernel << expr.m_input_iter[make_stride_expr(expr.m_index_expr, expr.m_stride)];
 }
@@ -167,11 +169,12 @@ public:
     detail::strided_iterator_index_expr<Iterator, difference_type, IndexExpression>
     operator[](const IndexExpression &expr) const
     {
-        return detail::strided_iterator_index_expr<Iterator,
-                                                   difference_type,
-                                                   IndexExpression>(super_type::base(),
-                                                                    m_stride,
-                                                                    expr);
+        typedef
+            typename detail::strided_iterator_index_expr<Iterator,
+                                                         difference_type,
+                                                         IndexExpression>
+            StridedIndexExprType;
+        return StridedIndexExprType(super_type::base(),m_stride, expr);
     }
 
 private:
@@ -226,7 +229,8 @@ private:
 /// \endcode
 template<class Iterator>
 inline strided_iterator<Iterator>
-make_strided_iterator(Iterator iterator, typename std::iterator_traits<Iterator>::difference_type stride)
+make_strided_iterator(Iterator iterator,
+                      typename std::iterator_traits<Iterator>::difference_type stride)
 {
     return strided_iterator<Iterator>(iterator, stride);
 }
@@ -256,16 +260,16 @@ make_strided_iterator(Iterator iterator, typename std::iterator_traits<Iterator>
 /// // copy every 3rd element to result
 /// boost::compute::copy(
 ///         strided_iterator_begin,
-///         strided_iterator_end,ided_iterator referring to element that would follow
-///         the last element accessible through strided_iterator for \p first
-///         iterator with \p stride.
+///         strided_iterator_end,
 ///         result.begin(),
 ///         queue
 /// );
 /// \endcode
 template<class Iterator>
 strided_iterator<Iterator>
-make_strided_iterator_end(Iterator first, Iterator last, typename std::iterator_traits<Iterator>::difference_type stride)
+make_strided_iterator_end(Iterator first,
+                          Iterator last,
+                          typename std::iterator_traits<Iterator>::difference_type stride)
 {
     typedef typename std::iterator_traits<Iterator>::difference_type difference_type;
 

--- a/include/boost/compute/iterator/strided_iterator.hpp
+++ b/include/boost/compute/iterator/strided_iterator.hpp
@@ -69,7 +69,9 @@ inline stride_expr<IndexExpr, Stride> make_stride_expr(const IndexExpr &expr, St
 template<class IndexExpr, class Stride>
 inline meta_kernel& operator<<(meta_kernel &kernel, const stride_expr<IndexExpr, Stride> &expr)
 {
-    return kernel << "(" << expr.m_stride << " * (" << expr.m_index_expr << "))";
+    // (expr.m_stride * (expr.m_index_expr))
+    return kernel << "(" << static_cast<ulong_>(expr.m_stride)
+                  << " * (" << expr.m_index_expr << "))";
 }
 
 template<class Iterator, class Stride, class IndexExpr>

--- a/test/test_strided_iterator.cpp
+++ b/test/test_strided_iterator.cpp
@@ -86,10 +86,10 @@ BOOST_AUTO_TEST_CASE(distance)
 
 BOOST_AUTO_TEST_CASE(copy)
 {
-    int data[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
-    boost::compute::vector<int> vec(data, data + 8, queue);
+    boost::compute::int_ data[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    boost::compute::vector<boost::compute::int_> vec(data, data + 8, queue);
 
-    boost::compute::vector<int> result(4, context);
+    boost::compute::vector<boost::compute::int_> result(4, context);
 
     // copy every other element to result
     boost::compute::copy(
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(copy)
         result.begin(),
         queue
     );
-    CHECK_RANGE_EQUAL(int, 4, result, (1, 3, 5, 7));
+    CHECK_RANGE_EQUAL(boost::compute::int_, 4, result, (1, 3, 5, 7));
 
     // copy every 3rd element to result
     boost::compute::copy(
@@ -107,19 +107,21 @@ BOOST_AUTO_TEST_CASE(copy)
         result.begin(),
         queue
     );
-    CHECK_RANGE_EQUAL(int, 3, result, (1, 4, 7));
+    CHECK_RANGE_EQUAL(boost::compute::int_, 3, result, (1, 4, 7));
 }
 
 BOOST_AUTO_TEST_CASE(make_strided_iterator_end)
 {
-    int data[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
-    boost::compute::vector<int> vec(data, data + 8, queue);
+    boost::compute::int_ data[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    boost::compute::vector<boost::compute::int_> vec(data, data + 8, queue);
 
     // stride equals 3
-    boost::compute::strided_iterator<boost::compute::vector<int>::iterator> end =
+    typedef boost::compute::vector<boost::compute::int_>::iterator IterType;
+    boost::compute::strided_iterator<IterType> end =
         boost::compute::make_strided_iterator_end(vec.begin(),
                                                   vec.end(),
                                                   3);
+
     // end should be vec.begin() + 9 which is one step after last element
     // accessible through strided_iterator, i.e. vec.begin()+6
     BOOST_CHECK(boost::compute::make_strided_iterator(vec.begin()+9, 3) ==
@@ -143,7 +145,7 @@ BOOST_AUTO_TEST_CASE(make_strided_iterator_end)
 
     // test boost::compute::make_strided_iterator_end with copy(..)
 
-    boost::compute::vector<int> result(4, context);
+    boost::compute::vector<boost::compute::int_> result(4, context);
 
     // copy every other element to result
     boost::compute::copy(
@@ -152,7 +154,7 @@ BOOST_AUTO_TEST_CASE(make_strided_iterator_end)
         result.begin(),
         queue
     );
-    CHECK_RANGE_EQUAL(int, 4, result, (2, 4, 6, 8));
+    CHECK_RANGE_EQUAL(boost::compute::int_, 4, result, (2, 4, 6, 8));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Unfortunately, commit 3826e9cae47f56d6ce91a6127800bce979155a0c (fixing some unsigned/signed int comparison warnings on Windows) introduced compilation errors for OSX that I did not notice. 

See build 1300.9: https://travis-ci.org/boostorg/compute/builds/115231140.

This PR fixes those erros and add OSX Travis-CI build without running tests (because currently a few tests fail on OSX) in order to avoid such a mistakes in the future. (OSX build with tests is still allowed to fail.) There is also a small code refactoring in `strided_iterator.hpp`  .