### PR TITLE
Add Travis CI build with latest Boost libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
     # Global build options and C++ flags
     - CMAKE_OPTIONS="-DBOOST_COMPUTE_BUILD_TESTS=ON -DBOOST_COMPUTE_BUILD_EXAMPLES=ON -DBOOST_COMPUTE_BUILD_BENCHMARKS=ON -DBOOST_COMPUTE_USE_OFFLINE_CACHE=ON -DBOOST_COMPUTE_HAVE_OPENCV=ON -DBOOST_COMPUTE_THREAD_SAFE=ON"
     - CXX_FLAGS="-Wall -pedantic -Werror -Wno-variadic-macros -Wno-long-long -Wno-shadow"
+    # Boost
+    - BOOST_VERSION=default
     # Misc
     - RUN_TESTS=true
     - COVERAGE=false
@@ -289,6 +291,43 @@ matrix:
         - ENV_CMAKE_OPTIONS="-DOpenCL_INCLUDE_DIR=${OPENCL_ROOT}/include -DBOOST_COMPUTE_ENABLE_COVERAGE=ON"
         - COVERAGE=true
 
+    # Latest Boost library builds (currently 1.61)
+    # Precise, AMD APP SDK v2.9.1, Travis CI container-based infrastructure
+    - os: linux
+      sudo: false
+      compiler: clang
+      addons:
+       apt:
+         packages: &precise_latest_boost_packages
+           - g++-4.8
+           # Misc
+           - python-yaml
+           - lcov
+           - libopencv-dev
+         sources: &precise_latest_boost_sources
+           - ubuntu-toolchain-r-test
+      env:
+        - OPENCL_LIB=amdappsdk
+        - OPENCL_VERSION="12"
+        - AMDAPPSDK_VERSION=291 # OpenCL 1.2
+        - BOOST_VERSION="1_61_0" # Boost 1.61
+        - BOOST_URL="http://sourceforge.net/projects/boost/files/boost/1.61.0/boost_1_61_0.tar.gz"
+        - ENV_CMAKE_OPTIONS="-DOpenCL_INCLUDE_DIR=${OPENCL_ROOT}/include"
+    - os: linux
+      sudo: false
+      compiler: gcc
+      addons:
+        apt:
+          packages: *precise_latest_boost_packages
+          sources: *precise_latest_boost_sources
+      env:
+        - OPENCL_LIB=amdappsdk
+        - OPENCL_VERSION="12"
+        - AMDAPPSDK_VERSION=291 # OpenCL 1.2
+        - BOOST_VERSION="1_61_0" # Boost 1.61
+        - BOOST_URL="http://sourceforge.net/projects/boost/files/boost/1.61.0/boost_1_61_0.tar.gz"
+        - ENV_CMAKE_OPTIONS="-DOpenCL_INCLUDE_DIR=${OPENCL_ROOT}/include"
+
     ############################################################################
     # OSX
     ############################################################################
@@ -324,12 +363,30 @@ before_install:
     - export CXX_FLAGS=${CXX_FLAGS}" "${ENV_CXX_FLAGS}
 
 install:
-    # Install recent cmake
+    # Download and install recent cmake
     - |
       if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
         CMAKE_URL="http://www.cmake.org/files/v3.4/cmake-3.4.3-Linux-x86_64.tar.gz"
-        mkdir -p ${DEPS_DIR}/cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/cmake
+        mkdir -p ${DEPS_DIR}/cmake
+        travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/cmake
         export PATH=${DEPS_DIR}/cmake/bin:${PATH}
