### PR TITLE
Check platform extension for issue #676

### DIFF
--- a/include/boost/compute/interop/opengl/context.hpp
+++ b/include/boost/compute/interop/opengl/context.hpp
@@ -75,6 +75,10 @@ inline context opengl_create_shared_context()
     for(size_t i = 0; i < platforms.size(); i++){
         const platform &platform = platforms[i];
 
+        // check whether this platform supports OpenCL/OpenGL sharing
+        if (!platform.supports_extension(cl_gl_sharing_extension))
+          continue;
+
         // load clGetGLContextInfoKHR() extension function
         GetGLContextInfoKHRFunction GetGLContextInfoKHR =
             reinterpret_cast<GetGLContextInfoKHRFunction>(


### PR DESCRIPTION
Check that a platform supports OpenCL/OpenGL sharing before attempting to load the clGetGLContextInfoKHR() extension function in function opengl_create_shared_context().