### PR TITLE
Various fixes

### DIFF
--- a/include/boost/compute/container/vector.hpp
+++ b/include/boost/compute/container/vector.hpp
@@ -253,6 +253,17 @@ public:
     }
 
     template<class OtherAlloc>
+    vector& operator=(const vector<T, OtherAlloc> &other)
+    {
+        command_queue queue = default_queue();
+        resize(other.size(), queue);
+        ::boost::compute::copy(other.begin(), other.end(), begin(), queue);
+        queue.finish();
+
+        return *this;
+    }
+
+    template<class OtherAlloc>
     vector& operator=(const std::vector<T, OtherAlloc> &vector)
     {
         command_queue queue = default_queue();

--- a/include/boost/compute/container/vector.hpp
+++ b/include/boost/compute/container/vector.hpp
@@ -196,8 +196,15 @@ public:
         m_data = m_allocator.allocate((std::max)(m_size, _minimum_capacity()));
 
         if(!other.empty()){
-            ::boost::compute::copy(other.begin(), other.end(), begin(), queue);
-            queue.finish();
+            if(other.get_buffer().get_context() != queue.get_context()){
+                command_queue other_queue = other.default_queue();
+                ::boost::compute::copy(other.begin(), other.end(), begin(), other_queue);
+                other_queue.finish();
+            }
+            else {
+                ::boost::compute::copy(other.begin(), other.end(), begin(), queue);
+                queue.finish();
+            }
         }
     }
 

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(size)
 
 BOOST_AUTO_TEST_CASE(at)
 {
-    boost::compute::array<int, 3> array;
+    boost::compute::array<int, 3> array(context);
     array[0] = 3;
     array[1] = -2;
     array[2] = 5;

--- a/test/test_for_each.cpp
+++ b/test/test_for_each.cpp
@@ -24,7 +24,7 @@ namespace bc = boost::compute;
 BOOST_AUTO_TEST_CASE(for_each_nop)
 {
     bc::vector<int> vector(4, context);
-    bc::iota(vector.begin(), vector.end(), 0);
+    bc::iota(vector.begin(), vector.end(), 0, queue);
 
     BOOST_COMPUTE_FUNCTION(void, nop, (int ignored), {});
 
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(for_each_nop)
 BOOST_AUTO_TEST_CASE(for_each_n_nop)
 {
     bc::vector<int> vector(4, context);
-    bc::iota(vector.begin(), vector.end(), 0);
+    bc::iota(vector.begin(), vector.end(), 0, queue);
 
     BOOST_COMPUTE_FUNCTION(void, nop, (int ignored), {});
 

--- a/test/test_malloc.cpp
+++ b/test/test_malloc.cpp
@@ -23,10 +23,10 @@ BOOST_AUTO_TEST_CASE(malloc_int)
     bc::experimental::device_ptr<int> ptr = bc::experimental::malloc<int>(5, context);
 
     int input_data[] = { 2, 5, 8, 3, 6 };
-    bc::copy(input_data, input_data + 5, ptr);
+    bc::copy(input_data, input_data + 5, ptr, queue);
 
     int output_data[5];
-    bc::copy(ptr, ptr + 5, output_data);
+    bc::copy(ptr, ptr + 5, output_data, queue);
 
     BOOST_CHECK_EQUAL(output_data[0], 2);
     BOOST_CHECK_EQUAL(output_data[1], 5);

--- a/test/test_reduce.cpp
+++ b/test/test_reduce.cpp
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(reduce_complex)
 
 BOOST_AUTO_TEST_CASE(reduce_uchar_to_float)
 {
-    compute::vector<compute::uchar_> data;
+    compute::vector<compute::uchar_> data(context);
     data.push_back(250, queue);
     data.push_back(250, queue);
     float sum = 0;

--- a/test/test_rotate.cpp
+++ b/test/test_rotate.cpp
@@ -26,10 +26,10 @@ BOOST_AUTO_TEST_CASE(rotate_trivial)
 
     boost::compute::copy_n(data, 10, vector.begin(), queue);
 
-    boost::compute::rotate(vector.begin(), vector.begin(), vector.end());
+    boost::compute::rotate(vector.begin(), vector.begin(), vector.end(), queue);
     CHECK_RANGE_EQUAL(int, 10, vector, (1, 4, 2, 6, 3, 2, 5, 3, 4, 6));
 
-    boost::compute::rotate(vector.begin(), vector.end(), vector.end());
+    boost::compute::rotate(vector.begin(), vector.end(), vector.end(), queue);
     CHECK_RANGE_EQUAL(int, 10, vector, (1, 4, 2, 6, 3, 2, 5, 3, 4, 6));
 }
 
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(rotate_1)
 
     boost::compute::copy_n(data, 10, vector.begin(), queue);
 
-    boost::compute::rotate(vector.begin(), vector.begin()+1, vector.end());
+    boost::compute::rotate(vector.begin(), vector.begin()+1, vector.end(), queue);
     CHECK_RANGE_EQUAL(int, 10, vector, (4, 2, 6, 3, 2, 5, 3, 4, 6, 1));
 }
 
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(rotate_4)
 
     boost::compute::copy_n(data, 10, vector.begin(), queue);
 
-    boost::compute::rotate(vector.begin(), vector.begin()+4, vector.end());
+    boost::compute::rotate(vector.begin(), vector.begin()+4, vector.end(), queue);
     CHECK_RANGE_EQUAL(int, 10, vector, (3, 2, 5, 3, 4, 6, 1, 4, 2, 6));
 }
 
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(rotate_9)
 
     boost::compute::copy_n(data, 10, vector.begin(), queue);
 
-    boost::compute::rotate(vector.begin(), vector.begin()+9, vector.end());
+    boost::compute::rotate(vector.begin(), vector.begin()+9, vector.end(), queue);
     CHECK_RANGE_EQUAL(int, 10, vector, (6, 1, 4, 2, 6, 3, 2, 5, 3, 4));
 }
 

