### PR TITLE
Scan for multicore CPUs

### DIFF
--- a/include/boost/compute/algorithm/detail/scan.hpp
+++ b/include/boost/compute/algorithm/detail/scan.hpp
@@ -12,8 +12,8 @@
 #define BOOST_COMPUTE_ALGORITHM_DETAIL_SCAN_HPP
 
 #include <boost/compute/device.hpp>
+#include <boost/compute/algorithm/detail/scan_on_cpu.hpp>
 #include <boost/compute/algorithm/detail/scan_on_gpu.hpp>
-#include <boost/compute/algorithm/detail/serial_scan.hpp>
 
 namespace boost {
 namespace compute {
@@ -31,7 +31,7 @@ inline OutputIterator scan(InputIterator first,
     const device &device = queue.get_device();
 
     if(device.type() & device::cpu){
-        return serial_scan(first, last, result, exclusive, init, op, queue);
+        return scan_on_cpu(first, last, result, exclusive, init, op, queue);
     }
     else {
         return scan_on_gpu(first, last, result, exclusive, init, op, queue);

--- a/include/boost/compute/algorithm/detail/scan.hpp
+++ b/include/boost/compute/algorithm/detail/scan.hpp
@@ -12,8 +12,8 @@
 #define BOOST_COMPUTE_ALGORITHM_DETAIL_SCAN_HPP
 
 #include <boost/compute/device.hpp>
-#include <boost/compute/algorithm/detail/scan_on_cpu.hpp>
 #include <boost/compute/algorithm/detail/scan_on_gpu.hpp>
+#include <boost/compute/algorithm/detail/serial_scan.hpp>
 
 namespace boost {
 namespace compute {
@@ -31,7 +31,7 @@ inline OutputIterator scan(InputIterator first,
     const device &device = queue.get_device();
 
     if(device.type() & device::cpu){
-        return scan_on_cpu(first, last, result, exclusive, init, op, queue);
+        return serial_scan(first, last, result, exclusive, init, op, queue);
     }
     else {
         return scan_on_gpu(first, last, result, exclusive, init, op, queue);

--- a/include/boost/compute/algorithm/detail/scan_on_cpu.hpp
+++ b/include/boost/compute/algorithm/detail/scan_on_cpu.hpp
@@ -1,0 +1,207 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2016 Jakub Szuppe <j.szuppe@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#ifndef BOOST_COMPUTE_ALGORITHM_DETAIL_SCAN_ON_CPU_HPP
+#define BOOST_COMPUTE_ALGORITHM_DETAIL_SCAN_ON_CPU_HPP
+
+#include <iterator>
+
+#include <boost/compute/device.hpp>
+#include <boost/compute/kernel.hpp>
+#include <boost/compute/command_queue.hpp>
+#include <boost/compute/algorithm/detail/serial_scan.hpp>
+#include <boost/compute/detail/meta_kernel.hpp>
+#include <boost/compute/detail/iterator_range_size.hpp>
+#include <boost/compute/detail/parameter_cache.hpp>
+
+namespace boost {
+namespace compute {
+namespace detail {
+
+template<class InputIterator, class OutputIterator, class T, class BinaryOperator>
+inline OutputIterator scan_on_cpu(InputIterator first,
+                                  InputIterator last,
+                                  OutputIterator result,
+                                  bool exclusive,
+                                  T init,
+                                  BinaryOperator op,
+                                  command_queue &queue)
+{
+    typedef typename
+        std::iterator_traits<InputIterator>::value_type input_type;
+    typedef typename
+        std::iterator_traits<OutputIterator>::value_type output_type;
+
+    const context &context = queue.get_context();
+    const device &device = queue.get_device();
+    const size_t compute_units = queue.get_device().compute_units();
+
+    boost::shared_ptr<parameter_cache> parameters =
+        detail::parameter_cache::get_global_cache(device);
+
+    std::string cache_key =
+        "__boost_scan_cpu_" + boost::lexical_cast<std::string>(sizeof(T));
+
+    // for inputs smaller than serial_scan_threshold
+    // serial_scan algorithm is used
+    uint_ serial_scan_threshold =
+        parameters->get(cache_key, "serial_scan_threshold", 16384 * sizeof(T));
+    serial_scan_threshold =
+        (std::max)(serial_scan_threshold, uint_(compute_units));
+
+    size_t count = detail::iterator_range_size(first, last);
+    if(count == 0){
+        return result;
+    }
+    else if(count < serial_scan_threshold) {
+        return serial_scan(first, last, result, exclusive, init, op, queue);
+    }
+
+    buffer block_partial_sums(context, sizeof(output_type) * compute_units );
+
+    // create scan kernel
+    meta_kernel k("scan_on_cpu_block_scan");
+
+    // Arguments
+    size_t count_arg = k.add_arg<uint_>("count");
+    size_t init_arg = k.add_arg<output_type>("initial_value");
+    size_t block_partial_sums_arg =
+        k.add_arg<output_type *>(memory_object::global_memory, "block_partial_sums");
+
+    k <<
+        "uint block = " <<
+            "(uint)ceil(((float)count)/(get_global_size(0) + 1));\n" <<
+        "uint index = get_global_id(0) * block;\n" <<
+        "uint end = min(count, index + block);\n";
+
+    if(!exclusive){
+        k <<
+            k.decl<output_type>("sum") << " = " <<
+                first[k.var<uint_>("index")] << ";\n" <<
+            result[k.var<uint_>("index")] << " = sum;\n" <<
+            "index++;\n";
+    }
+    else {
+        k <<
+            k.decl<output_type>("sum") << ";\n" <<
+            "if(index == 0){\n" <<
+                "sum = initial_value;\n" <<
+            "}\n" <<
+            "else {\n" <<
+                "sum = " << first[k.var<uint_>("index")] << ";\n" <<
+                "index++;\n" <<
+            "}\n";
+    }
+
+    k <<
+        "while(index < end){\n" <<
+            // load next value
+            k.decl<const input_type>("value") << " = "
+                << first[k.var<uint_>("index")] << ";\n";
+
+    if(exclusive){
+        k <<
+            "if(get_global_id(0) == 0){\n" <<
+                result[k.var<uint_>("index")] << " = sum;\n" <<
+            "}\n";
+    }
+    k <<
+            "sum = " << op(k.var<output_type>("sum"),
+                           k.var<output_type>("value")) << ";\n";
+
+    if(!exclusive){
+        k <<
+            "if(get_global_id(0) == 0){\n" <<
+                result[k.var<uint_>("index")] << " = sum;\n" <<
+            "}\n";
+    }
+
+    k <<
+            "index++;\n" <<
+        "}\n" << // end while
+        "block_partial_sums[get_global_id(0)] = sum;\n";
+
+    // compile scan kernel
+    kernel block_scan_kernel = k.compile(context);
+
+    // setup kernel arguments
+    block_scan_kernel.set_arg(count_arg, static_cast<uint_>(count));
+    block_scan_kernel.set_arg(init_arg, static_cast<output_type>(init));
+    block_scan_kernel.set_arg(block_partial_sums_arg, block_partial_sums);
+
+    // execute the kernel
+    size_t global_work_size = compute_units;
+    queue.enqueue_1d_range_kernel(block_scan_kernel, 0, global_work_size, 0);
+
+    // scan is done
+    if(compute_units < 2) {
+        return result + count;
+    }
+
+    // final scan kernel
+    meta_kernel l("scan_on_cpu_final_scan");
+
+    // Arguments
+    count_arg = l.add_arg<uint_>("count");
+    block_partial_sums_arg =
+        l.add_arg<output_type *>(memory_object::global_memory, "block_partial_sums");
+
+    l <<
+        "uint block = " <<
+            "(uint)ceil(((float)count)/(get_global_size(0) + 1));\n" <<
+        "uint index = block + get_global_id(0) * block;\n" <<
+        "uint end = min(count, index + block);\n" <<
+
+        k.decl<output_type>("sum") << " = block_partial_sums[0];\n" <<
+        "for(uint i = 0; i < get_global_id(0); i++) {\n" <<
+            "sum = " << op(k.var<output_type>("sum"),
+                           k.var<output_type>("block_partial_sums[i + 1]")) << ";\n" <<
+        "}\n" <<
+
+        "while(index < end){\n";
+    if(exclusive){
+        l <<
+            l.decl<output_type>("value") << " = "
+                << first[k.var<uint_>("index")] << ";\n" <<
+            result[k.var<uint_>("index")] << " = sum;\n" <<
+            "sum = " << op(k.var<output_type>("sum"),
+                           k.var<output_type>("value")) << ";\n";
+    }
+    else {
+        l <<
+            "sum = " << op(k.var<output_type>("sum"),
+                           first[k.var<uint_>("index")]) << ";\n" <<
+            result[k.var<uint_>("index")] << " = sum;\n";
+    }
+    l <<
+            "index++;\n" <<
+        "}\n";
+
+
+    // compile scan kernel
+    kernel final_scan_kernel = l.compile(context);
+
+    // setup kernel arguments
+    final_scan_kernel.set_arg(count_arg, static_cast<uint_>(count));
+    final_scan_kernel.set_arg(block_partial_sums_arg, block_partial_sums);
+
+    // execute the kernel
+    global_work_size = compute_units;
+    queue.enqueue_1d_range_kernel(final_scan_kernel, 0, global_work_size, 0);
+
+    // return iterator pointing to the end of the result range
+    return result + count;
+}
+
+} // end detail namespace
+} // end compute namespace
+} // end boost namespace
+
+#endif // BOOST_COMPUTE_ALGORITHM_DETAIL_SCAN_ON_CPU_HPP

--- a/include/boost/compute/algorithm/detail/scan_on_gpu.hpp
+++ b/include/boost/compute/algorithm/detail/scan_on_gpu.hpp
@@ -14,7 +14,6 @@
 #include <boost/compute/kernel.hpp>
 #include <boost/compute/detail/meta_kernel.hpp>
 #include <boost/compute/command_queue.hpp>
-#include <boost/compute/algorithm/detail/scan_on_cpu.hpp>
 #include <boost/compute/container/vector.hpp>
 #include <boost/compute/detail/iterator_range_size.hpp>
 #include <boost/compute/memory/local_buffer.hpp>

--- a/include/boost/compute/algorithm/detail/serial_scan.hpp
+++ b/include/boost/compute/algorithm/detail/serial_scan.hpp
@@ -8,8 +8,8 @@
 // See http://boostorg.github.com/compute for more information.
 //---------------------------------------------------------------------------//
 
-#ifndef BOOST_COMPUTE_ALGORITHM_DETAIL_SCAN_ON_CPU_HPP
-#define BOOST_COMPUTE_ALGORITHM_DETAIL_SCAN_ON_CPU_HPP
+#ifndef BOOST_COMPUTE_ALGORITHM_DETAIL_SERIAL_SCAN_HPP
+#define BOOST_COMPUTE_ALGORITHM_DETAIL_SERIAL_SCAN_HPP
 
 #include <iterator>
 
@@ -24,7 +24,7 @@ namespace compute {
 namespace detail {
 
 template<class InputIterator, class OutputIterator, class T, class BinaryOperator>
-inline OutputIterator scan_on_cpu(InputIterator first,
+inline OutputIterator serial_scan(InputIterator first,
                                   InputIterator last,
                                   OutputIterator result,
                                   bool exclusive,
@@ -44,7 +44,7 @@ inline OutputIterator scan_on_cpu(InputIterator first,
     const context &context = queue.get_context();
 
     // create scan kernel
-    meta_kernel k("scan_on_cpu");
+    meta_kernel k("serial_scan");
 
     // Arguments
     size_t n_arg = k.add_arg<ulong_>("n");
@@ -100,4 +100,4 @@ inline OutputIterator scan_on_cpu(InputIterator first,
 } // end compute namespace
 } // end boost namespace
 
-#endif // BOOST_COMPUTE_ALGORITHM_DETAIL_SCAN_ON_CPU_HPP
+#endif // BOOST_COMPUTE_ALGORITHM_DETAIL_SERIAL_SCAN_HPP

--- a/perf/perf_partial_sum.cpp
+++ b/perf/perf_partial_sum.cpp
@@ -26,6 +26,8 @@ int rand_int()
 
 int main(int argc, char *argv[])
 {
+    using boost::compute::int_;
+
     perf_parse_args(argc, argv);
 
     std::cout << "size: " << PERF_N << std::endl;
@@ -37,12 +39,12 @@ int main(int argc, char *argv[])
     std::cout << "device: " << device.name() << std::endl;
 
     // create vector of random numbers on the host
-    std::vector<int> host_vector(PERF_N);
+    std::vector<int_> host_vector(PERF_N);
     std::generate(host_vector.begin(), host_vector.end(), rand_int);
 
     // create vector on the device and copy the data
-    boost::compute::vector<int> device_vector(PERF_N, context);
-    boost::compute::vector<int> device_res(PERF_N,context);
+    boost::compute::vector<int_> device_vector(PERF_N, context);
+    boost::compute::vector<int_> device_res(PERF_N,context);
     boost::compute::copy(
         host_vector.begin(),
         host_vector.end(),

--- a/perf/perf_stl_partial_sum.cpp
+++ b/perf/perf_stl_partial_sum.cpp
@@ -13,6 +13,8 @@
 #include <numeric>
 #include <vector>
 
+#include <boost/compute/system.hpp>
+
 #include "perf.hpp"
 
 int rand_int()
@@ -22,18 +24,25 @@ int rand_int()
 
 int main(int argc, char *argv[])
 {
+    using boost::compute::int_;
+
     perf_parse_args(argc, argv);
 
     std::cout << "size: " << PERF_N << std::endl;
 
     // create vector of random numbers on the host
-    std::vector<int> v(PERF_N);
+    std::vector<int_> v(PERF_N);
+    std::vector<int_> r(PERF_N);
 
     perf_timer t;
     for(size_t trial = 0; trial < PERF_TRIALS; trial++){
         std::generate(v.begin(), v.end(), rand_int);
         t.start();
-        std::partial_sum(v.begin(), v.end(), v.begin());
+        std::partial_sum(
+            v.begin(),
+            v.end(),
+            r.begin()
+        );
         t.stop();
     }
     std::cout << "time: " << t.min_time() / 1e6 << " ms" << std::endl;

--- a/test/test_scan.cpp
+++ b/test/test_scan.cpp
@@ -8,6 +8,13 @@
 // See http://boostorg.github.com/compute for more information.
 //---------------------------------------------------------------------------//
 
+// Undefining BOOST_COMPUTE_USE_OFFLINE_CACHE macro as we want to modify cached
+// parameters for copy algorithm without any undesirable consequences (like
+// saving modified values of those parameters).
+#ifdef BOOST_COMPUTE_USE_OFFLINE_CACHE
+    #undef BOOST_COMPUTE_USE_OFFLINE_CACHE
+#endif
+
 #define BOOST_TEST_MODULE TestScan
 #include <boost/test/unit_test.hpp>
 
@@ -33,47 +40,110 @@ namespace bc = boost::compute;
 
 BOOST_AUTO_TEST_CASE(inclusive_scan_int)
 {
-    int data[] = { 1, 2, 1, 2, 3 };
-    bc::vector<int> vector(data, data + 5, queue);
-    BOOST_CHECK_EQUAL(vector.size(), size_t(5));
+    using boost::compute::uint_;
+    using boost::compute::int_;
 
-    bc::vector<int> result(5, context);
-    BOOST_CHECK_EQUAL(result.size(), size_t(5));
+    int_ data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+    bc::vector<int_> vector(data, data + 12, queue);
+    BOOST_CHECK_EQUAL(vector.size(), size_t(12));
+
+    bc::vector<int_> result(12, context);
+    BOOST_CHECK_EQUAL(result.size(), size_t(12));
 
     // inclusive scan
     bc::inclusive_scan(vector.begin(), vector.end(), result.begin(), queue);
-    CHECK_RANGE_EQUAL(int, 5, result, (1, 3, 4, 6, 9));
+    CHECK_RANGE_EQUAL(int_, 12, result, (0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66));
 
     // in-place inclusive scan
-    CHECK_RANGE_EQUAL(int, 5, vector, (1, 2, 1, 2, 3));
+    CHECK_RANGE_EQUAL(int_, 12, vector, (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11));
     bc::inclusive_scan(vector.begin(), vector.end(), vector.begin(), queue);
-    CHECK_RANGE_EQUAL(int, 5, vector, (1, 3, 4, 6, 9));
+    CHECK_RANGE_EQUAL(int_, 12, vector, (0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66));
+
+    // scan_on_cpu
+
+    bc::copy(data, data + 12, vector.begin(), queue);
+
+    // make sure parallel scan_on_cpu is used, no serial_scan
+    std::string cache_key =
+        "__boost_scan_cpu_4";
+    boost::shared_ptr<bc::detail::parameter_cache> parameters =
+        bc::detail::parameter_cache::get_global_cache(device);
+
+    // save
+    uint_ map_copy_threshold =
+        parameters->get(cache_key, "serial_scan_threshold", 0);
+    // force parallel scan_on_cpu
+    parameters->set(cache_key, "serial_scan_threshold", 0);
+
+    // inclusive scan
+    bc::inclusive_scan(vector.begin(), vector.end(), result.begin(), queue);
+    CHECK_RANGE_EQUAL(int_, 12, result, (0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66));
+
+    // in-place inclusive scan
+    CHECK_RANGE_EQUAL(int_, 12, vector, (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11));
+    bc::inclusive_scan(vector.begin(), vector.end(), vector.begin(), queue);
+    CHECK_RANGE_EQUAL(int_, 12, vector, (0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66));
+
+    // restore
+    parameters->set(cache_key, "serial_scan_threshold", map_copy_threshold);
 }
 
 BOOST_AUTO_TEST_CASE(exclusive_scan_int)
 {
-    int data[] = { 1, 2, 1, 2, 3 };
-    bc::vector<int> vector(data, data + 5, queue);
-    BOOST_CHECK_EQUAL(vector.size(), size_t(5));
+    using boost::compute::uint_;
+    using boost::compute::int_;
 
-    bc::vector<int> result(5, context);
-    BOOST_CHECK_EQUAL(vector.size(), size_t(5));
+    int_ data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+    bc::vector<int_> vector(data, data + 12, queue);
+    BOOST_CHECK_EQUAL(vector.size(), size_t(12));
+
+    bc::vector<int_> result(size_t(12), int_(0), queue);
+    BOOST_CHECK_EQUAL(result.size(), size_t(12));
 
     // exclusive scan
     bc::exclusive_scan(vector.begin(), vector.end(), result.begin(), queue);
-    CHECK_RANGE_EQUAL(int, 5, result, (0, 1, 3, 4, 6));
+    CHECK_RANGE_EQUAL(int_, 12, result, (0, 0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55));
 
     // in-place exclusive scan
-    CHECK_RANGE_EQUAL(int, 5, vector, (1, 2, 1, 2, 3));
+    CHECK_RANGE_EQUAL(int_, 12, vector, (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11));
     bc::exclusive_scan(vector.begin(), vector.end(), vector.begin(), queue);
-    CHECK_RANGE_EQUAL(int, 5, vector, (0, 1, 3, 4, 6));
+    CHECK_RANGE_EQUAL(int_, 12, vector, (0, 0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55));
+
+    // scan_on_cpu
+    bc::copy(data, data + 12, vector.begin(), queue);
+
+    // make sure parallel scan_on_cpu is used, no serial_scan
+    std::string cache_key =
+        "__boost_scan_cpu_4";
+    boost::shared_ptr<bc::detail::parameter_cache> parameters =
+        bc::detail::parameter_cache::get_global_cache(device);
+
+    // save
+    uint_ map_copy_threshold =
+        parameters->get(cache_key, "serial_scan_threshold", 0);
+    // force parallel scan_on_cpu
+    parameters->set(cache_key, "serial_scan_threshold", 0);
+
+    // exclusive scan
+    bc::exclusive_scan(vector.begin(), vector.end(), result.begin(), queue);
+    CHECK_RANGE_EQUAL(int_, 12, result, (0, 0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55));
+
+    // in-place exclusive scan
+    CHECK_RANGE_EQUAL(int_, 12, vector, (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11));
+    bc::exclusive_scan(vector.begin(), vector.end(), vector.begin(), queue);
+    CHECK_RANGE_EQUAL(int_, 12, vector, (0, 0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55));
+
+    // restore
+    parameters->set(cache_key, "serial_scan_threshold", map_copy_threshold);
 }
 
 BOOST_AUTO_TEST_CASE(inclusive_scan_int2)
 {
+    using boost::compute::int_;
+    using boost::compute::uint_;
     using boost::compute::int2_;
 
-    int data[] = { 1, 2,
+    int_ data[] = { 1, 2,
                    3, 4,
                    5, 6,
                    7, 8,
@@ -91,24 +161,98 @@ BOOST_AUTO_TEST_CASE(inclusive_scan_int2)
         int2_, 5, output,
         (int2_(1, 2), int2_(4, 6), int2_(9, 12), int2_(16, 20), int2_(25, 20))
     );
+
+    // scan_on_cpu
+
+    // make sure parallel scan_on_cpu is used, no serial_scan
+    std::string cache_key =
+        "__boost_scan_cpu_8";
+    boost::shared_ptr<bc::detail::parameter_cache> parameters =
+        bc::detail::parameter_cache::get_global_cache(device);
+
+    // save
+    uint_ map_copy_threshold =
+        parameters->get(cache_key, "serial_scan_threshold", 0);
+    // force parallel scan_on_cpu
+    parameters->set(cache_key, "serial_scan_threshold", 0);
+
+    boost::compute::inclusive_scan(input.begin(), input.end(), output.begin(),
+                                   queue);
+    CHECK_RANGE_EQUAL(
+        int2_, 5, output,
+        (int2_(1, 2), int2_(4, 6), int2_(9, 12), int2_(16, 20), int2_(25, 20))
+    );
+
+    // restore
+    parameters->set(cache_key, "serial_scan_threshold", map_copy_threshold);
 }
 
 BOOST_AUTO_TEST_CASE(inclusive_scan_counting_iterator)
 {
-    bc::vector<int> result(10, context);
+    using boost::compute::int_;
+    using boost::compute::uint_;
+
+    bc::vector<int_> result(10, context);
     bc::inclusive_scan(bc::make_counting_iterator(1),
                        bc::make_counting_iterator(11),
                        result.begin(), queue);
-    CHECK_RANGE_EQUAL(int, 10, result, (1, 3, 6, 10, 15, 21, 28, 36, 45, 55));
+    CHECK_RANGE_EQUAL(int_, 10, result, (1, 3, 6, 10, 15, 21, 28, 36, 45, 55));
+
+    // scan_on_cpu
+
+    // make sure parallel scan_on_cpu is used, no serial_scan
+    std::string cache_key =
+        "__boost_scan_cpu_4";
+    boost::shared_ptr<bc::detail::parameter_cache> parameters =
+        bc::detail::parameter_cache::get_global_cache(device);
+
+    // save
+    uint_ map_copy_threshold =
+        parameters->get(cache_key, "serial_scan_threshold", 0);
+    // force parallel scan_on_cpu
+    parameters->set(cache_key, "serial_scan_threshold", 0);
+
+    bc::inclusive_scan(bc::make_counting_iterator(1),
+                       bc::make_counting_iterator(11),
+                       result.begin(), queue);
+    CHECK_RANGE_EQUAL(int_, 10, result, (1, 3, 6, 10, 15, 21, 28, 36, 45, 55));
+
+    // restore
+    parameters->set(cache_key, "serial_scan_threshold", map_copy_threshold);
 }
 
 BOOST_AUTO_TEST_CASE(exclusive_scan_counting_iterator)
 {
-    bc::vector<int> result(10, context);
+    using boost::compute::int_;
+    using boost::compute::uint_;
+
+    bc::vector<int_> result(10, context);
     bc::exclusive_scan(bc::make_counting_iterator(1),
                        bc::make_counting_iterator(11),
                        result.begin(), queue);
-    CHECK_RANGE_EQUAL(int, 10, result, (0, 1, 3, 6, 10, 15, 21, 28, 36, 45));
+    CHECK_RANGE_EQUAL(int_, 10, result, (0, 1, 3, 6, 10, 15, 21, 28, 36, 45));
+
+    // scan_on_cpu
+
+    // make sure parallel scan_on_cpu is used, no serial_scan
+    std::string cache_key =
+        "__boost_scan_cpu_4";
+    boost::shared_ptr<bc::detail::parameter_cache> parameters =
+        bc::detail::parameter_cache::get_global_cache(device);
+
+    // save
+    uint_ map_copy_threshold =
+        parameters->get(cache_key, "serial_scan_threshold", 0);
+    // force parallel scan_on_cpu
+    parameters->set(cache_key, "serial_scan_threshold", 0);
+
+    bc::exclusive_scan(bc::make_counting_iterator(1),
+                       bc::make_counting_iterator(11),
+                       result.begin(), queue);
+    CHECK_RANGE_EQUAL(int_, 10, result, (0, 1, 3, 6, 10, 15, 21, 28, 36, 45));
+
+    // restore
+    parameters->set(cache_key, "serial_scan_threshold", map_copy_threshold);
 }
 
 BOOST_AUTO_TEST_CASE(inclusive_scan_transform_iterator)


### PR DESCRIPTION
This adds parallel scan for multicore CPUs. 

Unfortunately, it's not so much faster compared to `serial_scan` as you may think (at least in the simplest version of scan). Turns out that scan (partial_sum) is very memory bound operation and that's what limits the performance. If your scan is more computational intensive, like using multiplication as binary operator (instead of addition) or using `transform_iterator`, new implementation is much faster.

There is a parameter, a knob for `serial_scan`, so if anyone prefers that it's easy to force it. 

### Benchmarks:

1st test:

* Integers (4 bytes)
* Output is a different buffer than input
* Addition as binary operator

```
=== partial_sum with stl ===
size,time (ms)
2,0.000133
4,0.000142
8,0.000134
16,0.000138
32,0.000143
64,0.000160
128,0.000182
256,0.000231
512,0.000318
1024,0.000523
2048,0.000905
4096,0.001682
8192,0.003258
16384,0.006367
32768,0.012164
65536,0.024296
131072,0.048424
262144,0.096473
524288,0.193014
1048576,0.416432
2097152,0.918738
4194304,1.922140
8388608,3.920030
16777216,7.937260
33554432,16.039500
=== partial_sum with compute === [master]
size,time (ms)
2,0.024574
4,0.024136
8,0.024373
16,0.024759
32,0.023966
64,0.024143
128,0.024506
256,0.024866
512,0.024680
1024,0.024701
2048,0.024969
4096,0.027860
8192,0.029132
16384,0.031862
32768,0.037636
65536,0.050316
131072,0.072422
262144,0.119914
524288,0.262027
1048576,0.454836
2097152,0.913986
4194304,1.948580
8388608,3.856160
16777216,7.720050
33554432,15.435100
=== partial_sum with compute ===  [pr_scan_on_cpu]
size,time (ms)
2,0.024880
4,0.058831
8,0.058118
16,0.059220
32,0.058700
64,0.058996
128,0.059202
256,0.059067
512,0.059627
1024,0.059803
2048,0.059085
4096,0.061478
8192,0.063023
16384,0.063771
32768,0.067773
65536,0.075397
131072,0.087798
262144,0.118187
524288,0.182055
1048576,0.379444
2097152,0.878609
4194304,1.758310
8388608,3.607530
16777216,7.295870
33554432,14.755100
```

2nd test:

* Integers
* Input is a counting_iterator (less reads)
* Output is a different buffer than input
* Addition as binary operator

```
=== partial_sum with stl ===
size,time (ms)
2,0.000132
4,0.000134
8,0.000137
16,0.000136
32,0.000142
64,0.000159
128,0.000180
256,0.000226
512,0.000313
1024,0.000485
2048,0.000849
4096,0.001546
8192,0.002999
16384,0.005815
32768,0.011389
65536,0.022623
131072,0.045092
262144,0.089912
524288,0.179732
1048576,0.360201
2097152,0.727174
4194304,1.464850
8388608,2.940750
16777216,5.890150
33554432,11.794500
=== partial_sum with compute === [master]
size,time (ms)
2,0.022248
4,0.022358
8,0.022066
16,0.022683
32,0.022127
64,0.021975
128,0.022936
256,0.022848
512,0.022470
1024,0.023087
2048,0.023167
4096,0.024145
8192,0.025960
16384,0.028900
32768,0.034864
65536,0.045685
131072,0.067478
262144,0.110432
524288,0.196010
1048576,0.368173
2097152,0.775608
4194304,1.448320
8388608,2.817400
16777216,5.583590
33554432,11.205700
=== partial_sum with compute === [pr_scan_on_cpu]
size,time (ms)
2,0.022960
4,0.055819
8,0.050561
16,0.055357
32,0.055002
64,0.055797
128,0.054942
256,0.054740
512,0.055719
1024,0.055811
2048,0.056499
4096,0.057108
8192,0.058888
16384,0.061926
32768,0.065484
65536,0.074273
131072,0.090985
262144,0.127229
524288,0.195081
1048576,0.331918
2097152,0.611572
4194304,1.292590
8388608,2.716510
16777216,5.600410
33554432,11.391500
```

3rd test:

* Integers
* Output is a different buffer than input
* Multiplication as a binary operator

```
=== partial_sum with stl ===
size,time (ms)
2,0.000133
4,0.000133
8,0.000135
16,0.000142
32,0.000152
64,0.000177
128,0.000226
256,0.000325
512,0.000523
1024,0.000917
2048,0.001710
4096,0.003286
8192,0.006449
16384,0.012752
32768,0.025388
65536,0.050613
131072,0.101045
262144,0.201858
524288,0.403534
1048576,0.810035
2097152,1.621640
4194304,3.246170
8388608,6.496410
16777216,12.992500
33554432,25.989900
=== partial_sum with compute === [master]
size,time (ms)
2,0.024059
4,0.025767
8,0.024349
16,0.024042
32,0.024415
64,0.025828
128,0.024376
256,0.024326
512,0.024497
1024,0.025059
2048,0.027538
4096,0.029281
8192,0.032379
16384,0.038732
32768,0.051514
65536,0.077118
131072,0.127380
262144,0.229353
524288,0.433761
1048576,0.839425
2097152,1.653850
4194304,3.286110
8388608,6.531480
16777216,13.031700
33554432,26.011600
=== partial_sum with compute === [pr_scan_on_cpu]
size,time (ms)
2,0.025172
4,0.058407
8,0.058469
16,0.059471
32,0.058983
64,0.058180
128,0.059334
256,0.054043
512,0.059721
1024,0.058306
2048,0.059765
4096,0.060937
8192,0.065578
16384,0.069580
32768,0.076213
65536,0.080058
131072,0.102037
262144,0.178779
524288,0.225017
1048576,0.416907
2097152,0.884288
4194304,1.775860
8388608,3.635050
16777216,7.364730
33554432,14.820500
```

4th test:

* Integers
* Output is a different buffer than input,
* Input is a transform iterator with x^6 as unary function
* Addition as binary operator

```cpp
BOOST_COMPUTE_FUNCTION(int_, function, (int_ x),
{
  return x * x * x * x * x * x;
});

boost::compute::partial_sum(
  boost::compute::make_transform_iterator(device_vector.begin(), function),
  boost::compute::make_transform_iterator(device_vector.end(), function),
  device_res.begin(),
  queue
);
```

```
=== partial_sum with stl ===
size,time (ms)
2,0.000134
4,0.000134
8,0.000138
16,0.000143
32,0.000155
64,0.000247
128,0.000315
256,0.000446
512,0.000711
1024,0.001241
2048,0.002307
4096,0.004441
8192,0.006463
16384,0.012770
32768,0.025404
65536,0.050651
131072,0.101047
262144,0.201890
524288,0.403569
1048576,0.810233
2097152,1.624730
4194304,3.256530
8388608,6.510080
16777216,13.027200
33554432,26.051600
=== partial_sum with compute === [master]
size,time (ms)
2,0.027124
4,0.027188
8,0.026980
16,0.027497
32,0.027166
64,0.026947
128,0.027341
256,0.027279
512,0.027517
1024,0.027665
2048,0.030651
4096,0.032276
8192,0.035523
16384,0.041941
32768,0.054685
65536,0.081043
131072,0.130577
262144,0.231692
524288,0.436274
1048576,0.843986
2097152,1.655320
4194304,3.277980
8388608,6.551160
16777216,13.076400
33554432,26.125700
=== partial_sum with compute === [pr_scan_on_cpu]
size,time (ms)
2,0.028195
4,0.064608
8,0.064084
16,0.063037
32,0.064090
64,0.063634
128,0.063385
256,0.065218
512,0.064119
1024,0.064406
2048,0.065563
4096,0.065181
8192,0.069219
16384,0.071021
32768,0.072427
65536,0.086480
131072,0.110898
262144,0.154487
524288,0.242798
1048576,0.523602
2097152,0.957052
4194304,1.960660
8388608,4.072160
16777216,8.256710
33554432,16.574400
```