### PR TITLE
Fixes bug with boost::compute::fill

### DIFF
--- a/include/boost/compute/algorithm/fill.hpp
+++ b/include/boost/compute/algorithm/fill.hpp
@@ -138,7 +138,7 @@ dispatch_fill(BufferIterator first,
             sizeof(value_type),
             offset * sizeof(value_type),
             count * sizeof(value_type)
-        );
+        ).wait();
     }
 }
 


### PR DESCRIPTION
We need to wait for the event of clEnqueueFillBuffer, because the call
is always async!