### PR TITLE
find_extrema for CPUs

### DIFF
--- a/include/boost/compute/algorithm/detail/find_extrema.hpp
+++ b/include/boost/compute/algorithm/detail/find_extrema.hpp
@@ -12,6 +12,7 @@
 #define BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_HPP
 
 #include <boost/compute/detail/iterator_range_size.hpp>
+#include <boost/compute/algorithm/detail/find_extrema_on_cpu.hpp>
 #include <boost/compute/algorithm/detail/find_extrema_with_reduce.hpp>
 #include <boost/compute/algorithm/detail/find_extrema_with_atomics.hpp>
 #include <boost/compute/algorithm/detail/serial_find_extrema.hpp>
@@ -36,12 +37,17 @@ inline InputIterator find_extrema(InputIterator first,
 
     const device &device = queue.get_device();
 
-    // use serial method for small inputs
-    // and when device is a CPU
-    if(count < 512 || (device.type() & device::cpu)){
-        return serial_find_extrema(first, last, compare, find_minimum, queue);
+    // CPU
+    if(device.type() & device::cpu) {
+        return find_extrema_on_cpu(first, last, compare, find_minimum, queue);
     }
 
+    // GPU
+    // use serial method for small inputs
+    if(count < 512)
+    {
+        return serial_find_extrema(first, last, compare, find_minimum, queue);
+    }
     // find_extrema_with_reduce() is used only if requirements are met
     if(find_extrema_with_reduce_requirements_met(first, last, queue))
     {

--- a/include/boost/compute/algorithm/detail/find_extrema_on_cpu.hpp
+++ b/include/boost/compute/algorithm/detail/find_extrema_on_cpu.hpp
@@ -1,0 +1,138 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2016 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#ifndef BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_ON_CPU_HPP
+#define BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_ON_CPU_HPP
+
+#include <algorithm>
+
+#include <boost/compute/algorithm/detail/find_extrema_with_reduce.hpp>
+#include <boost/compute/algorithm/detail/find_extrema_with_atomics.hpp>
+#include <boost/compute/algorithm/detail/serial_find_extrema.hpp>
+#include <boost/compute/detail/iterator_range_size.hpp>
+#include <boost/compute/iterator/buffer_iterator.hpp>
+
+namespace boost {
+namespace compute {
+namespace detail {
+
+template<class InputIterator, class Compare>
+inline InputIterator find_extrema_on_cpu(InputIterator first,
+                                         InputIterator last,
+                                         Compare compare,
+                                         const bool find_minimum,
+                                         command_queue &queue)
+{
+    typedef typename std::iterator_traits<InputIterator>::value_type input_type;
+    typedef typename std::iterator_traits<InputIterator>::difference_type difference_type;
+    size_t count = iterator_range_size(first, last);
+
+    const device &device = queue.get_device();
+    const uint_ compute_units = queue.get_device().compute_units();
+
+    boost::shared_ptr<parameter_cache> parameters =
+        detail::parameter_cache::get_global_cache(device);
+    std::string cache_key =
+        "__boost_find_extrema_cpu_"
+            + boost::lexical_cast<std::string>(sizeof(input_type));
+
+    // for inputs smaller than serial_find_extrema_threshold
+    // serial_find_extrema algorithm is used
+    uint_ serial_find_extrema_threshold = parameters->get(
+        cache_key,
+        "serial_find_extrema_threshold",
+        16384 * sizeof(input_type)
+    );
+    serial_find_extrema_threshold =
+        (std::max)(serial_find_extrema_threshold, uint_(2 * compute_units));
+
+    const context &context = queue.get_context();
+    if(count < serial_find_extrema_threshold) {
+        return serial_find_extrema(first, last, compare, find_minimum, queue);
+    }
+
+    meta_kernel k("find_extrema_on_cpu");
+    buffer output(context, sizeof(input_type) * compute_units);
+    buffer output_idx(
+        context, sizeof(uint_) * compute_units,
+        buffer::read_write | buffer::alloc_host_ptr
+    );
+
+    size_t count_arg = k.add_arg<uint_>("count");
+    size_t output_arg =
+        k.add_arg<input_type *>(memory_object::global_memory, "output");
+    size_t output_idx_arg =
+        k.add_arg<uint_ *>(memory_object::global_memory, "output_idx");
+
+    k <<
+        "uint block = " <<
+            "(uint)ceil(((float)count)/get_global_size(0));\n" <<
+        "uint index = get_global_id(0) * block;\n" <<
+        "uint end = min(count, index + block);\n" <<
+
+        "uint value_index = index;\n" <<
+        k.decl<input_type>("value") << " = " << first[k.var<uint_>("index")] << ";\n" <<
+
+        "index++;\n" <<
+        "while(index < end){\n" <<
+            k.decl<input_type>("candidate") <<
+                " = " << first[k.var<uint_>("index")] << ";\n" <<
+        "#ifndef BOOST_COMPUTE_FIND_MAXIMUM\n" <<
+            "bool compare = " << compare(k.var<input_type>("candidate"),
+                                         k.var<input_type>("value")) << ";\n" <<
+        "#else\n" <<
+            "bool compare = " << compare(k.var<input_type>("value"),
+                                         k.var<input_type>("candidate")) << ";\n" <<
+        "#endif\n" <<
+            "value = compare ? candidate : value;\n" <<
+            "value_index = compare ? index : value_index;\n" <<
+            "index++;\n" <<
+        "}\n" <<
+        "output[get_global_id(0)] = value;\n" <<
+        "output_idx[get_global_id(0)] = value_index;\n";
+
+    size_t global_work_size = compute_units;
+    std::string options;
+    if(!find_minimum){
+        options = "-DBOOST_COMPUTE_FIND_MAXIMUM";
+    }
+    kernel kernel = k.compile(context, options);
+
+    kernel.set_arg(count_arg, static_cast<uint_>(count));
+    kernel.set_arg(output_arg, output);
+    kernel.set_arg(output_idx_arg, output_idx);
+    queue.enqueue_1d_range_kernel(kernel, 0, global_work_size, 0);
+    
+    buffer_iterator<input_type> result = serial_find_extrema(
+        make_buffer_iterator<input_type>(output),
+        make_buffer_iterator<input_type>(output, global_work_size),
+        compare,
+        find_minimum,
+        queue
+    );
+
+    uint_* output_idx_host_ptr =
+        static_cast<uint_*>(
+            queue.enqueue_map_buffer(
+                output_idx, command_queue::map_read,
+                0, global_work_size * sizeof(uint_)
+            )
+        );
+
+    difference_type extremum_idx =
+        static_cast<difference_type>(*(output_idx_host_ptr + result.get_index()));
+    return first + extremum_idx;
+}
+
+} // end detail namespace
+} // end compute namespace
+} // end boost namespace
+
+#endif // BOOST_COMPUTE_ALGORITHM_DETAIL_FIND_EXTREMA_ON_CPU_HPP

--- a/include/boost/compute/algorithm/detail/find_extrema_with_reduce.hpp
+++ b/include/boost/compute/algorithm/detail/find_extrema_with_reduce.hpp
@@ -128,7 +128,7 @@ inline void find_extrema_with_reduce(InputIterator input,
             // Next element
             k.decl<input_type>("next") << " = " << input[k.var<uint_>("idx")] << ";\n" <<
             "#ifdef BOOST_COMPUTE_USE_INPUT_IDX\n" <<
-            k.decl<input_type>("next_idx") << " = " << input_idx[k.var<uint_>("idx")] << ";\n" <<
+            k.decl<uint_>("next_idx") << " = " << input_idx[k.var<uint_>("idx")] << ";\n" <<
             "#endif\n" <<
 
             // Comparison between currently best element (acc) and next element

--- a/test/test_extrema.cpp
+++ b/test/test_extrema.cpp
@@ -8,6 +8,13 @@
 // See http://boostorg.github.com/compute for more information.
 //---------------------------------------------------------------------------//
 
+// Undefining BOOST_COMPUTE_USE_OFFLINE_CACHE macro as we want to modify cached
+// parameters for copy algorithm without any undesirable consequences (like
+// saving modified values of those parameters).
+#ifdef BOOST_COMPUTE_USE_OFFLINE_CACHE
+    #undef BOOST_COMPUTE_USE_OFFLINE_CACHE
+#endif
+
 #define BOOST_TEST_MODULE TestExtrema
 #include <boost/test/unit_test.hpp>
 
@@ -21,23 +28,117 @@
 #include <boost/compute/algorithm/minmax_element.hpp>
 #include <boost/compute/container/vector.hpp>
 #include <boost/compute/iterator/transform_iterator.hpp>
+#include <boost/compute/detail/parameter_cache.hpp>
 
+#include "quirks.hpp"
 #include "context_setup.hpp"
+
+namespace bc = boost::compute;
+namespace compute = boost::compute;
+
+BOOST_AUTO_TEST_CASE(empyt_min)
+{
+    using boost::compute::int_;
+
+    boost::compute::vector<int_> vector(size_t(16), int_(0), queue);
+    boost::compute::vector<int_>::iterator min_iter =
+        boost::compute::min_element(vector.begin(), vector.begin(), queue);
+    BOOST_CHECK(min_iter == vector.begin());
+
+    min_iter =
+        boost::compute::min_element(vector.begin(), vector.begin() + 1, queue);
+    BOOST_CHECK(min_iter == vector.begin());
+}
 
 BOOST_AUTO_TEST_CASE(int_min_max)
 {
-    boost::compute::vector<int> vector(size_t(4096), int(0), queue);
+    using boost::compute::int_;
+    using boost::compute::uint_;
+
+    boost::compute::vector<int_> vector(size_t(4096), int_(0), queue);
     boost::compute::iota(vector.begin(), (vector.begin() + 512), 1, queue);
     boost::compute::fill((vector.end() - 512), vector.end(), 513, queue);
 
-    boost::compute::vector<int>::iterator min_iter =
+    boost::compute::vector<int_>::iterator min_iter =
         boost::compute::min_element(vector.begin(), vector.end(), queue);
     BOOST_CHECK(min_iter == vector.begin() + 512);
     BOOST_CHECK_EQUAL((vector.begin() + 512).read(queue), 0);
     BOOST_CHECK_EQUAL(min_iter.read(queue), 0);
 
-    boost::compute::vector<int>::iterator max_iter =
+    boost::compute::vector<int_>::iterator max_iter =
         boost::compute::max_element(vector.begin(), vector.end(), queue);
+    BOOST_CHECK(max_iter == vector.end() - 512);
+    BOOST_CHECK_EQUAL((vector.end() - 512).read(queue), 513);
+    BOOST_CHECK_EQUAL(max_iter.read(queue), 513);
+
+    // compare function
+    boost::compute::less<int_> lestint;
+
+    // find_extrama_on_cpu
+
+    // make sure find_extrama_on_cpu is used, no serial_find_extrema
+    std::string cache_key =
+        "__boost_find_extrema_cpu_4";
+    boost::shared_ptr<bc::detail::parameter_cache> parameters =
+        bc::detail::parameter_cache::get_global_cache(device);
+
+    // save
+    uint_ map_copy_threshold =
+        parameters->get(cache_key, "serial_find_extrema_threshold", 0);
+    // force find_extrama_on_cpu
+    parameters->set(cache_key, "serial_find_extrema_threshold", 16);
+
+    min_iter = boost::compute::detail::find_extrema_on_cpu(
+        vector.begin(), vector.end(), lestint, true /* find minimum */, queue
+    );
+    BOOST_CHECK(min_iter == vector.begin() + 512);
+    BOOST_CHECK_EQUAL((vector.begin() + 512).read(queue), 0);
+    BOOST_CHECK_EQUAL(min_iter.read(queue), 0);
+
+    max_iter = boost::compute::detail::find_extrema_on_cpu(
+        vector.begin(), vector.end(), lestint, false /* find minimum */, queue
+    );
+    BOOST_CHECK(max_iter == vector.end() - 512);
+    BOOST_CHECK_EQUAL((vector.end() - 512).read(queue), 513);
+    BOOST_CHECK_EQUAL(max_iter.read(queue), 513);
+
+    // restore
+    parameters->set(cache_key, "serial_find_extrema_threshold", map_copy_threshold);
+
+    if(is_apple_cpu_device(device)) {
+        std::cerr
+            << "skipping all further tests due to Apple platform"
+            << " behavior when local memory is used on a CPU device"
+            << std::endl;
+        return;
+    }
+
+    // find_extrama_with_reduce
+    min_iter = boost::compute::detail::find_extrema_with_reduce(
+        vector.begin(), vector.end(), lestint, true /* find minimum */, queue
+    );
+    BOOST_CHECK(min_iter == vector.begin() + 512);
+    BOOST_CHECK_EQUAL((vector.begin() + 512).read(queue), 0);
+    BOOST_CHECK_EQUAL(min_iter.read(queue), 0);
+
+    max_iter = boost::compute::detail::find_extrema_with_reduce(
+        vector.begin(), vector.end(), lestint, false /* find minimum */, queue
+    );
+    BOOST_CHECK(max_iter == vector.end() - 512);
+    BOOST_CHECK_EQUAL((vector.end() - 512).read(queue), 513);
+    BOOST_CHECK_EQUAL(max_iter.read(queue), 513);
+
+    // find_extram_with_atomics
+    min_iter = boost::compute::detail::find_extrema_with_atomics(
+        vector.begin(), vector.end(), lestint, true /* find minimum */, queue
+    );
+    BOOST_CHECK(min_iter == vector.begin() + 512);
+    BOOST_CHECK_EQUAL((vector.begin() + 512).read(queue), 0);
+    BOOST_CHECK_EQUAL(min_iter.read(queue), 0);
+
+    max_iter = boost::compute::detail::find_extrema_with_atomics(
+        vector.begin(), vector.end(), lestint, false /* find minimum */, queue
+    );
     BOOST_CHECK(max_iter == vector.end() - 512);
     BOOST_CHECK_EQUAL((vector.end() - 512).read(queue), 513);
     BOOST_CHECK_EQUAL(max_iter.read(queue), 513);
@@ -46,6 +147,7 @@ BOOST_AUTO_TEST_CASE(int_min_max)
 BOOST_AUTO_TEST_CASE(int2_min_max_custom_comparision_function)
 {
     using boost::compute::int2_;
+    using boost::compute::uint_;
 
     boost::compute::vector<int2_> vector(context);
     vector.push_back(int2_(1, 10), queue);
@@ -73,6 +175,69 @@ BOOST_AUTO_TEST_CASE(int2_min_max_custom_comparision_function)
         boost::compute::max_element(
             vector.begin(), vector.end(), compare_second, queue
         );
+    BOOST_CHECK(max_iter == vector.begin() + 2);
+    BOOST_CHECK_EQUAL(*max_iter, int2_(3, 30));
+
+    // find_extrama_on_cpu
+
+    // make sure find_extrama_on_cpu is used, no serial_find_extrema
+    std::string cache_key =
+        "__boost_find_extrema_cpu_8";
+    boost::shared_ptr<bc::detail::parameter_cache> parameters =
+        bc::detail::parameter_cache::get_global_cache(device);
+
+    // save
+    uint_ map_copy_threshold =
+        parameters->get(cache_key, "serial_find_extrema_threshold", 0);
+    // force find_extrama_on_cpu
+    parameters->set(cache_key, "serial_find_extrema_threshold", 16);
+
+    min_iter = boost::compute::detail::find_extrema_on_cpu(
+        vector.begin(), vector.end(), compare_second, true /* find minimum */, queue
+    );
+    BOOST_CHECK(min_iter == vector.begin() + 1);
+    BOOST_CHECK_EQUAL(*min_iter, int2_(2, -100));
+
+    max_iter = boost::compute::detail::find_extrema_on_cpu(
+        vector.begin(), vector.end(), compare_second, false /* find minimum */, queue
+    );
+    BOOST_CHECK(max_iter == vector.begin() + 2);
+    BOOST_CHECK_EQUAL(*max_iter, int2_(3, 30));
+
+    // restore
+    parameters->set(cache_key, "serial_find_extrema_threshold", map_copy_threshold);
+
+    if(is_apple_cpu_device(device)) {
+        std::cerr
+            << "skipping all further tests due to Apple platform"
+            << " behavior when local memory is used on a CPU device"
+            << std::endl;
+        return;
+    }
+
+    // find_extrama_with_reduce
+    min_iter = boost::compute::detail::find_extrema_with_reduce(
+        vector.begin(), vector.end(), compare_second, true /* find minimum */, queue
+    );
+    BOOST_CHECK(min_iter == vector.begin() + 1);
+    BOOST_CHECK_EQUAL(*min_iter, int2_(2, -100));
+
+    max_iter = boost::compute::detail::find_extrema_with_reduce(
+        vector.begin(), vector.end(), compare_second, false /* find minimum */, queue
+    );
+    BOOST_CHECK(max_iter == vector.begin() + 2);
+    BOOST_CHECK_EQUAL(*max_iter, int2_(3, 30));
+
+    // find_extram_with_atomics
+    min_iter = boost::compute::detail::find_extrema_with_atomics(
+        vector.begin(), vector.end(), compare_second, true /* find minimum */, queue
+    );
+    BOOST_CHECK(min_iter == vector.begin() + 1);
+    BOOST_CHECK_EQUAL(*min_iter, int2_(2, -100));
+
+    max_iter = boost::compute::detail::find_extrema_with_atomics(
+        vector.begin(), vector.end(), compare_second, false /* find minimum */, queue
+    );
     BOOST_CHECK(max_iter == vector.begin() + 2);
     BOOST_CHECK_EQUAL(*max_iter, int2_(3, 30));
 }


### PR DESCRIPTION
* Add find_extrema() for multicore CPUs.

```
=== max_element with stl ===
size,time (ms)
2,0.000132
4,0.000133
8,0.000135
16,0.000138
32,0.000148
64,0.000161
128,0.000193
256,0.000258
512,0.000388
1024,0.000653
2048,0.001178
4096,0.002227
8192,0.004331
16384,0.008531
32768,0.016933
65536,0.033753
131072,0.067367
262144,0.134580
524288,0.269013
1048576,0.537921
2097152,1.088980
4194304,2.183200
8388608,4.367510
16777216,8.733790
33554432,17.461000

[master]
=== max_element with compute ===
size,time (ms)
2,0.027686
4,0.026849
8,0.026995
16,0.026756
32,0.027935
64,0.026681
128,0.027340
256,0.027736
512,0.027438
1024,0.027745
2048,0.028904
4096,0.031220
8192,0.034191
16384,0.038634
32768,0.049738
65536,0.069393
131072,0.111162
262144,0.165911
524288,0.364886
1048576,0.699782
2097152,1.385050
4194304,2.748430
8388608,5.471740
16777216,10.906000
33554432,21.787800


[pr_find_extrema_cpu]
=== max_element with compute ===
size,time (ms)
2,0.027209
4,0.027406
8,0.027629
16,0.027116
32,0.027406
64,0.027280
128,0.027115
256,0.028113
512,0.029018
1024,0.027919
2048,0.030889
4096,0.033261
8192,0.034010
16384,0.038657
32768,0.048916
65536,0.067615
131072,0.076154
262144,0.112971
524288,0.126911
1048576,0.194296
2097152,0.337320
4194304,0.619264
8388608,1.177890
16777216,2.303350
33554432,4.548920
=== max_element with stl ===
size,time (ms)
2,0.000132
4,0.000133
8,0.000135
16,0.000138
32,0.000148
64,0.000161
128,0.000193
256,0.000258
512,0.000388
1024,0.000653
2048,0.001178
4096,0.002227
8192,0.004331
16384,0.008531
32768,0.016933
65536,0.033753
131072,0.067367
262144,0.134580
524288,0.269013
1048576,0.537921
2097152,1.088980
4194304,2.183200
8388608,4.367510
16777216,8.733790
33554432,17.461000

[master]
=== max_element with compute ===
size,time (ms)
2,0.027686
4,0.026849
8,0.026995
16,0.026756
32,0.027935
64,0.026681
128,0.027340
256,0.027736
512,0.027438
1024,0.027745
2048,0.028904
4096,0.031220
8192,0.034191
16384,0.038634
32768,0.049738
65536,0.069393
131072,0.111162
262144,0.165911
524288,0.364886
1048576,0.699782
2097152,1.385050
4194304,2.748430
8388608,5.471740
16777216,10.906000
33554432,21.787800


[pr_find_extrema_cpu]
=== max_element with compute ===
size,time (ms)
2,0.027209
4,0.027406
8,0.027629
16,0.027116
32,0.027406
64,0.027280
128,0.027115
256,0.028113
512,0.029018
1024,0.027919
2048,0.030889
4096,0.033261
8192,0.034010
16384,0.038657
32768,0.048916
65536,0.067615
131072,0.076154
262144,0.112971
524288,0.126911
1048576,0.194296
2097152,0.337320
4194304,0.619264
8388608,1.177890
16777216,2.303350
33554432,4.548920
```

* Add more tests. I hope to refactor them later in October.
* Fix bug in find_extrema_with_reduce(). Variable representing index had wrong type.