### PR TITLE
Turn off coveralls for POCL builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -410,6 +410,9 @@ script:
       fi
 
 after_success:
-    - lcov --directory test --base-directory ../include/boost/compute/ --capture --output-file coverage.info
-    - lcov --remove coverage.info '/usr*' -o coverage.info
-    - cd .. && coveralls-lcov build/coverage.info
+    - |
+      if [[ ${OPENCL_LIB} != "pocl" && ${RUN_TESTS} == "true" ]]; then
+        lcov --directory test --base-directory ../include/boost/compute/ --capture --output-file coverage.info
+        lcov --remove coverage.info '/usr*' -o coverage.info
+        cd .. && coveralls-lcov build/coverage.info
+      fi


### PR DESCRIPTION
It takes a long time to run POCL builds and having coveralls in them only makes them fail due to exceeding the maximum time limit (see https://travis-ci.org/boostorg/compute/jobs/125418210). We will still have coveralls stats from AMD APP builds with gcc (OpenCL 1.2 and 2.0).