### PR TITLE
Fix uniform real distribution 

### DIFF
--- a/include/boost/compute/random/uniform_real_distribution.hpp
+++ b/include/boost/compute/random/uniform_real_distribution.hpp
@@ -20,7 +20,7 @@ namespace boost {
 namespace compute {
 
 /// \class uniform_real_distribution
-/// \brief Produces uniformily distributed random floating-point numbers.
+/// \brief Produces uniformly distributed random floating-point numbers.
 ///
 /// The following example shows how to setup a uniform real distribution to
 /// produce random \c float values between \c 1 and \c 100.
@@ -59,7 +59,7 @@ public:
         return m_b;
     }
 
-    /// Generates uniformily distributed floating-point numbers and stores
+    /// Generates uniformly distributed floating-point numbers and stores
     /// them to the range [\p first, \p last).
     template<class OutputIterator, class Generator>
     void generate(OutputIterator first,
@@ -69,7 +69,7 @@ public:
     {
         BOOST_COMPUTE_FUNCTION(RealType, scale_random, (const uint_ x),
         {
-            return LO + (convert_RealType(x) / MAX_RANDOM) * (HI - LO);
+            return nextafter(LO + (convert_RealType(x) / MAX_RANDOM) * (HI - LO), (RealType) LO);
         });
 
         scale_random.define("LO", detail::make_literal(m_a));
@@ -78,6 +78,7 @@ public:
         scale_random.define(
             "convert_RealType", std::string("convert_") + type_name<RealType>()
         );
+        scale_random.define("RealType", type_name<RealType>());
 
         generator.generate(
             first, last, scale_random, queue

--- a/include/boost/compute/random/uniform_real_distribution.hpp
+++ b/include/boost/compute/random/uniform_real_distribution.hpp
@@ -11,6 +11,8 @@
 #ifndef BOOST_COMPUTE_RANDOM_UNIFORM_REAL_DISTRIBUTION_HPP
 #define BOOST_COMPUTE_RANDOM_UNIFORM_REAL_DISTRIBUTION_HPP
 
+#include <boost/assert.hpp>
+
 #include <boost/compute/command_queue.hpp>
 #include <boost/compute/function.hpp>
 #include <boost/compute/detail/literal.hpp>
@@ -36,10 +38,12 @@ public:
 
     /// Creates a new uniform distribution producing numbers in the range
     /// [\p a, \p b).
+    /// Requires a < b
     uniform_real_distribution(RealType a = 0.f, RealType b = 1.f)
         : m_a(a),
           m_b(b)
     {
+        BOOST_ASSERT(a < b);
     }
 
     /// Destroys the uniform_real_distribution object.

--- a/test/test_uniform_real_distribution.cpp
+++ b/test/test_uniform_real_distribution.cpp
@@ -14,10 +14,13 @@
 #include <boost/compute/system.hpp>
 #include <boost/compute/command_queue.hpp>
 #include <boost/compute/algorithm/count_if.hpp>
+#include <boost/compute/algorithm/transform.hpp>
+#include <boost/compute/function.hpp>
 #include <boost/compute/container/vector.hpp>
 #include <boost/compute/random/default_random_engine.hpp>
 #include <boost/compute/random/uniform_real_distribution.hpp>
 #include <boost/compute/lambda.hpp>
+#include <boost/compute/types/fundamental.hpp>
 
 #include "context_setup.hpp"
 
@@ -40,7 +43,60 @@ distribution.generate(vec.begin(), vec.end(), engine, queue);
 
     BOOST_CHECK_EQUAL(
         boost::compute::count_if(
-            vec.begin(), vec.end(), _1 < 1.0f || _1 > 100.0f, queue
+            vec.begin(), vec.end(), _1 < 1.0f || _1 >= 100.0f, queue
+        ),
+        size_t(0)
+    );
+}
+
+template<class T>
+class range_test_engine
+{
+public:
+    explicit range_test_engine(boost::compute::command_queue &queue) {
+        (void) queue;
+    }
+
+    template<class OutputIterator, class Function>
+    void generate(OutputIterator first, OutputIterator last, Function op, boost::compute::command_queue &queue)
+    {
+        boost::compute::vector<T> tmp(std::distance(first, last), queue.get_context());
+
+        BOOST_COMPUTE_FUNCTION(T, max_random, (const T x),
+        {
+            if(get_global_id(0) < 1)
+                return (ValueType) MAX_RANDOM;
+            else
+                return (ValueType) 0;
+        });
+
+        max_random.define("MAX_RANDOM", "UINT_MAX");
+        max_random.define("ValueType", boost::compute::type_name<T>());
+
+        boost::compute::transform(tmp.begin(), tmp.end(), tmp.begin(), max_random, queue);
+        boost::compute::transform(tmp.begin(), tmp.end(), first, op, queue);
+    }
+};
+
+// For checking if result is in the correct range [low, hi)
+BOOST_AUTO_TEST_CASE(uniform_real_distribution_range)
+{
+    using boost::compute::lambda::_1;
+
+    boost::compute::vector<float> vec(32, context);
+
+    // initialize the range_test_engine
+    range_test_engine<boost::compute::uint_> engine(queue);
+
+    // setup the uniform distribution to produce floats between 0.9 and 1.0
+    boost::compute::uniform_real_distribution<float> distribution(0.9f, 1.0f);
+
+    // generate the random values and store them to 'vec'
+    distribution.generate(vec.begin(), vec.end(), engine, queue);
+
+    BOOST_CHECK_EQUAL(
+        boost::compute::count_if(
+            vec.begin(), vec.end(), _1 < 0.9f || _1 >= 1.0f, queue
         ),
         size_t(0)
     );


### PR DESCRIPTION
Related to https://github.com/boostorg/compute/issues/587. 

Now generated floating-point values are uniformly distributed on the interval `[a, b)` and no value is greater or equal to `b`.

I also added test that checks if results are in fact in `[a,b)` range (by using `range_test_engine` class that generates max random value or zeroes).