### PR TITLE
Build fixes and other

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -330,7 +330,7 @@ install:
         travis_retry git clone --depth 1 https://github.com/pocl/pocl.git -b ${POCL_BRANCH}
         cd pocl
         if [[ -n "${POCL_COMMIT}" ]]; then
-            git checkout ${POCL_COMMIT}
+          git checkout ${POCL_COMMIT}
         fi
         mkdir build
         cd build
@@ -377,8 +377,15 @@ install:
         mkdir -p ${OPENCL_VENDOR_PATH}
         sh AMD-APP-SDK*.sh --tar -xf -C ${AMDAPPSDKROOT}
         echo libamdocl64.so > ${OPENCL_VENDOR_PATH}/amdocl64.icd
-        export LD_LIBRARY_PATH=${AMDAPPSDKROOT}/lib/x86_64:${LD_LIBRARY_PATH}
-        export CMAKE_LIBRARY_PATH=${AMDAPPSDKROOT}/lib/x86_64;
+        if [[ ${AMDAPPSDK_VERSION} == "300" ]]; then
+          export LD_LIBRARY_PATH=${AMDAPPSDKROOT}/lib/x86_64/sdk:${LD_LIBRARY_PATH}
+          export CMAKE_LIBRARY_PATH=${AMDAPPSDKROOT}/lib/x86_64/sdk
+          cp ${AMDAPPSDKROOT}/lib/x86_64/libamdocl12cl64.so ${AMDAPPSDKROOT}/lib/x86_64/sdk/libamdocl12cl64.so
+        # 291
+        else
+          export LD_LIBRARY_PATH=${AMDAPPSDKROOT}/lib/x86_64:${LD_LIBRARY_PATH}
+          export CMAKE_LIBRARY_PATH=${AMDAPPSDKROOT}/lib/x86_64
+        fi
         chmod +x ${AMDAPPSDKROOT}/bin/x86_64/clinfo
         ${AMDAPPSDKROOT}/bin/x86_64/clinfo
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ env:
     - OPENCL_REGISTRY=https://www.khronos.org/registry/cl
     - OPENCL_ROOT=${DEPS_DIR}/opencl
     # POCL
-    - POCL_VERSION=master
+    - POCL_BRANCH=release_0_13 # branch/tag
+    #- POCL_COMMIT= # commit id
     - POCL_LLVM_CONFIG="llvm-config-3.7"
     - POCL_COMPILER=clang++-3.7
     # AMD APP SDK
@@ -326,13 +327,10 @@ install:
     ############################################################################
     - |
       if [[ ${TRAVIS_OS_NAME} == "linux" && ${OPENCL_LIB} == "pocl" ]]; then
-        if [[ "${POCL_VERSION}" == "master" ]]; then
-          travis_retry git clone --depth 1 https://github.com/pocl/pocl.git
-          cd pocl
-        else
-          travis_retry wget --no-check-certificate http://pocl.sourceforge.net/downloads/${POCL_VERSION}.tar.gz
-          tar -xf ${POCL_VERSION}.tar.gz
-          cd ${POCL_VERSION}
+        travis_retry git clone --depth 1 https://github.com/pocl/pocl.git -b ${POCL_BRANCH}
+        cd pocl
+        if [[ -n "${POCL_COMMIT}" ]]; then
+            git checkout ${POCL_COMMIT}
         fi
         mkdir build
         cd build

--- a/include/boost/compute/detail/parameter_cache.hpp
+++ b/include/boost/compute/detail/parameter_cache.hpp
@@ -161,7 +161,7 @@ private:
         try {
             read_json(m_file_name, pt);
         }
-        catch(boost::property_tree::json_parser::json_parser_error &e){
+        catch(boost::property_tree::json_parser::json_parser_error&){
             // no saved cache file, ignore
             return;
         }

--- a/perf/perf.hpp
+++ b/perf/perf.hpp
@@ -22,7 +22,7 @@
 #include <boost/timer/timer.hpp>
 
 static size_t PERF_N = 1024;
-static size_t PERF_TRIALS = 1;
+static size_t PERF_TRIALS = 3;
 
 // parses command line arguments and sets the corresponding perf variables
 inline void perf_parse_args(int argc, char *argv[])
@@ -31,8 +31,9 @@ inline void perf_parse_args(int argc, char *argv[])
         PERF_N = boost::lexical_cast<size_t>(argv[1]);
     }
 
-    // TODO: make this configurable from the command line
-    PERF_TRIALS = 3;
+    if(argc >= 3){
+        PERF_TRIALS = boost::lexical_cast<size_t>(argv[2]);
+    }
 }
 
 // generates a vector of random numbers

--- a/perf/perf_saxpy.cpp
+++ b/perf/perf_saxpy.cpp
@@ -43,6 +43,7 @@ double perf_saxpy(const compute::vector<T>& x,
     perf_timer t;
     for(size_t trial = 0; trial < trials; trial++){
         compute::fill(result.begin(), result.end(), T(0), queue);
+        queue.finish();
 
         t.start();
 

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -152,6 +152,13 @@ destructor_templated_callback_function(bool *flag)
 
 BOOST_AUTO_TEST_CASE(destructor_templated_callback)
 {
+    REQUIRES_OPENCL_VERSION(1,2);
+
+    if(!supports_destructor_callback(device))
+    {
+        return;
+    }
+
     bool invoked = false;
     {
         boost::compute::buffer buf(context, 128);


### PR DESCRIPTION
* Now 0.13 version of POCL is used instead of `master`-branch version.
* Fix for AMD APP SDK v3.0 builds, AMD updated the SDK and nothing works as it did :) I opened an [issue ](https://community.amd.com/thread/198900) on AMD forum, maybe they'll fix it later.
* Minor fixes in `test_buffer`, `parameter_cache` and `perf_saxpy`