### PR TITLE
Transform for multicore CPUs

### DIFF
--- a/include/boost/compute/algorithm/detail/copy_on_device.hpp
+++ b/include/boost/compute/algorithm/detail/copy_on_device.hpp
@@ -28,66 +28,85 @@ namespace compute {
 namespace detail {
 
 template<class InputIterator, class OutputIterator>
-class copy_kernel : public meta_kernel
+inline event copy_on_device_cpu(InputIterator first,
+                                OutputIterator result,
+                                size_t count,
+                                command_queue &queue)
 {
-public:
-    copy_kernel(const device &device)
-        : meta_kernel("copy")
-    {
-        m_count = 0;
+    meta_kernel k("copy");
+    const device& device = queue.get_device();
 
-        typedef typename std::iterator_traits<InputIterator>::value_type input_type;
+    k <<
+        "uint block = " <<
+            "(uint)ceil(((float)count)/get_global_size(0));\n" <<
+        "uint start = get_global_id(0) * block;\n" <<
+        "uint end = min(count, start + block);\n" <<
+        "for(uint i = start; i < end; i++){\n" <<
+            result[k.var<uint_>("i")] << '=' <<
+                first[k.var<uint_>("i")] << ";\n" <<
+        "}\n";
 
-        boost::shared_ptr<parameter_cache> parameters =
-            detail::parameter_cache::get_global_cache(device);
+    k.add_set_arg<const uint_>("count", count);
 
-        std::string cache_key =
-            "__boost_copy_kernel_" + boost::lexical_cast<std::string>(sizeof(input_type));
+    size_t global_work_size =
+        device.compute_units();
+    if(count <= 1024) global_work_size = 1;
+    return k.exec_1d(queue, 0, global_work_size);
+}
 
-        m_vpt = parameters->get(cache_key, "vpt", 4);
-        m_tpb = parameters->get(cache_key, "tpb", 128);
+template<class InputIterator, class OutputIterator>
+inline event copy_on_device_gpu(InputIterator first,
+                                OutputIterator result,
+                                size_t count,
+                                command_queue &queue)
+{
+    typedef typename std::iterator_traits<InputIterator>::value_type input_type;
+
+    const device& device = queue.get_device();
+    boost::shared_ptr<parameter_cache> parameters =
+        detail::parameter_cache::get_global_cache(device);
+    std::string cache_key =
+        "__boost_copy_kernel_" + boost::lexical_cast<std::string>(sizeof(input_type));
+
+    uint_ vpt = parameters->get(cache_key, "vpt", 4);
+    uint_ tpb = parameters->get(cache_key, "tpb", 128);
+
+    meta_kernel k("copy");
+    k <<
+        "uint index = get_local_id(0) + " <<
+            "(" << vpt * tpb << " * get_group_id(0));\n" <<
+        "for(uint i = 0; i < " << vpt << "; i++){\n" <<
+        "    if(index < count){\n" <<
+                result[k.var<uint_>("index")] << '=' <<
+                    first[k.var<uint_>("index")] << ";\n" <<
+        "       index += " << tpb << ";\n"
+        "    }\n"
+        "}\n";
+
+    k.add_set_arg<const uint_>("count", count);
+    size_t global_work_size = calculate_work_size(count, vpt, tpb);
+    return k.exec_1d(queue, 0, global_work_size, tpb);
+}
+
+template<class InputIterator, class OutputIterator>
+inline event dispatch_copy_on_device(InputIterator first,
+                                     InputIterator last,
+                                     OutputIterator result,
+                                     command_queue &queue)
+{
+    const size_t count = detail::iterator_range_size(first, last);
+
+    if(count == 0){
+        // nothing to do
+        return event();
     }
 
-    void set_range(InputIterator first,
-                   InputIterator last,
-                   OutputIterator result)
-    {
-        m_count_arg = add_arg<uint_>("count");
-
-        *this <<
-            "uint index = get_local_id(0) + " <<
-               "(" << m_vpt * m_tpb << " * get_group_id(0));\n" <<
-            "for(uint i = 0; i < " << m_vpt << "; i++){\n" <<
-            "    if(index < count){\n" <<
-                     result[expr<uint_>("index")] << '=' <<
-                         first[expr<uint_>("index")] << ";\n" <<
-            "        index += " << m_tpb << ";\n"
-            "    }\n"
-            "}\n";
-
-        m_count = detail::iterator_range_size(first, last);
+    const device& device = queue.get_device();
+    if(device.type() & device::cpu) {
+        return copy_on_device_cpu(first, result, count, queue);
     }
-
-    event exec(command_queue &queue)
-    {
-        if(m_count == 0){
-            // nothing to do
-            return event();
-        }
-
-        size_t global_work_size = calculate_work_size(m_count, m_vpt, m_tpb);
-
-        set_arg(m_count_arg, uint_(m_count));
-
-        return exec_1d(queue, 0, global_work_size, m_tpb);
-    }
-
-private:
-    size_t m_count;
-    size_t m_count_arg;
-    uint_ m_vpt;
-    uint_ m_tpb;
-};
+    return copy_on_device_gpu(first, result, count, queue);
+}
 
 template<class InputIterator, class OutputIterator>
 inline OutputIterator copy_on_device(InputIterator first,
@@ -95,13 +114,7 @@ inline OutputIterator copy_on_device(InputIterator first,
                                      OutputIterator result,
                                      command_queue &queue)
 {
-    const device &device = queue.get_device();
-
-    copy_kernel<InputIterator, OutputIterator> kernel(device);
-
-    kernel.set_range(first, last, result);
-    kernel.exec(queue);
-
+    dispatch_copy_on_device(first, last, result, queue);
     return result + std::distance(first, last);
 }
 
@@ -122,13 +135,7 @@ inline future<OutputIterator> copy_on_device_async(InputIterator first,
                                                    OutputIterator result,
                                                    command_queue &queue)
 {
-    const device &device = queue.get_device();
-
-    copy_kernel<InputIterator, OutputIterator> kernel(device);
-
-    kernel.set_range(first, last, result);
-    event event_ = kernel.exec(queue);
-
+    event event_ = dispatch_copy_on_device(first, last, result, queue);
     return make_future(result + std::distance(first, last), event_);
 }
 

--- a/include/boost/compute/algorithm/detail/copy_on_device.hpp
+++ b/include/boost/compute/algorithm/detail/copy_on_device.hpp
@@ -27,18 +27,6 @@ namespace boost {
 namespace compute {
 namespace detail {
 
-inline size_t pick_copy_work_group_size(size_t n, const device &device)
-{
-    (void) device;
-
-    if(n % 32 == 0) return 32;
-    else if(n % 16 == 0) return 16;
-    else if(n % 8 == 0) return 8;
-    else if(n % 4 == 0) return 4;
-    else if(n % 2 == 0) return 2;
-    else return 1;
-}
-
 template<class InputIterator, class OutputIterator>
 class copy_kernel : public meta_kernel
 {


### PR DESCRIPTION
This improves `transform()` (`copy_on_device()`) performance for multicore CPUs.

```
=== saxpy with stl ===
size,time (ms)
2,0.000160
4,0.000173
8,0.000200
16,0.000214
32,0.000225
64,0.000260
128,0.000944
256,0.001346
512,0.002352
1024,0.004416
2048,0.008575
4096,0.012101
8192,0.023922
16384,0.048170
524288,0.962686
1048576,1.929100
2097152,3.858070
4194304,7.719810
8388608,15.428000
16777216,30.873400
33554432,61.704100

[master]

=== saxpy with compute (CPU, Intel i5-6600K, 4/4 cores/threads) ===
size,time (ms)
2,0.024186
4,0.024106
8,0.024319
16,0.023895
32,0.024225
64,0.024235
128,0.024309
256,0.027449
512,0.027538
1024,0.028694
2048,0.029796
4096,0.031381
8192,0.028765
16384,0.039954
32768,0.045763
65536,0.063319
131072,0.087354
262144,0.130503
524288,0.292780
1048576,0.643207
2097152,1.271910
4194304,2.321300
8388608,4.728590
16777216,9.394120
33554432,18.629600

[pr_transform_cpu]

=== saxpy with compute (CPU, Intel i5-6600K, 4/4 cores/threads) ===
size,time (ms)
2,0.029375
4,0.028846
8,0.029399
16,0.028959
32,0.029304
64,0.029015
128,0.028879
256,0.029418
512,0.029383
1024,0.029599
2048,0.029605
4096,0.029974
8192,0.030838
16384,0.032885
32768,0.036190
65536,0.044674
131072,0.053115
262144,0.073374
524288,0.222535
1048576,0.468357
2097152,1.182020
4194304,2.110340
8388608,4.113700
16777216,8.209680
33554432,16.529000 

No difference in GPU performance.
```