### PR TITLE
Misc fixes

### DIFF
--- a/include/boost/compute/algorithm/gather.hpp
+++ b/include/boost/compute/algorithm/gather.hpp
@@ -36,7 +36,6 @@ public:
                    OutputIterator result)
     {
         m_count = iterator_range_size(first, last);
-        m_offset = first.get_index();
 
         *this <<
             "const uint i = get_global_id(0);\n" <<
@@ -50,12 +49,11 @@ public:
             return event();
         }
 
-        return exec_1d(queue, m_offset, m_count);
+        return exec_1d(queue, 0, m_count);
     }
 
 private:
     size_t m_count;
-    size_t m_offset;
 };
 
 } // end detail namespace

--- a/include/boost/compute/context.hpp
+++ b/include/boost/compute/context.hpp
@@ -204,7 +204,7 @@ public:
     typename detail::get_object_info_type<context, Enum>::type
     get_info() const;
 
-    /// Returns \c true if the context is the same at \p other.
+    /// Returns \c true if the context is the same as \p other.
     bool operator==(const context &other) const
     {
         return m_context == other.m_context;

--- a/include/boost/compute/kernel.hpp
+++ b/include/boost/compute/kernel.hpp
@@ -267,7 +267,7 @@ public:
     void set_arg_svm_ptr(size_t index, void* ptr)
     {
         #ifdef CL_VERSION_2_0
-        cl_int ret = clSetKernelArgSVMPointer(m_kernel, index, ptr);
+        cl_int ret = clSetKernelArgSVMPointer(m_kernel, static_cast<cl_uint>(index), ptr);
         if(ret != CL_SUCCESS){
             BOOST_THROW_EXCEPTION(opencl_error(ret));
         }

--- a/include/boost/compute/utility/wait_list.hpp
+++ b/include/boost/compute/utility/wait_list.hpp
@@ -33,7 +33,7 @@ template<class T> class future;
 /// specify dependencies for OpenCL operations or to wait on the host until
 /// all of the events have completed.
 ///
-/// This class also provides convenience fnuctions for interacting with
+/// This class also provides convenience functions for interacting with
 /// OpenCL APIs which typically accept event dependencies as a \c cl_event*
 /// pointer and a \c cl_uint size. For example:
 /// \code

--- a/test/test_gather.cpp
+++ b/test/test_gather.cpp
@@ -34,6 +34,11 @@ BOOST_AUTO_TEST_CASE(gather_int)
         indices.begin(), indices.end(), input.begin(), output.begin(), queue
     );
     CHECK_RANGE_EQUAL(int, 5, output, (1, 5, 2, 4, 3));
+
+    compute::gather(
+        indices.begin() + 1, indices.end(), input.begin(), output.begin(), queue
+    );
+    CHECK_RANGE_EQUAL(int, 5, output, (5, 2, 4, 3, 3));
 }
 
 BOOST_AUTO_TEST_CASE(copy_index_then_gather)


### PR DESCRIPTION
This fixes:

* Some typos 
* `C4267` warning when compiling with MSVC and OpenCL 2.0
* `gather()` algorithm, `m_offset` was unnecessary and caused errors since offset is already stored in an iterator.