### PR TITLE
Add OpenCL 2.0 command queue properties

### DIFF
--- a/include/boost/compute/command_queue.hpp
+++ b/include/boost/compute/command_queue.hpp
@@ -81,6 +81,11 @@ public:
     enum properties {
         enable_profiling = CL_QUEUE_PROFILING_ENABLE,
         enable_out_of_order_execution = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE
+        #ifdef CL_VERSION_2_0
+        ,
+        on_device = CL_QUEUE_ON_DEVICE,
+        on_device_default = CL_QUEUE_ON_DEVICE_DEFAULT
+        #endif
     };
 
     enum map_flags {


### PR DESCRIPTION
I wanted to play with device-side enqueue in OpenCL 2.x but it was not available in Boost.Compute.
Here are the missing properties.

On the longer term, do we want device command queue objects like the DeviceCommandQueue in https://github.com/KhronosGroup/OpenCL-CLHPP/blob/master/input_cl2.hpp#L8143 ?
