### PR TITLE
Fix find_end algorithm

### DIFF
--- a/include/boost/compute/algorithm/detail/search_all.hpp
+++ b/include/boost/compute/algorithm/detail/search_all.hpp
@@ -48,7 +48,7 @@ public:
 
         *this <<
             "uint i = get_global_id(0);\n" <<
-            "uint i1 = i;\n" <<
+            "const uint i1 = i;\n" <<
             "uint j;\n" <<
             "for(j = 0; j<p_count; j++,i++)\n" <<
             "{\n" <<

--- a/include/boost/compute/algorithm/find_end.hpp
+++ b/include/boost/compute/algorithm/find_end.hpp
@@ -36,6 +36,7 @@ inline InputIterator find_end_helper(InputIterator first,
                                      command_queue &queue)
 {
     typedef typename std::iterator_traits<InputIterator>::value_type value_type;
+    typedef typename std::iterator_traits<InputIterator>::difference_type difference_type;
 
     size_t count = detail::iterator_range_size(first, last);
     if(count == 0){
@@ -65,8 +66,13 @@ inline InputIterator find_end_helper(InputIterator first,
     queue.enqueue_1d_range_kernel(kernel, 0, count, 0);
 
     int result = static_cast<int>(index.read(queue));
-    if(result == -1) return last;
-    else return first + result;
+
+    if(result == -1){
+        return last;
+    }
+    else {
+        return first + static_cast<difference_type>(result);
+    }
 }
 
 } // end detail namespace
@@ -92,8 +98,13 @@ inline TextIterator find_end(TextIterator t_first,
                              command_queue &queue = system::default_queue())
 {
     const context &context = queue.get_context();
-    vector<uint_> matching_indices(detail::iterator_range_size(t_first, t_last),
-                                    context);
+
+    // there is no need to check if pattern starts at last n - 1 indices
+    vector<uint_> matching_indices(
+        detail::iterator_range_size(t_first, t_last)
+            + 1 - detail::iterator_range_size(p_first, p_last),
+        context
+    );
 
     detail::search_kernel<PatternIterator,
                           TextIterator,
@@ -105,10 +116,16 @@ inline TextIterator find_end(TextIterator t_first,
     using boost::compute::_1;
 
     vector<uint_>::iterator index =
-        detail::find_end_helper(matching_indices.begin(),
-                                matching_indices.end(),
-                                _1 == 1,
-                                queue);
+        detail::find_end_helper(
+            matching_indices.begin(),
+            matching_indices.end(),
+            _1 == 1,
+            queue
+        );
+
+    // pattern was not found
+    if(index == matching_indices.end())
+        return t_last;
 
     return t_first + detail::iterator_range_size(matching_indices.begin(), index);
 }

--- a/test/test_find_end.cpp
+++ b/test/test_find_end.cpp
@@ -24,40 +24,40 @@ namespace bc = boost::compute;
 
 BOOST_AUTO_TEST_CASE(find_end_int)
 {
-    int data[] = {1, 4, 2, 6, 3, 2, 6, 3, 4, 6};
+    bc::int_ data[] = {1, 4, 2, 6, 3, 2, 6, 3, 4, 6};
     bc::vector<bc::int_> vectort(data, data + 10, queue);
 
-    int datap[] = {2, 6};
+    bc::int_ datap[] = {2, 6};
     bc::vector<bc::int_> vectorp(datap, datap + 2, queue);
 
     bc::vector<bc::int_>::iterator iter =
         bc::find_end(vectort.begin(), vectort.end(),
                     vectorp.begin(), vectorp.end(), queue);
 
-    BOOST_VERIFY(iter == vectort.begin() + 5);
+    BOOST_CHECK(iter == vectort.begin() + 5);
 
-    vectorp[1] = 9;
+    vectorp.insert(vectorp.begin() + 1, bc::int_(9), queue);
 
     iter =
         bc::find_end(vectort.begin(), vectort.end(),
-                    vectorp.begin(), vectorp.end(), queue);
+                     vectorp.begin(), vectorp.end(), queue);
 
-    BOOST_VERIFY(iter == vectort.begin() + 10);
+    BOOST_CHECK(iter == vectort.end());
 }
 
 BOOST_AUTO_TEST_CASE(find_end_string)
 {
-    char text[] = "sdabababacabskjabacab";
+    bc::char_ text[] = "sdabababacabskjabacab";
     bc::vector<bc::char_> vectort(text, text + 21, queue);
 
-    char pattern[] = "aba";
+    bc::char_ pattern[] = "aba";
     bc::vector<bc::char_> vectorp(pattern, pattern + 3, queue);
 
     bc::vector<bc::char_>::iterator iter =
         bc::find_end(vectort.begin(), vectort.end(),
-                    vectorp.begin(), vectorp.end(), queue);
+                     vectorp.begin(), vectorp.end(), queue);
 
-    BOOST_VERIFY(iter == vectort.begin() + 15);
+    BOOST_CHECK(iter == (vectort.begin() + 15));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
I've found out what's wrong in the `find_end` algorithm. Using uninitialized memory (from the end of `matching_indices`) was causing undefined behaviour. It was uninitialized because `search_kernel` does not initialize the last `<pattern_size> - 1` elements of `matching_indices` as the pattern can not start there. Now it's fixed.