### PR TITLE
Reduce for CPU

### DIFF
--- a/include/boost/compute/algorithm/adjacent_difference.hpp
+++ b/include/boost/compute/algorithm/adjacent_difference.hpp
@@ -33,12 +33,7 @@ dispatch_adjacent_difference(InputIterator first,
                              BinaryFunction op,
                              command_queue &queue = system::default_queue())
 {
-    if(first == last){
-        return result;
-    }
-
     size_t count = detail::iterator_range_size(first, last);
-
     detail::meta_kernel k("adjacent_difference");
 
     k << "const uint i = get_global_id(0);\n"

--- a/include/boost/compute/algorithm/detail/merge_sort_on_gpu.hpp
+++ b/include/boost/compute/algorithm/detail/merge_sort_on_gpu.hpp
@@ -96,7 +96,7 @@ inline size_t bitonic_block_sort(KeyIterator keys_first,
     size_t count_arg = k.add_arg<const uint_>("count");
 
     size_t local_keys_arg = k.add_arg<key_type *>(memory_object::local_memory, "lkeys");
-    size_t local_vals_arg;
+    size_t local_vals_arg = 0;
     if(sort_by_key) {
         local_vals_arg = k.add_arg<uchar_ *>(memory_object::local_memory, "lidx");
     }

--- a/include/boost/compute/algorithm/detail/reduce_on_cpu.hpp
+++ b/include/boost/compute/algorithm/detail/reduce_on_cpu.hpp
@@ -1,0 +1,94 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2015 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#ifndef BOOST_COMPUTE_ALGORITHM_DETAIL_SERIAL_REDUCE_HPP
+#define BOOST_COMPUTE_ALGORITHM_DETAIL_SERIAL_REDUCE_HPP
+
+#include <boost/compute/buffer.hpp>
+#include <boost/compute/command_queue.hpp>
+#include <boost/compute/detail/meta_kernel.hpp>
+#include <boost/compute/detail/iterator_range_size.hpp>
+#include <boost/compute/iterator/buffer_iterator.hpp>
+#include <boost/compute/type_traits/result_of.hpp>
+
+namespace boost {
+namespace compute {
+namespace detail {
+
+template<class InputIterator, class OutputIterator, class BinaryFunction>
+inline void reduce_on_cpu(InputIterator first,
+                          InputIterator last,
+                          OutputIterator result,
+                          BinaryFunction function,
+                          command_queue &queue)
+{
+    typedef typename
+        std::iterator_traits<InputIterator>::value_type T;
+    typedef typename
+        ::boost::compute::result_of<BinaryFunction(T, T)>::type result_type;
+
+    const context &context = queue.get_context();
+    size_t count = detail::iterator_range_size(first, last);
+    if(count == 0){
+        return;
+    }
+
+    meta_kernel k("reduce_on_cpu");
+    const size_t compute_units = queue.get_device().compute_units();
+    buffer output(context, sizeof(result_type) * compute_units);
+
+    size_t count_arg = k.add_arg<uint_>("count");
+    size_t output_arg =
+        k.add_arg<result_type *>(memory_object::global_memory, "output");
+
+    k <<
+        "uint block = " <<
+            "(uint)ceil(((float)count)/get_global_size(0));\n" <<
+        "uint index = get_global_id(0) * block;\n" <<
+        "uint end = min(count, index + block);\n" <<
+
+        k.decl<result_type>("result") << " = " << first[k.var<uint_>("index")] << ";\n" <<
+        "index++;\n" <<
+        "while(index < end){\n" <<
+             "result = " << function(k.var<T>("result"),
+                                     first[k.var<uint_>("index")]) << ";\n" <<
+             "index++;\n" <<
+        "}\n" <<
+        "output[get_global_id(0)] = result;\n";
+
+    size_t global_work_size = compute_units;
+    if(count <= 1024) global_work_size = 1;
+    kernel kernel = k.compile(context);
+
+    if(global_work_size == 1) {
+        kernel.set_arg(count_arg, static_cast<uint_>(count));
+        kernel.set_arg(output_arg, result.get_buffer());
+        queue.enqueue_1d_range_kernel(kernel, 0, global_work_size, 0);
+        return;
+    }
+
+    kernel.set_arg(count_arg, static_cast<uint_>(count));
+    kernel.set_arg(output_arg, output);
+    queue.enqueue_1d_range_kernel(kernel, 0, global_work_size, 0);
+
+    reduce_on_cpu(
+        make_buffer_iterator<result_type>(output),
+        make_buffer_iterator<result_type>(output, global_work_size),
+        result,
+        function,
+        queue
+    );
+}
+
+} // end detail namespace
+} // end compute namespace
+} // end boost namespace
+
+#endif // BOOST_COMPUTE_ALGORITHM_DETAIL_SERIAL_REDUCE_HPP

--- a/test/test_adjacent_difference.cpp
+++ b/test/test_adjacent_difference.cpp
@@ -28,37 +28,67 @@ namespace compute = boost::compute;
 
 BOOST_AUTO_TEST_CASE(adjacent_difference_int)
 {
-    compute::vector<int> a(5, context);
-    compute::iota(a.begin(), a.end(), 0, queue);
-    CHECK_RANGE_EQUAL(int, 5, a, (0, 1, 2, 3, 4));
+    using compute::int_;
 
-    compute::vector<int> b(5, context);
-    compute::vector<int>::iterator iter =
+    compute::vector<int_> a(5, context);
+    compute::iota(a.begin(), a.end(), 0, queue);
+    CHECK_RANGE_EQUAL(int_, 5, a, (0, 1, 2, 3, 4));
+
+    compute::vector<int_> b(5, context);
+    compute::vector<int_>::iterator iter =
         compute::adjacent_difference(a.begin(), a.end(), b.begin(), queue);
     BOOST_CHECK(iter == b.end());
-    CHECK_RANGE_EQUAL(int, 5, b, (0, 1, 1, 1, 1));
+    CHECK_RANGE_EQUAL(int_, 5, b, (0, 1, 1, 1, 1));
 
-    int data[] = { 1, 9, 36, 48, 81 };
+    int_ data[] = { 1, 9, 36, 48, 81 };
     compute::copy(data, data + 5, a.begin(), queue);
-    CHECK_RANGE_EQUAL(int, 5, a, (1, 9, 36, 48, 81));
+    CHECK_RANGE_EQUAL(int_, 5, a, (1, 9, 36, 48, 81));
 
     iter = compute::adjacent_difference(a.begin(), a.end(), b.begin(), queue);
     BOOST_CHECK(iter == b.end());
-    CHECK_RANGE_EQUAL(int, 5, b, (1, 8, 27, 12, 33));
+    CHECK_RANGE_EQUAL(int_, 5, b, (1, 8, 27, 12, 33));
+}
+
+BOOST_AUTO_TEST_CASE(adjacent_difference_first_eq_last)
+{
+    using compute::int_;
+
+    compute::vector<int_> a(size_t(5), int_(1), queue);
+    compute::vector<int_> b(size_t(5), int_(0), queue);
+    compute::vector<int_>::iterator iter =
+        compute::adjacent_difference(a.begin(), a.begin(), b.begin(), queue);
+    BOOST_CHECK(iter == b.begin());
+    CHECK_RANGE_EQUAL(int_, 5, b, (0, 0, 0, 0, 0));
+}
+
+BOOST_AUTO_TEST_CASE(adjacent_difference_first_eq_result)
+{
+    using compute::int_;
+
+    compute::vector<int_> a(5, context);
+    compute::iota(a.begin(), a.end(), 0, queue);
+    CHECK_RANGE_EQUAL(int_, 5, a, (0, 1, 2, 3, 4));
+
+    compute::vector<int_>::iterator iter =
+        compute::adjacent_difference(a.begin(), a.end(), a.begin(), queue);
+    BOOST_CHECK(iter == a.end());
+    CHECK_RANGE_EQUAL(int_, 5, a, (0, 1, 1, 1, 1));
 }
 
 BOOST_AUTO_TEST_CASE(all_same)
 {
-    compute::vector<int> input(1000, context);
+    using compute::int_;
+
+    compute::vector<int_> input(1000, context);
     compute::fill(input.begin(), input.end(), 42, queue);
 
-    compute::vector<int> output(input.size(), context);
+    compute::vector<int_> output(input.size(), context);
 
     compute::adjacent_difference(
         input.begin(), input.end(), output.begin(), queue
     );
 
-    int first;
+    int_ first;
     compute::copy_n(output.begin(), 1, &first, queue);
     BOOST_CHECK_EQUAL(first, 42);
 


### PR DESCRIPTION
```
Device: Intel(R) Core(TM) i5-6600K CPU @ 3.50GHz (4/4 cores/threads)

=== accumulate with stl ===
size,time (ms)
2,0.000133
4,0.000133
8,0.000133
16,0.000135
32,0.000136
64,0.000139
128,0.000151
256,0.000165
512,0.000189
1024,0.000238
2048,0.000463
4096,0.000758
8192,0.001401
16384,0.002684
32768,0.005183
65536,0.009545
131072,0.018869
262144,0.033239
524288,0.059656
1048576,0.119746
2097152,0.295889
4194304,0.606165
8388608,1.219240
16777216,2.450350
33554432,4.898130

[master]

=== accumulate with compute ===
size,time (ms)
2,0.022182
4,0.021758
8,0.021698
16,0.021807
32,0.024980
64,0.021770
128,0.025144
256,0.025538
512,0.025886
1024,0.026272
2048,0.026631
4096,0.024762
8192,0.030600
16384,0.034140
32768,0.043930
65536,0.063510
131072,0.102598
262144,0.181727
524288,0.377996
1048576,0.655540
2097152,1.303180
4194304,2.582180
8388608,5.143530
16777216,10.262900
33554432,20.502700

[pr_reduce_on_cpu]

=== accumulate with compute ===
size,time (ms)
2,0.022874
4,0.022268
8,0.022637
16,0.022521
32,0.022562
64,0.023775
128,0.025854
256,0.025927
512,0.026442
1024,0.023142
2048,0.026977
4096,0.028208
8192,0.031033
16384,0.034424
32768,0.043838
65536,0.053461
131072,0.055120
262144,0.080476
524288,0.092360
1048576,0.131765
2097152,0.228212
4194304,0.421832
8388608,0.832666
16777216,1.697780
33554432,3.461450
```

You can see that STL is very fast with the reduction (5x faster compare to our `serial_reduce` used currently in `master` for reduction on CPUs). I assume it uses SSE/AVX. When reducing vector of `int4_`s instead of vector of `int_`s, the performance of `serial_reduce` becomes almost identical to the performance of STL (for big inputs).

New implementation is faster compared to STL for inputs bigger than 2097152 (for reduction with `plus<int>` function).