--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(inclusive_scan_transform_iterator)
 
     // normal inclusive scan of the input
     bc::inclusive_scan(input.begin(), input.end(), output.begin(), queue);
-    bc::system::finish();
+    queue.finish();
     BOOST_CHECK_CLOSE(float(output[0]), 1.0f, 1e-4f);
     BOOST_CHECK_CLOSE(float(output[1]), 3.0f, 1e-4f);
     BOOST_CHECK_CLOSE(float(output[2]), 6.0f, 1e-4f);
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(inclusive_scan_transform_iterator)
     bc::inclusive_scan(bc::make_transform_iterator(input.begin(), pown(_1, 2)),
                        bc::make_transform_iterator(input.end(), pown(_1, 2)),
                        output.begin(), queue);
-    bc::system::finish();
+    queue.finish();
     BOOST_CHECK_CLOSE(float(output[0]), 1.0f, 1e-4f);
     BOOST_CHECK_CLOSE(float(output[1]), 5.0f, 1e-4f);
     BOOST_CHECK_CLOSE(float(output[2]), 14.0f, 1e-4f);

--- a/test/test_scatter.cpp
+++ b/test/test_scatter.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(scatter_int)
     bc::vector<int> map(map_data, map_data + 5, queue);
 
     bc::vector<int> output(5, context);
-    bc::scatter(input.begin(), input.end(), map.begin(), output.begin());
+    bc::scatter(input.begin(), input.end(), map.begin(), output.begin(), queue);
     CHECK_RANGE_EQUAL(int, 5, output, (1, 3, 5, 4, 2));
 }
 

--- a/test/test_scatter_if.cpp
+++ b/test/test_scatter_if.cpp
@@ -39,7 +39,8 @@ BOOST_AUTO_TEST_CASE(scatter_if_int)
 
     bc::scatter_if(input.begin(), input.end(),
                    map.begin(), stencil.begin(),
-                   output.begin());
+                   output.begin(),
+                   queue);
 
     CHECK_RANGE_EQUAL(int, 10, output, (9, -1, 7, -1, 5, -1, 3, -1, 1, -1) );
 }

