### PR TITLE
Add initializer list constructor to wait_list

### DIFF
--- a/include/boost/compute/utility/wait_list.hpp
+++ b/include/boost/compute/utility/wait_list.hpp
@@ -13,6 +13,12 @@
 
 #include <vector>
 
+#include <boost/compute/config.hpp>
+
+#ifndef BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
+#include <initializer_list>
+#endif
+
 #include <boost/compute/event.hpp>
 
 namespace boost {
@@ -59,6 +65,14 @@ public:
         : m_events(other.m_events)
     {
     }
+
+    #ifndef BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
+    /// Creates a wait-list from \p events
+    wait_list(std::initializer_list<event> events)
+        : m_events(events)
+    {
+    }
+    #endif // BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
 
     /// Copies the events in the wait-list from \p other.
     wait_list& operator=(const wait_list &other)

--- a/test/test_wait_list.cpp
+++ b/test/test_wait_list.cpp
@@ -34,6 +34,18 @@ BOOST_AUTO_TEST_CASE(create_wait_list)
     BOOST_CHECK(events.get_event_ptr() == 0);
 }
 
+#ifndef BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
+BOOST_AUTO_TEST_CASE(create_wait_list_from_initializer_list)
+{
+    compute::event event0;
+    compute::event event1;
+    compute::event event2;
+    compute::wait_list events = { event0, event1, event2 };
+    BOOST_CHECK_EQUAL(events.size(), size_t(3));
+    CHECK_RANGE_EQUAL(compute::event, 3, events, (event0, event1, event2));
+}
+#endif // BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
+
 BOOST_AUTO_TEST_CASE(insert_future)
 {
     // create vector on the host


### PR DESCRIPTION
Constructing a wait_list from an initializer list is often convenient.