### PR TITLE
Fix buffer_iterator_index_expr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -366,6 +366,7 @@ before_install:
       # OSX
       elif [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
         brew update
+        /usr/bin/yes | pip uninstall numpy
         brew outdated boost || brew upgrade boost
         brew outdated cmake || brew upgrade cmake
         brew install lcov homebrew/science/opencv

--- a/include/boost/compute/iterator/buffer_iterator.hpp
+++ b/include/boost/compute/iterator/buffer_iterator.hpp
@@ -58,11 +58,18 @@ struct buffer_iterator_index_expr
                                size_t index,
                                const memory_object::address_space address_space,
                                const IndexExpr &expr)
-        : m_buffer(buffer),
+        : m_buffer(buffer.get(), false),
           m_index(index),
           m_address_space(address_space),
           m_expr(expr)
     {
+    }
+
+    ~buffer_iterator_index_expr()
+    {
+        // set buffer to null so that its reference count will
+        // not be decremented when its destructor is called
+        m_buffer.get() = 0;
     }
 
     operator T() const
@@ -73,7 +80,7 @@ struct buffer_iterator_index_expr
         return buffer_value<T>(m_buffer, size_t(m_expr) * sizeof(T));
     }
 
-    const buffer &m_buffer;
+    const buffer m_buffer;
     size_t m_index;
     memory_object::address_space m_address_space;
     IndexExpr m_expr;

--- a/include/boost/compute/iterator/buffer_iterator.hpp
+++ b/include/boost/compute/iterator/buffer_iterator.hpp
@@ -81,9 +81,9 @@ struct buffer_iterator_index_expr
     }
 
     const buffer m_buffer;
-    size_t m_index;
-    memory_object::address_space m_address_space;
-    IndexExpr m_expr;
+    const size_t m_index;
+    const memory_object::address_space m_address_space;
+    const IndexExpr m_expr;
 };
 
 template<class T, class IndexExpr>

--- a/include/boost/compute/iterator/counting_iterator.hpp
+++ b/include/boost/compute/iterator/counting_iterator.hpp
@@ -47,14 +47,14 @@ struct counting_iterator_index_expr
 {
     typedef T result_type;
 
-    counting_iterator_index_expr(const T &init, const IndexExpr &expr)
+    counting_iterator_index_expr(const T init, const IndexExpr &expr)
         : m_init(init),
           m_expr(expr)
     {
     }
 
-    const T &m_init;
-    IndexExpr m_expr;
+    const T m_init;
+    const IndexExpr m_expr;
 };
 
 template<class T, class IndexExpr>

--- a/include/boost/compute/iterator/function_input_iterator.hpp
+++ b/include/boost/compute/iterator/function_input_iterator.hpp
@@ -53,7 +53,7 @@ struct function_input_iterator_expr
     {
     }
 
-    Function m_function;
+    const Function m_function;
 };
 
 template<class Function>

--- a/include/boost/compute/iterator/permutation_iterator.hpp
+++ b/include/boost/compute/iterator/permutation_iterator.hpp
@@ -60,9 +60,9 @@ struct permutation_iterator_access_expr
     {
     }
 
-    ElementIterator m_element_iter;
-    IndexIterator m_index_iter;
-    IndexExpr m_expr;
+    const ElementIterator m_element_iter;
+    const IndexIterator m_index_iter;
+    const IndexExpr m_expr;
 };
 
 template<class ElementIterator, class IndexIterator, class IndexExpr>

--- a/include/boost/compute/iterator/strided_iterator.hpp
+++ b/include/boost/compute/iterator/strided_iterator.hpp
@@ -56,8 +56,8 @@ struct stride_expr
     {
     }
 
-    IndexExpr m_index_expr;
-    Stride m_stride;
+    const IndexExpr m_index_expr;
+    const Stride m_stride;
 };
 
 template<class IndexExpr, class Stride>
@@ -90,9 +90,9 @@ struct strided_iterator_index_expr
     {
     }
 
-    Iterator m_input_iter;
-    const Stride& m_stride;
-    IndexExpr m_index_expr;
+    const Iterator m_input_iter;
+    const Stride m_stride;
+    const IndexExpr m_index_expr;
 };
 
 template<class Iterator, class Stride, class IndexExpr>

--- a/include/boost/compute/iterator/transform_iterator.hpp
+++ b/include/boost/compute/iterator/transform_iterator.hpp
@@ -76,9 +76,9 @@ struct transform_iterator_index_expr
     {
     }
 
-    InputIterator m_input_iter;
-    UnaryFunction m_transform_expr;
-    IndexExpr m_index_expr;
+    const InputIterator m_input_iter;
+    const UnaryFunction m_transform_expr;
+    const IndexExpr m_index_expr;
 };
 
 template<class InputIterator, class UnaryFunction, class IndexExpr>

--- a/include/boost/compute/iterator/zip_iterator.hpp
+++ b/include/boost/compute/iterator/zip_iterator.hpp
@@ -92,8 +92,8 @@ struct zip_iterator_index_expr
     {
     }
 
-    IteratorTuple m_iterators;
-    IndexExpr m_index_expr;
+    const IteratorTuple m_iterators;
+    const IndexExpr m_index_expr;
 };
 
 /// \internal_


### PR DESCRIPTION
This addresses https://github.com/boostorg/compute/issues/665. I also made all index expression immutable.
