### PR TITLE
Increase make_literal precision

### DIFF
--- a/include/boost/compute/detail/literal.hpp
+++ b/include/boost/compute/detail/literal.hpp
@@ -27,7 +27,15 @@ template<class T>
 std::string make_literal(T x)
 {
     std::stringstream s;
-    s << std::setprecision(std::numeric_limits<T>::digits10)
+    s << std::setprecision(
+#ifndef BOOST_NO_CXX11_NUMERIC_LIMITS
+            std::numeric_limits<T>::max_digits10
+#else
+            // We don't have max_digits10, so add 3 other digits (this is what is required for
+            // float, and is one more than required for double).
+            3 + std::numeric_limits<T>::digits10
+#endif
+            )
       << std::scientific
       << x;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -225,6 +225,7 @@ add_compute_test("experimental.tabulate" test_tabulate.cpp)
 add_compute_test("misc.amd_cpp_kernel_language" test_amd_cpp_kernel_language.cpp)
 add_compute_test("misc.lambda" test_lambda.cpp)
 add_compute_test("misc.user_defined_types" test_user_defined_types.cpp)
+add_compute_test("misc.literal_conversion" test_literal_conversion.cpp)
 
 # extra tests (interop tests, linkage tests, etc.)
 add_subdirectory(extra)

--- a/test/test_literal_conversion.cpp
+++ b/test/test_literal_conversion.cpp
@@ -1,0 +1,60 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2016 Jason Rhinelander <jason@imaginary.ca>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE TestLiteralConversion
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <sstream>
+#include <vector>
+
+#include <boost/compute/detail/literal.hpp>
+
+BOOST_AUTO_TEST_CASE(literal_conversion_float)
+{
+    std::vector<float> values, roundtrip;
+    values.push_back(1.2345679f);
+    values.push_back(1.2345680f);
+    values.push_back(1.2345681f);
+    for (int i = 0; i < values.size(); i++) {
+        std::istringstream iss(boost::compute::detail::make_literal(values[i]));
+        float x;
+        BOOST_CHECK(iss >> x);
+        BOOST_CHECK_EQUAL(char(iss.get()), 'f');
+        // Make sure we're at the end:
+        iss.peek();
+        BOOST_CHECK(iss.eof());
+
+        roundtrip.push_back(x);
+    }
+    BOOST_CHECK_EQUAL(values[0], roundtrip[0]);
+    BOOST_CHECK_EQUAL(values[1], roundtrip[1]);
+    BOOST_CHECK_EQUAL(values[2], roundtrip[2]);
+}
+
+BOOST_AUTO_TEST_CASE(literal_conversion_double)
+{
+    std::vector<double> values, roundtrip;
+    values.push_back(1.2345678901234567);
+    values.push_back(1.2345678901234569);
+    values.push_back(1.2345678901234571);
+    for (int i = 0; i < values.size(); i++) {
+        std::istringstream iss(boost::compute::detail::make_literal(values[i]));
+        double x;
+        BOOST_CHECK(iss >> x);
+        // Make sure we're at the end:
+        iss.peek();
+        BOOST_CHECK(iss.eof());
+        roundtrip.push_back(x);
+    }
+    BOOST_CHECK_EQUAL(values[0], roundtrip[0]);
+    BOOST_CHECK_EQUAL(values[1], roundtrip[1]);
+    BOOST_CHECK_EQUAL(values[2], roundtrip[2]);
+}


### PR DESCRIPTION
boost::compute::detail::make_literal is losing some precision when making literal floating point values because it uses std::numeric_limits<T>::digits10, but that only gives us the number of decimal digits that will survive a decimal->native>decimal conversion; what we are doing is a native->decimal->native conversion, which can require up to ::max_digits10 (which is larger than ::digits10 by 2 (double) or 3 (float)).

However, max_digits10 is a c++11 feature, so this commit uses digits10 + 3 when the c++11 numeric_limits isn't available.  That should be enough for an IEEE-style float, though is slightly more than necessary for some (e.g. double).

I also added a test for this (which fails with the current conversion for both float and double, and passes with the proposed commits).