+      fi
+
+    # Download and install Boost
+    - |
+      if [[ "${TRAVIS_OS_NAME}" == "linux" && "${BOOST_VERSION}" != "default" ]]; then
+        # create dirs for source and install
+        mkdir -p ${DEPS_DIR}/boost${BOOST_VERSION}
+        mkdir -p ${DEPS_DIR}/boost
+        # download
+        travis_retry wget --no-check-certificate --quiet -O - ${BOOST_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/boost${BOOST_VERSION}
+        pushd ${DEPS_DIR}/boost${BOOST_VERSION}
+        # configure and install
+        echo "using gcc : 4.8 : g++-4.8 ;" > $HOME/user-config.jam
+        ./bootstrap.sh --prefix=${DEPS_DIR}/boost/ --with-libraries=program_options,filesystem,system,thread,test,timer,chrono
+        ./b2 -d0 install
+        popd
+        export CMAKE_OPTIONS=${CMAKE_OPTIONS}" -DBOOST_ROOT=${DEPS_DIR}/boost"
       fi
 
     ############################################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -296,6 +296,10 @@ matrix:
     - os: linux
       sudo: false
       compiler: clang
+      cache:
+        ccache: true
+        directories:
+          - ${DEPS_DIR}/boost
       addons:
        apt:
          packages: &precise_latest_boost_packages
@@ -316,6 +320,10 @@ matrix:
     - os: linux
       sudo: false
       compiler: gcc
+      cache:
+        ccache: true
+        directories:
+          - ${DEPS_DIR}/boost
       addons:
         apt:
           packages: *precise_latest_boost_packages
@@ -365,7 +373,7 @@ before_install:
 install:
     # Download and install recent cmake
     - |
-      if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
         CMAKE_URL="http://www.cmake.org/files/v3.4/cmake-3.4.3-Linux-x86_64.tar.gz"
         mkdir -p ${DEPS_DIR}/cmake
         travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/cmake
@@ -374,18 +382,24 @@ install:
 
     # Download and install Boost
     - |
-      if [[ "${TRAVIS_OS_NAME}" == "linux" && "${BOOST_VERSION}" != "default" ]]; then
-        # create dirs for source and install
-        mkdir -p ${DEPS_DIR}/boost${BOOST_VERSION}
-        mkdir -p ${DEPS_DIR}/boost
-        # download
-        travis_retry wget --no-check-certificate --quiet -O - ${BOOST_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/boost${BOOST_VERSION}
-        pushd ${DEPS_DIR}/boost${BOOST_VERSION}
-        # configure and install
-        echo "using gcc : 4.8 : g++-4.8 ;" > $HOME/user-config.jam
-        ./bootstrap.sh --prefix=${DEPS_DIR}/boost/ --with-libraries=program_options,filesystem,system,thread,test,timer,chrono
-        ./b2 -d0 install
-        popd
+      if [[ ${TRAVIS_OS_NAME} == "linux" && ${BOOST_VERSION} != "default" ]]; then
+        if [ ! -f "${DEPS_DIR}/boost/${BOOST_VERSION}_cached" ]; then
+          # create dirs for source and install
+          mkdir -p ${DEPS_DIR}/boost${BOOST_VERSION}
+          mkdir -p ${DEPS_DIR}/boost
+          rm -rf ${DEPS_DIR}/boost/*
+          # download
+          travis_retry wget --no-check-certificate --quiet -O - ${BOOST_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/boost${BOOST_VERSION}
+          pushd ${DEPS_DIR}/boost${BOOST_VERSION}
+          # configure and install
+          echo "using gcc : 4.8 : g++-4.8 ;" > $HOME/user-config.jam
+          ./bootstrap.sh --prefix=${DEPS_DIR}/boost/ --with-libraries=program_options,filesystem,system,thread,test,timer,chrono
+          ./b2 -d0 install
+          popd
+          touch ${DEPS_DIR}/boost/${BOOST_VERSION}_cached
+        else
+          echo 'Using cached Boost ${BOOST_VERSION} libraries.'
+        fi
         export CMAKE_OPTIONS=${CMAKE_OPTIONS}" -DBOOST_ROOT=${DEPS_DIR}/boost"
       fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -212,7 +212,6 @@ matrix:
            - libopencv-dev
          sources: &precise_amdappsdk_sources
            - ubuntu-toolchain-r-test
-           - llvm-toolchain-precise-3.7
            - boost-latest
       env:
         - OPENCL_LIB=amdappsdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -300,14 +300,6 @@ matrix:
         - ENV_CXX_FLAGS="-Wno-c99-extensions"
 
 before_install:
-    # Install recent cmake
-    - |
-      if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-        CMAKE_URL="http://www.cmake.org/files/v3.4/cmake-3.4.3-Linux-x86_64.tar.gz"
-        mkdir -p ${DEPS_DIR}/cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/cmake
-        export PATH=${DEPS_DIR}/cmake/bin:${PATH}
-      fi
-
     # Install dependencies
     - |
       # POCL dependencies for Trusty
@@ -332,6 +324,14 @@ before_install:
     - export CXX_FLAGS=${CXX_FLAGS}" "${ENV_CXX_FLAGS}
 
 install:
+    # Install recent cmake
+    - |
+      if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+        CMAKE_URL="http://www.cmake.org/files/v3.4/cmake-3.4.3-Linux-x86_64.tar.gz"
+        mkdir -p ${DEPS_DIR}/cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/cmake
+        export PATH=${DEPS_DIR}/cmake/bin:${PATH}
+      fi
+
     ############################################################################
     # Download OpenCL headers (and cl.hpp)
     ############################################################################


### PR DESCRIPTION
Two additional Travis-CI builds (gcc and clang) to be sure that Boost.Compute works with libraries from the latest Boost version. Spoiler: it works.

POCL builds may not work now. It has nothing to do with this pull-request, it's just because llvm [turned off their APT mirror](http://lists.llvm.org/pipermail/llvm-foundation/2016-May/000020.html) and gpg key can't be download.