### PR TITLE
Provide wait_list::reserve() method

### DIFF
--- a/include/boost/compute/utility/wait_list.hpp
+++ b/include/boost/compute/utility/wait_list.hpp
@@ -120,6 +120,11 @@ public:
         return reinterpret_cast<const cl_event *>(&m_events[0]);
     }
 
+    /// Reserves a minimum length of storage for the wait list object.
+    void reserve(size_t new_capacity) {
+        m_events.reserve(new_capacity);
+    }
+
     /// Inserts \p event into the wait-list.
     void insert(const event &event)
     {


### PR DESCRIPTION
This should help to get rid of unnecessary heap allocations.

The wait lists are usually small, which means that just pushing back
elements without prior call to reserve has very high chance of hitting
capacity limit every time [wait_list::insert](https://github.com/boostorg/compute/blob/38ba1c54479869c6ad6d2ea1f828e6d113bc5ab9/include/boost/compute/utility/wait_list.hpp#L124) is called.