### PR TITLE
Add BOOST_COMPUTE_NO_BOOST_CHRONO configuration macro

### DIFF
--- a/include/boost/compute/detail/duration.hpp
+++ b/include/boost/compute/detail/duration.hpp
@@ -17,7 +17,9 @@
 #include <chrono>
 #endif
 
+#ifndef BOOST_COMPUTE_NO_BOOST_CHRONO
 #include <boost/chrono/duration.hpp>
+#endif
 
 namespace boost {
 namespace compute {
@@ -34,6 +36,7 @@ make_duration_from_nanoseconds(std::chrono::duration<Rep, Period>, size_t nanose
 }
 #endif // BOOST_COMPUTE_NO_HDR_CHRONO
 
+#ifndef BOOST_COMPUTE_NO_BOOST_CHRONO
 template<class Rep, class Period>
 inline boost::chrono::duration<Rep, Period>
 make_duration_from_nanoseconds(boost::chrono::duration<Rep, Period>, size_t nanoseconds)
@@ -42,6 +45,7 @@ make_duration_from_nanoseconds(boost::chrono::duration<Rep, Period>, size_t nano
         boost::chrono::nanoseconds(nanoseconds)
     );
 }
+#endif // BOOST_COMPUTE_NO_BOOST_CHRONO
 
 } // end detail namespace
 } // end compute namespace


### PR DESCRIPTION
This adds a "BOOST_COMPUTE_NO_BOOST_CHRONO" which disables
including/using Boost.Chrono from Boost.Compute.