--- a/test/test_sort.cpp
+++ b/test/test_sort.cpp
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(sort_char_vector)
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
-    boost::compute::sort(vector.begin(), vector.end());
+    boost::compute::sort(vector.begin(), vector.end(), queue);
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(char_, 8, vector, ('\0', '$', '0', '7', 'B', 'F', 'a', 'c'));
 }
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(sort_uchar_vector)
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
-    boost::compute::sort(vector.begin(), vector.end());
+    boost::compute::sort(vector.begin(), vector.end(), queue);
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(uchar_, 8, vector, (0x00, 0x12, 0x32, 0x64, 0x80, 0xA2, 0xB4, 0xFF));
 }
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(sort_short_vector)
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
-    boost::compute::sort(vector.begin(), vector.end());
+    boost::compute::sort(vector.begin(), vector.end(), queue);
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(short_, 8, vector, (-2113, -456, -94, -4, 0, 152, 963, 31002));
 }
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(sort_ushort_vector)
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
-    boost::compute::sort(vector.begin(), vector.end());
+    boost::compute::sort(vector.begin(), vector.end(), queue);
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(ushort_, 8, vector, (0, 4, 94, 152, 963, 2113, 34560, 63202));
 }
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(sort_int_vector)
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
-    boost::compute::sort(vector.begin(), vector.end());
+    boost::compute::sort(vector.begin(), vector.end(), queue);
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(int, 8, vector, (-5000, -456, -4, 0, 152, 963, 1112, 75321));
 }
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(sort_uint_vector)
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
-    boost::compute::sort(vector.begin(), vector.end());
+    boost::compute::sort(vector.begin(), vector.end(), queue);
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(uint_, 8, vector, (0, 500, 562, 1988, 9852, 102030, 123456, 4000000));
 }
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(sort_long_vector)
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
-    boost::compute::sort(vector.begin(), vector.end());
+    boost::compute::sort(vector.begin(), vector.end(), queue);
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(long_, 8, vector, (0, 500, 562, 1988, 9852, 102030, 123456, 4000000));
 }
@@ -181,8 +181,8 @@ BOOST_AUTO_TEST_CASE(sort_ulong_vector)
     BOOST_CHECK_EQUAL(vector.size(), size_t(8));
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
-    boost::compute::sort(vector.begin(), vector.end());
-    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end()) == true);
+    boost::compute::sort(vector.begin(), vector.end(), queue);
+    BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(ulong_, 8, vector, (0, 500, 562, 1988, 9852, 102030, 123456, 4000000));
 }
 
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(sort_float_vector)
     BOOST_CHECK_EQUAL(vector.size(), size_t(10));
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
-    boost::compute::sort(vector.begin(), vector.end());
+    boost::compute::sort(vector.begin(), vector.end(), queue);
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(
         float, 10, vector,
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(sort_double_vector)
     BOOST_CHECK_EQUAL(vector.size(), size_t(10));
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == false);
 
-    boost::compute::sort(vector.begin(), vector.end());
+    boost::compute::sort(vector.begin(), vector.end(), queue);
     BOOST_CHECK(boost::compute::is_sorted(vector.begin(), vector.end(), queue) == true);
     CHECK_RANGE_EQUAL(
         double, 10, vector,

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -28,11 +28,19 @@ BOOST_AUTO_TEST_CASE(empty)
 
 BOOST_AUTO_TEST_CASE(swap)
 {
+    // boost::compute::string currently uses only default_queue, default_context,
+    // default_device so this overrides queue variable set in
+    // BOOST_FIXTURE_TEST_SUITE(compute_test, Context) in context_setup.hpp
+    // in case it is not the default_queue
+    boost::compute::command_queue& queue =
+        boost::compute::system::default_queue();
+
     boost::compute::string str1 = "compute";
     boost::compute::string str2 = "boost";
     BOOST_VERIFY(!str2.empty());
     BOOST_VERIFY(!str2.empty()); 
     str1.swap(str2);
+    // this macro uses queue variable and it must be default_queue
     CHECK_STRING_EQUAL(str1, "boost");
     CHECK_STRING_EQUAL(str2, "compute");
     str1.clear();

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -64,11 +64,11 @@ BOOST_AUTO_TEST_CASE(resize)
 
 BOOST_AUTO_TEST_CASE(array_operator)
 {
-    bc::vector<int> vector(10);
-    bc::fill(vector.begin(), vector.end(), 0);
+    bc::vector<int> vector(10, context);
+    bc::fill(vector.begin(), vector.end(), 0, queue);
     CHECK_RANGE_EQUAL(int, 10, vector, (0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
 
-    bc::fill(vector.begin(), vector.end(), 42);
+    bc::fill(vector.begin(), vector.end(), 42, queue);
     CHECK_RANGE_EQUAL(int, 10, vector, (42, 42, 42, 42, 42, 42, 42, 42, 42, 42));
 
     vector[0] = 9;
@@ -216,9 +216,14 @@ BOOST_AUTO_TEST_CASE(move_ctor_custom_alloc)
 #ifdef BOOST_COMPUTE_USE_CPP11
 BOOST_AUTO_TEST_CASE(initializer_list_ctor)
 {
-    bc::vector<int> vector = { 2, 4, 6, 8 };
+    // ctor with std::initializer_list<T> always uses
+    // default_queue in this case
+    bc::vector<int> vector = { 2, -4, 6, 8 };
     BOOST_CHECK_EQUAL(vector.size(), size_t(4));
-    CHECK_RANGE_EQUAL(int, 4, vector, (2, 4, 6, 8));
+    BOOST_CHECK_EQUAL(vector[0], 2);
+    BOOST_CHECK_EQUAL(vector[1], -4);
+    BOOST_CHECK_EQUAL(vector[2], 6);
+    BOOST_CHECK_EQUAL(vector[3], 8);
 }
 #endif // BOOST_COMPUTE_USE_CPP11
 
@@ -397,11 +402,11 @@ BOOST_AUTO_TEST_CASE(assignment_operator)
     BOOST_CHECK_EQUAL(a.size(), size_t(4));
     CHECK_RANGE_EQUAL(int, 4, a, (11, 12, 13, 14));
 
-    bc::vector<int> b = a;
+    bc::vector<int> b(context); b = a;
     BOOST_CHECK_EQUAL(b.size(), size_t(4));
     CHECK_RANGE_EQUAL(int, 4, b, (11, 12, 13, 14));
 
-    bc::vector<int, bc::pinned_allocator<int> > c = b;
+    bc::vector<int, bc::pinned_allocator<int> > c(context); c = b;
     BOOST_CHECK_EQUAL(c.size(), size_t(4));
     CHECK_RANGE_EQUAL(int, 4, c, (11, 12, 13, 14));
 

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -402,11 +402,12 @@ BOOST_AUTO_TEST_CASE(assignment_operator)
     BOOST_CHECK_EQUAL(a.size(), size_t(4));
     CHECK_RANGE_EQUAL(int, 4, a, (11, 12, 13, 14));
 
-    bc::vector<int> b(context); b = a;
+    bc::vector<int> b = a;
     BOOST_CHECK_EQUAL(b.size(), size_t(4));
     CHECK_RANGE_EQUAL(int, 4, b, (11, 12, 13, 14));
 
-    bc::vector<int, bc::pinned_allocator<int> > c(context); c = b;
+    bc::vector<int, bc::pinned_allocator<int> > c(context);
+    c = b;
     BOOST_CHECK_EQUAL(c.size(), size_t(4));
     CHECK_RANGE_EQUAL(int, 4, c, (11, 12, 13, 14));
 


### PR DESCRIPTION
This fixes 3 things:

* `boost::compute::array<T>` was not working correctly with context different than `system::default_context()` since it was using `default_queue()` in its methods (so wild `Invalid context` errors could appear).
* I added

```cpp
template<class OtherAlloc>
vector& operator=(const vector<T, OtherAlloc> &other)
{
}
```
for `boost::compute::vector<T, A>, so now something like this:

```cpp
vector<int, some_allocator> b(context);
vector<int, different_allocator> a(context);
vector<int, some_allocator> c = a; // this works in `develop`
a = b; // this does not work in `develop`, works now
```

works.

* I changed several tests so in the future we can change `Context::context, Context::queue, Context::device` and tests will run using those context, queue and device, not the default context, queue and device.

In October I will work more on Boost.Compute tests and try to somehow organize them and also increase coverage.