### PR TITLE
Add Wrapper to clfft clblas ...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -366,6 +366,7 @@ before_install:
       # OSX
       elif [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
         brew update
+        /usr/bin/yes | pip uninstall numpy
         brew outdated boost || brew upgrade boost
         brew outdated cmake || brew upgrade cmake
         brew install lcov homebrew/science/opencv

--- a/include/boost/compute/algorithm/accumulate.hpp
+++ b/include/boost/compute/algorithm/accumulate.hpp
@@ -26,6 +26,7 @@ namespace boost {
 namespace compute {
 namespace detail {
 
+// Space complexity O(1)
 template<class InputIterator, class T, class BinaryFunction>
 inline T generic_accumulate(InputIterator first,
                             InputIterator last,
@@ -154,6 +155,9 @@ inline T dispatch_accumulate(InputIterator first,
 /// accumulate(vec.begin(), vec.end(), 0, plus<float>());   // slow
 /// reduce(vec.begin(), vec.end(), &result, plus<float>()); // fast
 /// \endcode
+///
+/// Space complexity: \Omega(1)<br>
+/// Space complexity when optimized to \c reduce(): \Omega(n)
 ///
 /// \see reduce()
 template<class InputIterator, class T, class BinaryFunction>

--- a/include/boost/compute/algorithm/adjacent_difference.hpp
+++ b/include/boost/compute/algorithm/adjacent_difference.hpp
@@ -64,6 +64,9 @@ dispatch_adjacent_difference(InputIterator first,
 ///
 /// \return \c OutputIterator to the end of the result range
 ///
+/// Space complexity: \Omega(1)<br>
+/// Space complexity when \p result == \p first: \Omega(n)
+///
 /// \see adjacent_find()
 template<class InputIterator, class OutputIterator, class BinaryFunction>
 inline OutputIterator

--- a/include/boost/compute/algorithm/adjacent_find.hpp
+++ b/include/boost/compute/algorithm/adjacent_find.hpp
@@ -114,6 +114,8 @@ adjacent_find_with_atomics(InputIterator first,
 /// \return \c InputIteratorm to the first element which compares equal
 ///         to the following element. If none are equal, returns \c last.
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see find(), adjacent_difference()
 template<class InputIterator, class Compare>
 inline InputIterator

--- a/include/boost/compute/algorithm/all_of.hpp
+++ b/include/boost/compute/algorithm/all_of.hpp
@@ -20,6 +20,8 @@ namespace compute {
 /// Returns \c true if \p predicate returns \c true for all of the elements in
 /// the range [\p first, \p last).
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see any_of(), none_of()
 template<class InputIterator, class UnaryPredicate>
 inline bool all_of(InputIterator first,

--- a/include/boost/compute/algorithm/any_of.hpp
+++ b/include/boost/compute/algorithm/any_of.hpp
@@ -24,6 +24,8 @@ namespace compute {
 ///
 /// \snippet test/test_any_all_none_of.cpp any_of
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see all_of(), none_of()
 template<class InputIterator, class UnaryPredicate>
 inline bool any_of(InputIterator first,

--- a/include/boost/compute/algorithm/binary_search.hpp
+++ b/include/boost/compute/algorithm/binary_search.hpp
@@ -20,6 +20,8 @@ namespace compute {
 
 /// Returns \c true if \p value is in the sorted range [\p first,
 /// \p last).
+///
+/// Space complexity: \Omega(1)
 template<class InputIterator, class T>
 inline bool binary_search(InputIterator first,
                           InputIterator last,

--- a/include/boost/compute/algorithm/copy.hpp
+++ b/include/boost/compute/algorithm/copy.hpp
@@ -826,6 +826,8 @@ dispatch_copy(InputIterator first,
 /// );
 /// \endcode
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see copy_n(), copy_if(), copy_async()
 template<class InputIterator, class OutputIterator>
 inline OutputIterator copy(InputIterator first,

--- a/include/boost/compute/algorithm/copy_if.hpp
+++ b/include/boost/compute/algorithm/copy_if.hpp
@@ -38,6 +38,8 @@ inline OutputIterator copy_index_if(InputIterator first,
 
 /// Copies each element in the range [\p first, \p last) for which
 /// \p predicate returns \c true to the range beginning at \p result.
+///
+/// Space complexity: \Omega(2n)
 template<class InputIterator, class OutputIterator, class Predicate>
 inline OutputIterator copy_if(InputIterator first,
                               InputIterator last,

--- a/include/boost/compute/algorithm/copy_n.hpp
+++ b/include/boost/compute/algorithm/copy_n.hpp
@@ -30,6 +30,8 @@ namespace compute {
 /// boost::compute::copy_n(values, 4, vec.begin(), queue);
 /// \endcode
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see copy()
 template<class InputIterator, class Size, class OutputIterator>
 inline OutputIterator copy_n(InputIterator first,

--- a/include/boost/compute/algorithm/count.hpp
+++ b/include/boost/compute/algorithm/count.hpp
@@ -23,6 +23,9 @@ namespace compute {
 /// Returns the number of occurrences of \p value in the range
 /// [\p first, \p last).
 ///
+/// Space complexity on CPUs: \Omega(1)<br>
+/// Space complexity on GPUs: \Omega(n)
+///
 /// \see count_if()
 template<class InputIterator, class T>
 inline size_t count(InputIterator first,

--- a/include/boost/compute/algorithm/count_if.hpp
+++ b/include/boost/compute/algorithm/count_if.hpp
@@ -25,6 +25,9 @@ namespace compute {
 
 /// Returns the number of elements in the range [\p first, \p last)
 /// for which \p predicate returns \c true.
+///
+/// Space complexity on CPUs: \Omega(1)<br>
+/// Space complexity on GPUs: \Omega(n)
 template<class InputIterator, class Predicate>
 inline size_t count_if(InputIterator first,
                        InputIterator last,

--- a/include/boost/compute/algorithm/detail/find_extrema_with_reduce.hpp
+++ b/include/boost/compute/algorithm/detail/find_extrema_with_reduce.hpp
@@ -246,6 +246,7 @@ inline void find_extrema_with_reduce(InputIterator input,
     );
 }
 
+// Space complexity: \Omega(2 * work-group-size * work-groups-per-compute-unit)
 template<class InputIterator, class Compare>
 InputIterator find_extrema_with_reduce(InputIterator first,
                                        InputIterator last,

--- a/include/boost/compute/algorithm/detail/find_if_with_atomics.hpp
+++ b/include/boost/compute/algorithm/detail/find_if_with_atomics.hpp
@@ -153,6 +153,7 @@ inline InputIterator find_if_with_atomics_multiple_vpt(InputIterator first,
     return first + static_cast<difference_type>(index.read(queue));
 }
 
+// Space complexity: O(1)
 template<class InputIterator, class UnaryPredicate>
 inline InputIterator find_if_with_atomics(InputIterator first,
                                           InputIterator last,

--- a/include/boost/compute/algorithm/detail/merge_sort_on_gpu.hpp
+++ b/include/boost/compute/algorithm/detail/merge_sort_on_gpu.hpp
@@ -418,7 +418,7 @@ inline void merge_blocks_on_gpu(KeyIterator keys_first,
                     ");\n" <<
                 "left_idx = equal ? mid_idx + 1 : left_idx + 1;\n" <<
                 "right_idx = equal ? right_idx : mid_idx;\n" <<
-                "upper_key = equal ? upper_key : " <<
+                "upper_key = " <<
                     keys_first[k.var<const uint_>("left_idx")] << ";\n" <<
             "}\n" <<
         "}\n" <<

--- a/include/boost/compute/algorithm/detail/serial_reduce.hpp
+++ b/include/boost/compute/algorithm/detail/serial_reduce.hpp
@@ -20,6 +20,7 @@ namespace boost {
 namespace compute {
 namespace detail {
 
+// Space complexity: O(1)
 template<class InputIterator, class OutputIterator, class BinaryFunction>
 inline void serial_reduce(InputIterator first,
                           InputIterator last,

--- a/include/boost/compute/algorithm/detail/serial_reduce_by_key.hpp
+++ b/include/boost/compute/algorithm/detail/serial_reduce_by_key.hpp
@@ -55,11 +55,9 @@ inline size_t serial_reduce_by_key(InputKeyIterator keys_first,
     size_t result_size_arg = k.add_arg<uint_ *>(memory_object::global_memory,
                                                 "result_size");
 
-    convert<result_type> to_result_type;
-
     k <<
         k.decl<result_type>("result") <<
-            " = " << to_result_type(values_first[0]) << ";\n" <<
+            " = " << values_first[0] << ";\n" <<
         k.decl<key_type>("previous_key") << " = " << keys_first[0] << ";\n" <<
         k.decl<result_type>("value") << ";\n" <<
         k.decl<key_type>("key") << ";\n" <<
@@ -70,7 +68,7 @@ inline size_t serial_reduce_by_key(InputKeyIterator keys_first,
         values_result[0] << " = result;\n" <<
 
         "for(ulong i = 1; i < count; i++) {\n" <<
-        "    value = " << to_result_type(values_first[k.var<uint_>("i")]) << ";\n" <<
+        "    value = " << values_first[k.var<uint_>("i")] << ";\n" <<
         "    key = " << keys_first[k.var<uint_>("i")] << ";\n" <<
         "    if (" << predicate(k.var<key_type>("previous_key"),
                                 k.var<key_type>("key")) << ") {\n" <<

--- a/include/boost/compute/algorithm/equal.hpp
+++ b/include/boost/compute/algorithm/equal.hpp
@@ -20,6 +20,8 @@ namespace compute {
 
 /// Returns \c true if the range [\p first1, \p last1) and the range
 /// beginning at \p first2 are equal.
+///
+/// Space complexity: \Omega(1)
 template<class InputIterator1, class InputIterator2>
 inline bool equal(InputIterator1 first1,
                   InputIterator1 last1,

--- a/include/boost/compute/algorithm/equal_range.hpp
+++ b/include/boost/compute/algorithm/equal_range.hpp
@@ -23,6 +23,8 @@ namespace compute {
 
 /// Returns a pair of iterators containing the range of values equal
 /// to \p value in the sorted range [\p first, \p last).
+///
+/// Space complexity: \Omega(1)
 template<class InputIterator, class T>
 inline std::pair<InputIterator, InputIterator>
 equal_range(InputIterator first,

--- a/include/boost/compute/algorithm/exclusive_scan.hpp
+++ b/include/boost/compute/algorithm/exclusive_scan.hpp
@@ -44,6 +44,10 @@ namespace compute {
 ///
 /// \snippet test/test_scan.cpp exclusive_scan_int_multiplies
 ///
+/// Space complexity on GPUs: \Omega(n)<br>
+/// Space complexity on GPUs when \p first == \p result: \Omega(2n)<br>
+/// Space complexity on CPUs: \Omega(1)
+///
 /// \see inclusive_scan()
 template<class InputIterator, class OutputIterator, class T, class BinaryOperator>
 inline OutputIterator

--- a/include/boost/compute/algorithm/fill.hpp
+++ b/include/boost/compute/algorithm/fill.hpp
@@ -271,6 +271,8 @@ inline future<void> dispatch_fill_async(BufferIterator first,
 /// boost::compute::fill(vec.begin(), vec.end(), 7, queue);
 /// \endcode
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see boost::compute::fill_n()
 template<class BufferIterator, class T>
 inline void fill(BufferIterator first,

--- a/include/boost/compute/algorithm/fill_n.hpp
+++ b/include/boost/compute/algorithm/fill_n.hpp
@@ -20,6 +20,8 @@ namespace compute {
 
 /// Fills the range [\p first, \p first + count) with \p value.
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see fill()
 template<class BufferIterator, class Size, class T>
 inline void fill_n(BufferIterator first,

--- a/include/boost/compute/algorithm/find.hpp
+++ b/include/boost/compute/algorithm/find.hpp
@@ -22,6 +22,8 @@ namespace compute {
 
 /// Returns an iterator pointing to the first element in the range
 /// [\p first, \p last) that equals \p value.
+///
+/// Space complexity: \Omega(1)
 template<class InputIterator, class T>
 inline InputIterator find(InputIterator first,
                           InputIterator last,

--- a/include/boost/compute/algorithm/find_end.hpp
+++ b/include/boost/compute/algorithm/find_end.hpp
@@ -26,8 +26,8 @@ namespace detail {
 ///
 /// \brief Helper function for find_end
 ///
-/// Basically a copy of find_if which returns last occurence
-/// instead of first occurence
+/// Basically a copy of find_if which returns last occurrence
+/// instead of first occurrence
 ///
 template<class InputIterator, class UnaryPredicate>
 inline InputIterator find_end_helper(InputIterator first,
@@ -89,6 +89,8 @@ inline InputIterator find_end_helper(InputIterator first,
 /// \param p_first Iterator pointing to start of pattern
 /// \param p_last Iterator pointing to end of pattern
 /// \param queue Queue on which to execute
+///
+/// Space complexity: \Omega(n)
 ///
 template<class TextIterator, class PatternIterator>
 inline TextIterator find_end(TextIterator t_first,

--- a/include/boost/compute/algorithm/find_if.hpp
+++ b/include/boost/compute/algorithm/find_if.hpp
@@ -20,6 +20,8 @@ namespace compute {
 
 /// Returns an iterator pointing to the first element in the range
 /// [\p first, \p last) for which \p predicate returns \c true.
+///
+/// Space complexity: \Omega(1)
 template<class InputIterator, class UnaryPredicate>
 inline InputIterator find_if(InputIterator first,
                              InputIterator last,

--- a/include/boost/compute/algorithm/find_if_not.hpp
+++ b/include/boost/compute/algorithm/find_if_not.hpp
@@ -22,6 +22,8 @@ namespace compute {
 /// Returns an iterator pointing to the first element in the range
 /// [\p first, \p last) for which \p predicate returns \c false.
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see find_if()
 template<class InputIterator, class UnaryPredicate>
 inline InputIterator find_if_not(InputIterator first,

--- a/include/boost/compute/algorithm/for_each.hpp
+++ b/include/boost/compute/algorithm/for_each.hpp
@@ -45,6 +45,8 @@ struct for_each_kernel : public meta_kernel
 
 /// Calls \p function on each element in the range [\p first, \p last).
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see transform()
 template<class InputIterator, class UnaryFunction>
 inline UnaryFunction for_each(InputIterator first,

--- a/include/boost/compute/algorithm/for_each_n.hpp
+++ b/include/boost/compute/algorithm/for_each_n.hpp
@@ -19,6 +19,8 @@ namespace compute {
 /// Calls \p function on each element in the range [\p first, \p first
 /// \c + \p count).
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see for_each()
 template<class InputIterator, class Size, class UnaryFunction>
 inline UnaryFunction for_each_n(InputIterator first,

--- a/include/boost/compute/algorithm/gather.hpp
+++ b/include/boost/compute/algorithm/gather.hpp
@@ -62,6 +62,8 @@ private:
 /// to the range beginning at \p result using the input values from the range
 /// beginning at \p input.
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see scatter()
 template<class InputIterator, class MapIterator, class OutputIterator>
 inline void gather(MapIterator first,

--- a/include/boost/compute/algorithm/generate.hpp
+++ b/include/boost/compute/algorithm/generate.hpp
@@ -22,6 +22,8 @@ namespace compute {
 
 /// Stores the result of \p generator for each element in the range
 /// [\p first, \p last).
+///
+/// Space complexity: \Omega(1)
 template<class OutputIterator, class Generator>
 inline void generate(OutputIterator first,
                      OutputIterator last,

--- a/include/boost/compute/algorithm/generate_n.hpp
+++ b/include/boost/compute/algorithm/generate_n.hpp
@@ -20,6 +20,8 @@ namespace compute {
 
 /// Stores the result of \p generator for each element in the range
 /// [\p first, \p first + \p count).
+///
+/// Space complexity: \Omega(1)
 template<class OutputIterator, class Size, class Generator>
 inline void generate_n(OutputIterator first,
                        Size count,

--- a/include/boost/compute/algorithm/includes.hpp
+++ b/include/boost/compute/algorithm/includes.hpp
@@ -110,6 +110,7 @@ private:
 /// \param last2 Iterator pointing to end of second set
 /// \param queue Queue on which to execute
 ///
+/// Space complexity: \Omega(distance(\p first1, \p last1) + distance(\p first2, \p last2))
 template<class InputIterator1, class InputIterator2>
 inline bool includes(InputIterator1 first1,
                     InputIterator1 last1,

--- a/include/boost/compute/algorithm/inclusive_scan.hpp
+++ b/include/boost/compute/algorithm/inclusive_scan.hpp
@@ -42,6 +42,10 @@ namespace compute {
 ///
 /// \snippet test/test_scan.cpp inclusive_scan_int_multiplies
 ///
+/// Space complexity on GPUs: \Omega(n)<br>
+/// Space complexity on GPUs when \p first == \p result: \Omega(2n)<br>
+/// Space complexity on CPUs: \Omega(1)
+///
 /// \see exclusive_scan()
 template<class InputIterator, class OutputIterator, class BinaryOperator>
 inline OutputIterator

--- a/include/boost/compute/algorithm/inner_product.hpp
+++ b/include/boost/compute/algorithm/inner_product.hpp
@@ -26,6 +26,9 @@ namespace compute {
 /// Returns the inner product of the elements in the range
 /// [\p first1, \p last1) with the elements in the range beginning
 /// at \p first2.
+///
+/// Space complexity: \Omega(1)<br>
+/// Space complexity when binary operator is recognized as associative: \Omega(n)
 template<class InputIterator1, class InputIterator2, class T>
 inline T inner_product(InputIterator1 first1,
                        InputIterator1 last1,

--- a/include/boost/compute/algorithm/inplace_merge.hpp
+++ b/include/boost/compute/algorithm/inplace_merge.hpp
@@ -23,6 +23,8 @@ namespace compute {
 
 /// Merges the sorted values in the range [\p first, \p middle) with
 /// the sorted values in the range [\p middle, \p last) in-place.
+///
+/// Space complexity: \Omega(n)
 template<class Iterator>
 inline void inplace_merge(Iterator first,
                           Iterator middle,

--- a/include/boost/compute/algorithm/iota.hpp
+++ b/include/boost/compute/algorithm/iota.hpp
@@ -26,6 +26,8 @@ namespace compute {
 /// \snippet test/test_iota.cpp iota
 ///
 /// Will fill \c vec with the values (\c 0, \c 1, \c 2, \c ...).
+///
+/// Space complexity: \Omega(1)
 template<class BufferIterator, class T>
 inline void iota(BufferIterator first,
                  BufferIterator last,

--- a/include/boost/compute/algorithm/is_partitioned.hpp
+++ b/include/boost/compute/algorithm/is_partitioned.hpp
@@ -21,6 +21,8 @@ namespace compute {
 
 /// Returns \c true if the values in the range [\p first, \p last)
 /// are partitioned according to \p predicate.
+///
+/// Space complexity: \Omega(1)
 template<class InputIterator, class UnaryPredicate>
 inline bool is_partitioned(InputIterator first,
                            InputIterator last,

--- a/include/boost/compute/algorithm/is_permutation.hpp
+++ b/include/boost/compute/algorithm/is_permutation.hpp
@@ -36,6 +36,7 @@ namespace compute {
 /// \param last2 Iterator pointing to end of second range
 /// \param queue Queue on which to execute
 ///
+/// Space complexity: \Omega(distance(\p first1, \p last1) + distance(\p first2, \p last2))
 template<class InputIterator1, class InputIterator2>
 inline bool is_permutation(InputIterator1 first1,
                            InputIterator1 last1,

--- a/include/boost/compute/algorithm/is_sorted.hpp
+++ b/include/boost/compute/algorithm/is_sorted.hpp
@@ -30,6 +30,8 @@ namespace compute {
 ///
 /// \return \c true if the range [\p first, \p last) is sorted
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see sort()
 template<class InputIterator, class Compare>
 inline bool is_sorted(InputIterator first,

--- a/include/boost/compute/algorithm/lexicographical_compare.hpp
+++ b/include/boost/compute/algorithm/lexicographical_compare.hpp
@@ -42,10 +42,10 @@ const char lexicographical_compare_source[] =
 
 template<class InputIterator1, class InputIterator2>
 inline bool dispatch_lexicographical_compare(InputIterator1 first1,
-                                     InputIterator1 last1,
-                                     InputIterator2 first2,
-                                     InputIterator2 last2,
-                                     command_queue &queue)
+                                             InputIterator1 last1,
+                                             InputIterator2 first2,
+                                             InputIterator2 last2,
+                                             command_queue &queue)
 {
     const boost::compute::context &context = queue.get_context();
 
@@ -103,6 +103,9 @@ inline bool dispatch_lexicographical_compare(InputIterator1 first1,
 
 /// Checks if the first range [first1, last1) is lexicographically
 /// less than the second range [first2, last2).
+///
+/// Space complexity:
+/// \Omega(max(distance(\p first1, \p last1), distance(\p first2, \p last2)))
 template<class InputIterator1, class InputIterator2>
 inline bool lexicographical_compare(InputIterator1 first1,
                                     InputIterator1 last1,

--- a/include/boost/compute/algorithm/lower_bound.hpp
+++ b/include/boost/compute/algorithm/lower_bound.hpp
@@ -22,6 +22,8 @@ namespace compute {
 /// Returns an iterator pointing to the first element in the sorted
 /// range [\p first, \p last) that is not less than \p value.
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see upper_bound()
 template<class InputIterator, class T>
 inline InputIterator

--- a/include/boost/compute/algorithm/max_element.hpp
+++ b/include/boost/compute/algorithm/max_element.hpp
@@ -43,6 +43,9 @@ namespace compute {
 ///     boost::compute::max_element(data.begin(), data.end(), compare_first, queue);
 /// \endcode
 ///
+/// Space complexity on CPUs: \Omega(1)<br>
+/// Space complexity on GPUs: \Omega(N)
+///
 /// \see min_element()
 template<class InputIterator, class Compare>
 inline InputIterator

--- a/include/boost/compute/algorithm/merge.hpp
+++ b/include/boost/compute/algorithm/merge.hpp
@@ -37,6 +37,8 @@ namespace compute {
 ///
 /// \return \c OutputIterator to the end of the result range
 ///
+/// Space complexity: \Omega(distance(\p first1, \p last1) + distance(\p first2, \p last2))
+///
 /// \see inplace_merge()
 template<class InputIterator1,
          class InputIterator2,

--- a/include/boost/compute/algorithm/min_element.hpp
+++ b/include/boost/compute/algorithm/min_element.hpp
@@ -43,6 +43,9 @@ namespace compute {
 ///     boost::compute::min_element(data.begin(), data.end(), compare_first, queue);
 /// \endcode
 ///
+/// Space complexity on CPUs: \Omega(1)<br>
+/// Space complexity on GPUs: \Omega(N)
+///
 /// \see max_element()
 template<class InputIterator, class Compare>
 inline InputIterator

--- a/include/boost/compute/algorithm/minmax_element.hpp
+++ b/include/boost/compute/algorithm/minmax_element.hpp
@@ -31,6 +31,9 @@ namespace compute {
 ///        argument is less than (i.e. is ordered before) the second.
 /// \param queue command queue to perform the operation
 ///
+/// Space complexity on CPUs: \Omega(1)<br>
+/// Space complexity on GPUs: \Omega(N)
+///
 /// \see max_element(), min_element()
 template<class InputIterator, class Compare>
 inline std::pair<InputIterator, InputIterator>

--- a/include/boost/compute/algorithm/mismatch.hpp
+++ b/include/boost/compute/algorithm/mismatch.hpp
@@ -28,6 +28,8 @@ namespace compute {
 /// Returns a pair of iterators pointing to the first position where the
 /// range [\p first1, \p last1) and the range starting at \p first2
 /// differ.
+///
+/// Space complexity: \Omega(1)
 template<class InputIterator1, class InputIterator2>
 inline std::pair<InputIterator1, InputIterator2>
 mismatch(InputIterator1 first1,

--- a/include/boost/compute/algorithm/next_permutation.hpp
+++ b/include/boost/compute/algorithm/next_permutation.hpp
@@ -131,6 +131,7 @@ inline InputIterator np_ceiling(InputIterator first,
 /// \param last Iterator pointing to end of range
 /// \param queue Queue on which to execute
 ///
+/// Space complexity: \Omega(1)
 template<class InputIterator>
 inline bool next_permutation(InputIterator first,
                              InputIterator last,

--- a/include/boost/compute/algorithm/none_of.hpp
+++ b/include/boost/compute/algorithm/none_of.hpp
@@ -20,6 +20,8 @@ namespace compute {
 /// Returns \c true if \p predicate returns \c true for none of the elements in
 /// the range [\p first, \p last).
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see all_of(), any_of()
 template<class InputIterator, class UnaryPredicate>
 inline bool none_of(InputIterator first,

--- a/include/boost/compute/algorithm/nth_element.hpp
+++ b/include/boost/compute/algorithm/nth_element.hpp
@@ -23,6 +23,8 @@ namespace compute {
 
 /// Rearranges the elements in the range [\p first, \p last) such that
 /// the \p nth element would be in that position in a sorted sequence.
+///
+/// Space complexity: \Omega(3n)
 template<class Iterator, class Compare>
 inline void nth_element(Iterator first,
                         Iterator nth,

--- a/include/boost/compute/algorithm/partial_sum.hpp
+++ b/include/boost/compute/algorithm/partial_sum.hpp
@@ -21,6 +21,10 @@ namespace compute {
 /// Calculates the cumulative sum of the elements in the range [\p first,
 /// \p last) and writes the resulting values to the range beginning at
 /// \p result.
+///
+/// Space complexity on GPUs: \Omega(n)<br>
+/// Space complexity on GPUs when \p first == \p result: \Omega(2n)<br>
+/// Space complexity on CPUs: \Omega(1)
 template<class InputIterator, class OutputIterator>
 inline OutputIterator
 partial_sum(InputIterator first,

--- a/include/boost/compute/algorithm/partition.hpp
+++ b/include/boost/compute/algorithm/partition.hpp
@@ -22,6 +22,8 @@ namespace compute {
 /// Partitions the elements in the range [\p first, \p last) according to
 /// \p predicate. Order of the elements need not be preserved.
 ///
+/// Space complexity: \Omega(3n)
+///
 /// \see is_partitioned() and stable_partition()
 ///
 template<class Iterator, class UnaryPredicate>

--- a/include/boost/compute/algorithm/partition_copy.hpp
+++ b/include/boost/compute/algorithm/partition_copy.hpp
@@ -24,6 +24,8 @@ namespace compute {
 /// and all of the elements for which \p predicate returns \c false to
 /// the range beginning at \p first_false.
 ///
+/// Space complexity: \Omega(2n)
+///
 /// \see partition()
 template<class InputIterator,
          class OutputIterator1,

--- a/include/boost/compute/algorithm/partition_point.hpp
+++ b/include/boost/compute/algorithm/partition_point.hpp
@@ -29,6 +29,8 @@ namespace compute {
 /// \param predicate Unary predicate to be applied on each element
 /// \param queue Queue on which to execute
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see partition() and stable_partition()
 ///
 template<class InputIterator, class UnaryPredicate>

--- a/include/boost/compute/algorithm/prev_permutation.hpp
+++ b/include/boost/compute/algorithm/prev_permutation.hpp
@@ -131,6 +131,7 @@ inline InputIterator pp_floor(InputIterator first,
 /// \param last Iterator pointing to end of range
 /// \param queue Queue on which to execute
 ///
+/// Space complexity: \Omega(1)
 template<class InputIterator>
 inline bool prev_permutation(InputIterator first,
                              InputIterator last,

--- a/include/boost/compute/algorithm/random_shuffle.hpp
+++ b/include/boost/compute/algorithm/random_shuffle.hpp
@@ -28,6 +28,8 @@ namespace compute {
 
 /// Randomly shuffles the elements in the range [\p first, \p last).
 ///
+/// Space complexity: \Omega(2n)
+///
 /// \see scatter()
 template<class Iterator>
 inline void random_shuffle(Iterator first,

--- a/include/boost/compute/algorithm/reduce.hpp
+++ b/include/boost/compute/algorithm/reduce.hpp
@@ -153,6 +153,7 @@ block_reduce(InputIterator first,
     return result_vector;
 }
 
+// Space complexity: O( ceil(n / 2 / 256) )
 template<class InputIterator, class OutputIterator, class BinaryFunction>
 inline void generic_reduce(InputIterator first,
                            InputIterator last,
@@ -263,6 +264,9 @@ inline void dispatch_reduce(InputIterator first,
 /// the \c accumulate() algorithm, its implementation is substantially more
 /// efficient on parallel hardware. For more information, see the documentation
 /// on the \c accumulate() algorithm.
+///
+/// Space complexity on GPUs: \Omega(n)<br>
+/// Space complexity on CPUs: \Omega(1)
 ///
 /// \see accumulate()
 template<class InputIterator, class OutputIterator, class BinaryFunction>

--- a/include/boost/compute/algorithm/reduce_by_key.hpp
+++ b/include/boost/compute/algorithm/reduce_by_key.hpp
@@ -51,6 +51,9 @@ namespace compute {
 ///
 /// \snippet test/test_reduce_by_key.cpp reduce_by_key_int
 ///
+/// Space complexity on GPUs: \Omega(2n)<br>
+/// Space complexity on CPUs: \Omega(1)
+///
 /// \see reduce()
 template<class InputKeyIterator, class InputValueIterator,
          class OutputKeyIterator, class OutputValueIterator,

--- a/include/boost/compute/algorithm/remove.hpp
+++ b/include/boost/compute/algorithm/remove.hpp
@@ -22,6 +22,8 @@ namespace compute {
 /// Removes each element equal to \p value in the range [\p first,
 /// \p last).
 ///
+/// Space complexity: \Omega(3n)
+///
 /// \see remove_if()
 template<class Iterator, class T>
 inline Iterator remove(Iterator first,

--- a/include/boost/compute/algorithm/remove_if.hpp
+++ b/include/boost/compute/algorithm/remove_if.hpp
@@ -22,6 +22,8 @@ namespace compute {
 /// Removes each element for which \p predicate returns \c true in the
 /// range [\p first, \p last).
 ///
+/// Space complexity: \Omega(3n)
+///
 /// \see remove()
 template<class Iterator, class Predicate>
 inline Iterator remove_if(Iterator first,

--- a/include/boost/compute/algorithm/replace.hpp
+++ b/include/boost/compute/algorithm/replace.hpp
@@ -68,6 +68,8 @@ private:
 
 /// Replaces each instance of \p old_value in the range [\p first,
 /// \p last) with \p new_value.
+///
+/// Space complexity: \Omega(1)
 template<class Iterator, class T>
 inline void replace(Iterator first,
                     Iterator last,

--- a/include/boost/compute/algorithm/replace_copy.hpp
+++ b/include/boost/compute/algorithm/replace_copy.hpp
@@ -25,6 +25,8 @@ namespace compute {
 /// beginning at \p result while replacing each instance of \p old_value
 /// with \p new_value.
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see replace()
 template<class InputIterator, class OutputIterator, class T>
 inline OutputIterator

--- a/include/boost/compute/algorithm/reverse.hpp
+++ b/include/boost/compute/algorithm/reverse.hpp
@@ -52,6 +52,8 @@ struct reverse_kernel : public meta_kernel
 
 /// Reverses the elements in the range [\p first, \p last).
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see reverse_copy()
 template<class Iterator>
 inline void reverse(Iterator first,

--- a/include/boost/compute/algorithm/reverse_copy.hpp
+++ b/include/boost/compute/algorithm/reverse_copy.hpp
@@ -51,6 +51,8 @@ struct reverse_copy_kernel : public meta_kernel
 /// Copies the elements in the range [\p first, \p last) in reversed
 /// order to the range beginning at \p result.
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see reverse()
 template<class InputIterator, class OutputIterator>
 inline OutputIterator

--- a/include/boost/compute/algorithm/rotate.hpp
+++ b/include/boost/compute/algorithm/rotate.hpp
@@ -21,6 +21,8 @@ namespace compute {
 /// Performs left rotation such that element at \p n_first comes to the
 /// beginning.
 ///
+/// Space complexity: \Omega(distance(\p first, \p last))
+///
 /// \see rotate_copy()
 template<class InputIterator>
 inline void rotate(InputIterator first,

--- a/include/boost/compute/algorithm/rotate_copy.hpp
+++ b/include/boost/compute/algorithm/rotate_copy.hpp
@@ -20,6 +20,8 @@ namespace compute {
 /// Performs left rotation such that element at n_first comes to the
 /// beginning and the output is stored in range starting at result.
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see rotate()
 template<class InputIterator, class OutputIterator>
 inline void rotate_copy(InputIterator first,

--- a/include/boost/compute/algorithm/scatter.hpp
+++ b/include/boost/compute/algorithm/scatter.hpp
@@ -79,6 +79,8 @@ private:
 /// beginning at \p result using the output indices from the range beginning
 /// at \p map.
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see gather()
 template<class InputIterator, class MapIterator, class OutputIterator>
 inline void scatter(InputIterator first,

--- a/include/boost/compute/algorithm/scatter_if.hpp
+++ b/include/boost/compute/algorithm/scatter_if.hpp
@@ -83,7 +83,7 @@ private:
 /// at \p map if stencil is resolved to true. By default the predicate is
 /// an identity
 ///
-///
+/// Space complexity: \Omega(1)
 template<class InputIterator, class MapIterator, class StencilIterator, class OutputIterator,
          class Predicate>
 inline void scatter_if(InputIterator first,

--- a/include/boost/compute/algorithm/search.hpp
+++ b/include/boost/compute/algorithm/search.hpp
@@ -34,6 +34,7 @@ namespace compute {
 /// \param p_last Iterator pointing to end of pattern
 /// \param queue Queue on which to execute
 ///
+/// Space complexity: \Omega(distance(\p t_first, \p t_last))
 template<class TextIterator, class PatternIterator>
 inline TextIterator search(TextIterator t_first,
                            TextIterator t_last,

--- a/include/boost/compute/algorithm/search_n.hpp
+++ b/include/boost/compute/algorithm/search_n.hpp
@@ -102,6 +102,7 @@ private:
 /// \param value Value which repeats
 /// \param queue Queue on which to execute
 ///
+/// Space complexity: \Omega(distance(\p t_first, \p t_last))
 template<class TextIterator, class ValueType>
 inline TextIterator search_n(TextIterator t_first,
                              TextIterator t_last,

--- a/include/boost/compute/algorithm/set_difference.hpp
+++ b/include/boost/compute/algorithm/set_difference.hpp
@@ -122,6 +122,8 @@ private:
 /// will be stored
 /// \param queue Queue on which to execute
 ///
+/// Space complexity:
+/// \Omega(2(distance(\p first1, \p last1) + distance(\p first2, \p last2)))
 template<class InputIterator1, class InputIterator2, class OutputIterator>
 inline OutputIterator set_difference(InputIterator1 first1,
                                      InputIterator1 last1,

--- a/include/boost/compute/algorithm/set_intersection.hpp
+++ b/include/boost/compute/algorithm/set_intersection.hpp
@@ -110,6 +110,8 @@ private:
 /// will be stored
 /// \param queue Queue on which to execute
 ///
+/// Space complexity:
+/// \Omega(2(distance(\p first1, \p last1) + distance(\p first2, \p last2)))
 template<class InputIterator1, class InputIterator2, class OutputIterator>
 inline OutputIterator set_intersection(InputIterator1 first1,
                                        InputIterator1 last1,

--- a/include/boost/compute/algorithm/set_symmetric_difference.hpp
+++ b/include/boost/compute/algorithm/set_symmetric_difference.hpp
@@ -133,13 +133,16 @@ private:
 /// difference will be stored
 /// \param queue Queue on which to execute
 ///
+/// Space complexity:
+/// \Omega(2(distance(\p first1, \p last1) + distance(\p first2, \p last2)))
 template<class InputIterator1, class InputIterator2, class OutputIterator>
-inline OutputIterator set_symmetric_difference(InputIterator1 first1,
-                                     InputIterator1 last1,
-                                     InputIterator2 first2,
-                                     InputIterator2 last2,
-                                     OutputIterator result,
-                                     command_queue &queue = system::default_queue())
+inline OutputIterator
+set_symmetric_difference(InputIterator1 first1,
+                         InputIterator1 last1,
+                         InputIterator2 first2,
+                         InputIterator2 last2,
+                         OutputIterator result,
+                         command_queue &queue = system::default_queue())
 {
     typedef typename std::iterator_traits<InputIterator1>::value_type value_type;
 

--- a/include/boost/compute/algorithm/set_union.hpp
+++ b/include/boost/compute/algorithm/set_union.hpp
@@ -135,6 +135,8 @@ private:
 /// will be stored
 /// \param queue Queue on which to execute
 ///
+/// Space complexity:
+/// \Omega(2(distance(\p first1, \p last1) + distance(\p first2, \p last2)))
 template<class InputIterator1, class InputIterator2, class OutputIterator>
 inline OutputIterator set_union(InputIterator1 first1,
                                 InputIterator1 last1,

--- a/include/boost/compute/algorithm/sort.hpp
+++ b/include/boost/compute/algorithm/sort.hpp
@@ -176,6 +176,8 @@ inline void dispatch_sort(Iterator first,
 /// boost::compute::sort(data.begin(), data.end(), queue);
 /// \endcode
 ///
+/// Space complexity: \Omega(n)
+///
 /// \see is_sorted()
 template<class Iterator, class Compare>
 inline void sort(Iterator first,

--- a/include/boost/compute/algorithm/sort_by_key.hpp
+++ b/include/boost/compute/algorithm/sort_by_key.hpp
@@ -128,6 +128,8 @@ inline void dispatch_sort_by_key(KeyIterator keys_first,
 ///
 /// If no compare function is specified, \c less is used.
 ///
+/// Space complexity: \Omega(2n)
+///
 /// \see sort()
 template<class KeyIterator, class ValueIterator, class Compare>
 inline void sort_by_key(KeyIterator keys_first,

--- a/include/boost/compute/algorithm/stable_partition.hpp
+++ b/include/boost/compute/algorithm/stable_partition.hpp
@@ -33,6 +33,8 @@ namespace compute {
 /// \param predicate Unary predicate to be applied on each element
 /// \param queue Queue on which to execute
 ///
+/// Space complexity: \Omega(3n)
+///
 /// \see is_partitioned() and partition()
 ///
 template<class Iterator, class UnaryPredicate>

--- a/include/boost/compute/algorithm/stable_sort.hpp
+++ b/include/boost/compute/algorithm/stable_sort.hpp
@@ -72,6 +72,8 @@ dispatch_gpu_stable_sort(buffer_iterator<T> first,
 /// Sorts the values in the range [\p first, \p last) according to
 /// \p compare. The relative order of identical values is preserved.
 ///
+/// Space complexity: \Omega(n)
+///
 /// \see sort(), is_sorted()
 template<class Iterator, class Compare>
 inline void stable_sort(Iterator first,

--- a/include/boost/compute/algorithm/stable_sort_by_key.hpp
+++ b/include/boost/compute/algorithm/stable_sort_by_key.hpp
@@ -126,6 +126,8 @@ inline void dispatch_ssort_by_key(KeyIterator keys_first,
 ///
 /// If no compare function is specified, \c less is used.
 ///
+/// Space complexity: \Omega(2n)
+///
 /// \see sort()
 template<class KeyIterator, class ValueIterator, class Compare>
 inline void stable_sort_by_key(KeyIterator keys_first,

--- a/include/boost/compute/algorithm/swap_ranges.hpp
+++ b/include/boost/compute/algorithm/swap_ranges.hpp
@@ -21,6 +21,8 @@ namespace compute {
 
 /// Swaps the elements in the range [\p first1, \p last1) with the
 /// elements in the range beginning at \p first2.
+///
+/// Space complexity: \Omega(distance(\p first1, \p last1))
 template<class Iterator1, class Iterator2>
 inline Iterator2 swap_ranges(Iterator1 first1,
                              Iterator1 last1,

--- a/include/boost/compute/algorithm/transform.hpp
+++ b/include/boost/compute/algorithm/transform.hpp
@@ -29,6 +29,8 @@ namespace compute {
 ///
 /// \snippet test/test_transform.cpp transform_abs
 ///
+/// Space complexity: \Omega(1)
+///
 /// \see copy()
 template<class InputIterator, class OutputIterator, class UnaryOperator>
 inline OutputIterator transform(InputIterator first,

--- a/include/boost/compute/algorithm/transform_if.hpp
+++ b/include/boost/compute/algorithm/transform_if.hpp
@@ -54,14 +54,12 @@ inline OutputIterator transform_if_impl(InputIterator first,
            << predicate(first[k1.get_global_id(0)]) << " ? 1 : 0;\n";
     k1.exec_1d(queue, 0, count);
 
-    // count number of elements to be copied
-    size_t copied_element_count =
-        ::boost::compute::count(indices.begin(), indices.end(), 1, queue);
-
     // scan indices
+    size_t copied_element_count = (indices.cend() - 1).read(queue);
     ::boost::compute::exclusive_scan(
         indices.begin(), indices.end(), indices.begin(), queue
     );
+    copied_element_count += (indices.cend() - 1).read(queue); // last scan element plus last mask element
 
     // copy values
     ::boost::compute::detail::meta_kernel k2("transform_if_do_copy");

--- a/include/boost/compute/algorithm/transform_if.hpp
+++ b/include/boost/compute/algorithm/transform_if.hpp
@@ -26,6 +26,7 @@ namespace boost {
 namespace compute {
 namespace detail {
 
+// Space complexity: O(2n)
 template<class InputIterator, class OutputIterator, class UnaryFunction, class Predicate>
 inline OutputIterator transform_if_impl(InputIterator first,
                                         InputIterator last,
@@ -98,6 +99,8 @@ inline discard_iterator transform_if_impl(InputIterator first,
 
 /// Copies each element in the range [\p first, \p last) for which
 /// \p predicate returns \c true to the range beginning at \p result.
+///
+/// Space complexity: O(2n)
 template<class InputIterator, class OutputIterator, class UnaryFunction, class Predicate>
 inline OutputIterator transform_if(InputIterator first,
                                    InputIterator last,

--- a/include/boost/compute/algorithm/transform_reduce.hpp
+++ b/include/boost/compute/algorithm/transform_reduce.hpp
@@ -30,6 +30,9 @@ namespace compute {
 ///
 /// \snippet test/test_transform_reduce.cpp sum_abs_int
 ///
+/// Space complexity on GPUs: \Omega(n)<br>
+/// Space complexity on CPUs: \Omega(1)
+///
 /// \see reduce(), inner_product()
 template<class InputIterator,
          class OutputIterator,

--- a/include/boost/compute/algorithm/unique.hpp
+++ b/include/boost/compute/algorithm/unique.hpp
@@ -31,6 +31,8 @@ namespace compute {
 ///
 /// \return \c InputIterator to the new logical end of the range
 ///
+/// Space complexity: \Omega(4n)
+///
 /// \see unique_copy()
 template<class InputIterator, class BinaryPredicate>
 inline InputIterator unique(InputIterator first,

--- a/include/boost/compute/algorithm/unique_copy.hpp
+++ b/include/boost/compute/algorithm/unique_copy.hpp
@@ -127,6 +127,8 @@ inline OutputIterator unique_copy(InputIterator first,
 ///
 /// \return \c OutputIterator to the end of the result range
 ///
+/// Space complexity: \Omega(4n)
+///
 /// \see unique()
 template<class InputIterator, class OutputIterator, class BinaryPredicate>
 inline OutputIterator unique_copy(InputIterator first,

--- a/include/boost/compute/algorithm/upper_bound.hpp
+++ b/include/boost/compute/algorithm/upper_bound.hpp
@@ -22,6 +22,8 @@ namespace compute {
 /// Returns an iterator pointing to the first element in the sorted
 /// range [\p first, \p last) that is not less than or equal to
 /// \p value.
+///
+/// Space complexity: \Omega(1)
 template<class InputIterator, class T>
 inline InputIterator
 upper_bound(InputIterator first,

--- a/include/boost/compute/command_queue.hpp
+++ b/include/boost/compute/command_queue.hpp
@@ -1511,7 +1511,10 @@ public:
     {
         BOOST_ASSERT(m_queue != 0);
 
-        clFlush(m_queue);
+        cl_int ret = clFlush(m_queue);
+        if(ret != CL_SUCCESS){
+            BOOST_THROW_EXCEPTION(opencl_error(ret));
+        }
     }
 
     /// Blocks until all outstanding commands in the queue have finished.
@@ -1521,7 +1524,10 @@ public:
     {
         BOOST_ASSERT(m_queue != 0);
 
-        clFinish(m_queue);
+        cl_int ret = clFinish(m_queue);
+        if(ret != CL_SUCCESS){
+            BOOST_THROW_EXCEPTION(opencl_error(ret));
+        }
     }
 
     /// Enqueues a barrier in the queue.

--- a/include/boost/compute/command_queue.hpp
+++ b/include/boost/compute/command_queue.hpp
@@ -81,6 +81,11 @@ public:
     enum properties {
         enable_profiling = CL_QUEUE_PROFILING_ENABLE,
         enable_out_of_order_execution = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE
+        #ifdef CL_VERSION_2_0
+        ,
+        on_device = CL_QUEUE_ON_DEVICE,
+        on_device_default = CL_QUEUE_ON_DEVICE_DEFAULT
+        #endif
     };
 
     enum map_flags {

--- a/include/boost/compute/detail/duration.hpp
+++ b/include/boost/compute/detail/duration.hpp
@@ -17,7 +17,9 @@
 #include <chrono>
 #endif
 
+#ifndef BOOST_COMPUTE_NO_BOOST_CHRONO
 #include <boost/chrono/duration.hpp>
+#endif
 
 namespace boost {
 namespace compute {
@@ -34,6 +36,7 @@ make_duration_from_nanoseconds(std::chrono::duration<Rep, Period>, size_t nanose
 }
 #endif // BOOST_COMPUTE_NO_HDR_CHRONO
 
+#ifndef BOOST_COMPUTE_NO_BOOST_CHRONO
 template<class Rep, class Period>
 inline boost::chrono::duration<Rep, Period>
 make_duration_from_nanoseconds(boost::chrono::duration<Rep, Period>, size_t nanoseconds)
@@ -42,6 +45,7 @@ make_duration_from_nanoseconds(boost::chrono::duration<Rep, Period>, size_t nano
         boost::chrono::nanoseconds(nanoseconds)
     );
 }
+#endif // BOOST_COMPUTE_NO_BOOST_CHRONO
 
 } // end detail namespace
 } // end compute namespace

--- a/include/boost/compute/iterator/buffer_iterator.hpp
+++ b/include/boost/compute/iterator/buffer_iterator.hpp
@@ -58,11 +58,18 @@ struct buffer_iterator_index_expr
                                size_t index,
                                const memory_object::address_space address_space,
                                const IndexExpr &expr)
-        : m_buffer(buffer),
+        : m_buffer(buffer.get(), false),
           m_index(index),
           m_address_space(address_space),
           m_expr(expr)
     {
+    }
+
+    ~buffer_iterator_index_expr()
+    {
+        // set buffer to null so that its reference count will
+        // not be decremented when its destructor is called
+        m_buffer.get() = 0;
     }
 
     operator T() const
@@ -73,10 +80,10 @@ struct buffer_iterator_index_expr
         return buffer_value<T>(m_buffer, size_t(m_expr) * sizeof(T));
     }
 
-    const buffer &m_buffer;
-    size_t m_index;
-    memory_object::address_space m_address_space;
-    IndexExpr m_expr;
+    const buffer m_buffer;
+    const size_t m_index;
+    const memory_object::address_space m_address_space;
+    const IndexExpr m_expr;
 };
 
 template<class T, class IndexExpr>

--- a/include/boost/compute/iterator/counting_iterator.hpp
+++ b/include/boost/compute/iterator/counting_iterator.hpp
@@ -47,14 +47,14 @@ struct counting_iterator_index_expr
 {
     typedef T result_type;
 
-    counting_iterator_index_expr(const T &init, const IndexExpr &expr)
+    counting_iterator_index_expr(const T init, const IndexExpr &expr)
         : m_init(init),
           m_expr(expr)
     {
     }
 
-    const T &m_init;
-    IndexExpr m_expr;
+    const T m_init;
+    const IndexExpr m_expr;
 };
 
 template<class T, class IndexExpr>

--- a/include/boost/compute/iterator/function_input_iterator.hpp
+++ b/include/boost/compute/iterator/function_input_iterator.hpp
@@ -53,7 +53,7 @@ struct function_input_iterator_expr
     {
     }
 
-    Function m_function;
+    const Function m_function;
 };
 
 template<class Function>

--- a/include/boost/compute/iterator/permutation_iterator.hpp
+++ b/include/boost/compute/iterator/permutation_iterator.hpp
@@ -60,9 +60,9 @@ struct permutation_iterator_access_expr
     {
     }
 
-    ElementIterator m_element_iter;
-    IndexIterator m_index_iter;
-    IndexExpr m_expr;
+    const ElementIterator m_element_iter;
+    const IndexIterator m_index_iter;
+    const IndexExpr m_expr;
 };
 
 template<class ElementIterator, class IndexIterator, class IndexExpr>

--- a/include/boost/compute/iterator/strided_iterator.hpp
+++ b/include/boost/compute/iterator/strided_iterator.hpp
@@ -56,8 +56,8 @@ struct stride_expr
     {
     }
 
-    IndexExpr m_index_expr;
-    Stride m_stride;
+    const IndexExpr m_index_expr;
+    const Stride m_stride;
 };
 
 template<class IndexExpr, class Stride>
@@ -90,9 +90,9 @@ struct strided_iterator_index_expr
     {
     }
 
-    Iterator m_input_iter;
-    const Stride& m_stride;
-    IndexExpr m_index_expr;
+    const Iterator m_input_iter;
+    const Stride m_stride;
+    const IndexExpr m_index_expr;
 };
 
 template<class Iterator, class Stride, class IndexExpr>

--- a/include/boost/compute/iterator/transform_iterator.hpp
+++ b/include/boost/compute/iterator/transform_iterator.hpp
@@ -76,9 +76,9 @@ struct transform_iterator_index_expr
     {
     }
 
-    InputIterator m_input_iter;
-    UnaryFunction m_transform_expr;
-    IndexExpr m_index_expr;
+    const InputIterator m_input_iter;
+    const UnaryFunction m_transform_expr;
+    const IndexExpr m_index_expr;
 };
 
 template<class InputIterator, class UnaryFunction, class IndexExpr>

--- a/include/boost/compute/iterator/zip_iterator.hpp
+++ b/include/boost/compute/iterator/zip_iterator.hpp
@@ -92,8 +92,8 @@ struct zip_iterator_index_expr
     {
     }
 
-    IteratorTuple m_iterators;
-    IndexExpr m_index_expr;
+    const IteratorTuple m_iterators;
+    const IndexExpr m_index_expr;
 };
 
 /// \internal_

--- a/include/boost/compute/lambda/functional.hpp
+++ b/include/boost/compute/lambda/functional.hpp
@@ -22,6 +22,11 @@
 #include <boost/compute/lambda/result_of.hpp>
 #include <boost/compute/lambda/placeholder.hpp>
 
+#include <boost/compute/types/fundamental.hpp>
+#include <boost/compute/type_traits/scalar_type.hpp>
+#include <boost/compute/type_traits/vector_size.hpp>
+#include <boost/compute/type_traits/make_vector_type.hpp>
+
 namespace boost {
 namespace compute {
 namespace lambda {
@@ -29,7 +34,8 @@ namespace lambda {
 namespace mpl = boost::mpl;
 namespace proto = boost::proto;
 
-// wraps a unary boolean function
+// wraps a unary boolean function whose result type is an int_ when the argument
+// type is a scalar, and intN_ if the argument type is a vector of size N
 #define BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_UNARY_FUNCTION(name) \
     namespace detail { \
         struct BOOST_PP_CAT(name, _func) \
@@ -37,7 +43,12 @@ namespace proto = boost::proto;
             template<class Expr, class Args> \
             struct lambda_result \
             { \
-                typedef int type; \
+                typedef typename proto::result_of::child_c<Expr, 1>::type Arg; \
+                typedef typename ::boost::compute::lambda::result_of<Arg, Args>::type result_type; \
+                typedef typename ::boost::compute::make_vector_type< \
+                    ::boost::compute::int_, \
+                    ::boost::compute::vector_size<result_type>::value \
+                >::type type; \
             }; \
             \
             template<class Context, class Arg> \
@@ -60,7 +71,7 @@ namespace proto = boost::proto;
         ); \
     }
 
-// wraps a unary function who's return type is the same as the argument type
+// wraps a unary function whose return type is the same as the argument type
 #define BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(name) \
     namespace detail { \
         struct BOOST_PP_CAT(name, _func) \
@@ -92,7 +103,79 @@ namespace proto = boost::proto;
         ); \
     }
 
-// wraps a binary function
+// wraps a unary function whose result type is the scalar type of the first argument
+#define BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_ST(name) \
+    namespace detail { \
+        struct BOOST_PP_CAT(name, _func) \
+        { \
+            template<class Expr, class Args> \
+            struct lambda_result \
+            { \
+                typedef typename proto::result_of::child_c<Expr, 1>::type Arg; \
+                typedef typename ::boost::compute::lambda::result_of<Arg, Args>::type result_type; \
+                typedef typename ::boost::compute::scalar_type<result_type>::type type; \
+            }; \
+            \
+            template<class Context, class Arg> \
+            static void apply(Context &ctx, const Arg &arg) \
+            { \
+                ctx.stream << #name << "("; \
+                proto::eval(arg, ctx); \
+                ctx.stream << ")"; \
+            } \
+        }; \
+    } \
+    template<class Arg> \
+    inline typename proto::result_of::make_expr< \
+        proto::tag::function, BOOST_PP_CAT(detail::name, _func), const Arg& \
+    >::type const \
+    name(const Arg &arg) \
+    { \
+        return proto::make_expr<proto::tag::function>( \
+            BOOST_PP_CAT(detail::name, _func)(), ::boost::ref(arg) \
+        ); \
+    }
+
+// wraps a binary boolean function whose result type is an int_ when the first
+// argument type is a scalar, and intN_ if the first argument type is a vector
+// of size N
+#define BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_BINARY_FUNCTION(name) \
+    namespace detail { \
+        struct BOOST_PP_CAT(name, _func) \
+        { \
+            template<class Expr, class Args> \
+            struct lambda_result \
+            { \
+                typedef typename proto::result_of::child_c<Expr, 1>::type Arg1; \
+                typedef typename ::boost::compute::make_vector_type< \
+                    ::boost::compute::int_, \
+                    ::boost::compute::vector_size<Arg1>::value \
+                >::type type; \
+            }; \
+            \
+            template<class Context, class Arg1, class Arg2> \
+            static void apply(Context &ctx, const Arg1 &arg1, const Arg2 &arg2) \
+            { \
+                ctx.stream << #name << "("; \
+                proto::eval(arg1, ctx); \
+                ctx.stream << ", "; \
+                proto::eval(arg2, ctx); \
+                ctx.stream << ")"; \
+            } \
+        }; \
+    } \
+    template<class Arg1, class Arg2> \
+    inline typename proto::result_of::make_expr< \
+        proto::tag::function, BOOST_PP_CAT(detail::name, _func), const Arg1&, const Arg2& \
+    >::type const \
+    name(const Arg1 &arg1, const Arg2 &arg2) \
+    { \
+        return proto::make_expr<proto::tag::function>( \
+            BOOST_PP_CAT(detail::name, _func)(), ::boost::ref(arg1), ::boost::ref(arg2) \
+        ); \
+    }
+
+// wraps a binary function whose result type is the type of the first argument
 #define BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(name) \
     namespace detail { \
         struct BOOST_PP_CAT(name, _func) \
@@ -102,6 +185,40 @@ namespace proto = boost::proto;
             { \
                 typedef typename proto::result_of::child_c<Expr, 1>::type Arg1; \
                 typedef typename ::boost::compute::lambda::result_of<Arg1, Args>::type type; \
+            }; \
+            \
+            template<class Context, class Arg1, class Arg2> \
+            static void apply(Context &ctx, const Arg1 &arg1, const Arg2 &arg2) \
+            { \
+                ctx.stream << #name << "("; \
+                proto::eval(arg1, ctx); \
+                ctx.stream << ", "; \
+                proto::eval(arg2, ctx); \
+                ctx.stream << ")"; \
+            } \
+        }; \
+    } \
+    template<class Arg1, class Arg2> \
+    inline typename proto::result_of::make_expr< \
+        proto::tag::function, BOOST_PP_CAT(detail::name, _func), const Arg1&, const Arg2& \
+    >::type const \
+    name(const Arg1 &arg1, const Arg2 &arg2) \
+    { \
+        return proto::make_expr<proto::tag::function>( \
+            BOOST_PP_CAT(detail::name, _func)(), ::boost::ref(arg1), ::boost::ref(arg2) \
+        ); \
+    }
+
+// wraps a binary function whose result type is the type of the second argument
+#define BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION_2(name) \
+    namespace detail { \
+        struct BOOST_PP_CAT(name, _func) \
+        { \
+            template<class Expr, class Args> \
+            struct lambda_result \
+            { \
+                typedef typename proto::result_of::child_c<Expr, 2>::type Arg2; \
+                typedef typename ::boost::compute::lambda::result_of<Arg2, Args>::type type; \
             }; \
             \
             template<class Context, class Arg1, class Arg2> \
@@ -161,6 +278,41 @@ namespace proto = boost::proto;
         ); \
     }
 
+// wraps a binary function whose result type is the type of the first argument
+// and the second argument is a pointer
+#define BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION_PTR(name) \
+    namespace detail { \
+        struct BOOST_PP_CAT(name, _func) \
+        { \
+            template<class Expr, class Args> \
+            struct lambda_result \
+            { \
+                typedef typename proto::result_of::child_c<Expr, 1>::type Arg1; \
+                typedef typename ::boost::compute::lambda::result_of<Arg1, Args>::type type; \
+            }; \
+            \
+            template<class Context, class Arg1, class Arg2> \
+            static void apply(Context &ctx, const Arg1 &arg1, const Arg2 &arg2) \
+            { \
+                ctx.stream << #name << "("; \
+                proto::eval(arg1, ctx); \
+                ctx.stream << ", &"; \
+                proto::eval(arg2, ctx); \
+                ctx.stream << ")"; \
+            } \
+        }; \
+    } \
+    template<class Arg1, class Arg2> \
+    inline typename proto::result_of::make_expr< \
+        proto::tag::function, BOOST_PP_CAT(detail::name, _func), const Arg1&, const Arg2& \
+    >::type const \
+    name(const Arg1 &arg1, const Arg2 &arg2) \
+    { \
+        return proto::make_expr<proto::tag::function>( \
+            BOOST_PP_CAT(detail::name, _func)(), ::boost::ref(arg1), ::boost::ref(arg2) \
+        ); \
+    }
+
 // wraps a ternary function
 #define BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(name) \
     namespace detail { \
@@ -197,43 +349,246 @@ namespace proto = boost::proto;
         ); \
     }
 
+// wraps a ternary function whose result type is the type of the third argument
+#define BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION_3(name) \
+    namespace detail { \
+        struct BOOST_PP_CAT(name, _func) \
+        { \
+            template<class Expr, class Args> \
+            struct lambda_result \
+            { \
+                typedef typename proto::result_of::child_c<Expr, 3>::type Arg3; \
+                typedef typename ::boost::compute::lambda::result_of<Arg3, Args>::type type; \
+            }; \
+            \
+            template<class Context, class Arg1, class Arg2, class Arg3> \
+            static void apply(Context &ctx, const Arg1 &arg1, const Arg2 &arg2, const Arg3 &arg3) \
+            { \
+                ctx.stream << #name << "("; \
+                proto::eval(arg1, ctx); \
+                ctx.stream << ", "; \
+                proto::eval(arg2, ctx); \
+                ctx.stream << ", "; \
+                proto::eval(arg3, ctx); \
+                ctx.stream << ")"; \
+            } \
+        }; \
+    } \
+    template<class Arg1, class Arg2, class Arg3> \
+    inline typename proto::result_of::make_expr< \
+        proto::tag::function, BOOST_PP_CAT(detail::name, _func), const Arg1&, const Arg2&, const Arg3& \
+    >::type const \
+    name(const Arg1 &arg1, const Arg2 &arg2, const Arg3 &arg3) \
+    { \
+        return proto::make_expr<proto::tag::function>( \
+            BOOST_PP_CAT(detail::name, _func)(), ::boost::ref(arg1), ::boost::ref(arg2), ::boost::ref(arg3) \
+        ); \
+    }
 
-BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_UNARY_FUNCTION(all)
-BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_UNARY_FUNCTION(any)
-BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_UNARY_FUNCTION(isinf)
-BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_UNARY_FUNCTION(isnan)
-BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_UNARY_FUNCTION(isfinite)
+// wraps a ternary function whose result type is the type of the first argument
+// and the third argument of the function is a pointer
+#define BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION_PTR(name) \
+    namespace detail { \
+        struct BOOST_PP_CAT(name, _func) \
+        { \
+            template<class Expr, class Args> \
+            struct lambda_result \
+            { \
+                typedef typename proto::result_of::child_c<Expr, 3>::type Arg3; \
+                typedef typename ::boost::compute::lambda::result_of<Arg3, Args>::type type; \
+            }; \
+            \
+            template<class Context, class Arg1, class Arg2, class Arg3> \
+            static void apply(Context &ctx, const Arg1 &arg1, const Arg2 &arg2, const Arg3 &arg3) \
+            { \
+                ctx.stream << #name << "("; \
+                proto::eval(arg1, ctx); \
+                ctx.stream << ", "; \
+                proto::eval(arg2, ctx); \
+                ctx.stream << ", &"; \
+                proto::eval(arg3, ctx); \
+                ctx.stream << ")"; \
+            } \
+        }; \
+    } \
+    template<class Arg1, class Arg2, class Arg3> \
+    inline typename proto::result_of::make_expr< \
+        proto::tag::function, BOOST_PP_CAT(detail::name, _func), const Arg1&, const Arg2&, const Arg3& \
+    >::type const \
+    name(const Arg1 &arg1, const Arg2 &arg2, const Arg3 &arg3) \
+    { \
+        return proto::make_expr<proto::tag::function>( \
+            BOOST_PP_CAT(detail::name, _func)(), ::boost::ref(arg1), ::boost::ref(arg2), ::boost::ref(arg3) \
+        ); \
+    }
 
+// Common Built-In Functions
+BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(clamp)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(degrees)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(min)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(max)
+BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(mix)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(radians)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(sign)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION_2(step)
+BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION_3(smoothstep)
+
+// Geometric Built-In Functions
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(cross)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION_ST(dot)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION_ST(distance)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_ST(length)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(normalize)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION_ST(fast_distance)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_ST(fast_length)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(fast_normalize)
+
+// Integer Built-In Functions
 BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(abs)
-BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(cos)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(abs_diff)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(add_sat)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(hadd)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(rhadd)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(clz)
+#ifdef CL_VERSION_2_0
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(ctz)
+#endif
+// clamp() (since 1.1) already defined in common
+BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(mad_hi)
+BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(mad24)
+BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(mad_sat)
+// max() and min() functions are defined in common
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(mul_hi)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(mul24)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(rotate)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(sub_sat)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(upsample)
+#ifdef CL_VERSION_1_2
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(popcount)
+#endif
+
+// Math Built-In Functions
 BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(acos)
-BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(sin)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(acosh)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(acospi)
 BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(asin)
-BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(tan)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(asinh)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(asinpi)
 BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(atan)
-BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(sqrt)
-BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(rsqrt)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(atan2)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(atanh)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(atanpi)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(atan2pi)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(cbrt)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(ceil)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(copysign)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(cos)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(cosh)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(cospi)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(erfc)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(erf)
 BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(exp)
 BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(exp2)
 BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(exp10)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(expm1)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(fabs)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(fdim)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(floor)
+BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(fma)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(fmax)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(fmin)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(fmod)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION_PTR(fract)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION_PTR(frexp)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(hypot)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_BINARY_FUNCTION(ilogb) // ilogb returns intN_
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(ldexp)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(lgamma)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION_PTR(lgamma_r)
 BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(log)
 BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(log2)
 BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(log10)
-BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(round)
-BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(length)
-
-BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(cross)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(log1p)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(logb)
+BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(mad)
+#ifdef CL_VERSION_1_1
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(maxmag)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(minmag)
+#endif
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION_PTR(modf)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(nan)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(nextafter)
 BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(pow)
 BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(pown)
 BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(powr)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(remainder)
+BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION_PTR(remquo)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(rint)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(rootn)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(round)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(rsqrt)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(sin)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(sincos)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(sinh)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(sinpi)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(sqrt)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(tan)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(tanh)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(tanpi)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(tgamma)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(trunc)
 
-BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION_ST(dot)
-BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION_ST(distance)
+// Native Math Built-In Functions
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(native_cos)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(native_divide)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(native_exp)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(native_exp2)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(native_exp10)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(native_log)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(native_log2)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(native_log10)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(native_powr)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(native_recip)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(native_rsqrt)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(native_sin)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(native_sqrt)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(native_tan)
 
-BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(clamp)
-BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(fma)
-BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(mad)
-BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(smoothstep)
+// Half Math Built-In Functions
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(half_cos)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(half_divide)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(half_exp)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(half_exp2)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(half_exp10)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(half_log)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(half_log2)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(half_log10)
+BOOST_COMPUTE_LAMBDA_WRAP_BINARY_FUNCTION(half_powr)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(half_recip)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(half_rsqrt)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(half_sin)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(half_sqrt)
+BOOST_COMPUTE_LAMBDA_WRAP_UNARY_FUNCTION_T(half_tan)
+
+// Relational Built-In Functions
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_BINARY_FUNCTION(isequal)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_BINARY_FUNCTION(isnotequal)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_BINARY_FUNCTION(isgreater)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_BINARY_FUNCTION(isgreaterequal)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_BINARY_FUNCTION(isless)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_BINARY_FUNCTION(islessequal)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_BINARY_FUNCTION(islessgreater)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_UNARY_FUNCTION(isfinite)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_UNARY_FUNCTION(isinf)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_UNARY_FUNCTION(isnan)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_UNARY_FUNCTION(isnormal)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_BINARY_FUNCTION(isordered)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_BINARY_FUNCTION(isunordered)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_UNARY_FUNCTION(singbit)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_UNARY_FUNCTION(all)
+BOOST_COMPUTE_LAMBDA_WRAP_BOOLEAN_UNARY_FUNCTION(any)
+BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(bitselect)
+BOOST_COMPUTE_LAMBDA_WRAP_TERNARY_FUNCTION(select)
 
 } // end lambda namespace
 } // end compute namespace

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -6,6 +6,9 @@ import testing ;
 
 lib boost_unit_test_framework ;
 
+compile check/has_opencl.cpp : : has_opencl ;
+explicit has_opencl ;
+
 project
     : source-location .
     : requirements
@@ -19,6 +22,8 @@ project
         <toolset>msvc:<cxxflags>/wd4800 # Warning C4800: 'uint32_t' : forcing value to bool 'true' or 'false' (performance warning)
         <toolset>msvc:<cxxflags>/wd4838 # Warning C4838: conversion from 'double' to 'float' requires a narrowing conversion
         <library>/boost/test//boost_unit_test_framework
+
+        [ check-target-builds has_opencl "OpenCL" : : <build>no ]
     ;
 
 rule test_all

--- a/test/check/has_opencl.cpp
+++ b/test/check/has_opencl.cpp
@@ -1,0 +1,11 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2017 Kohei Takahashi
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <boost/compute/cl.hpp>

--- a/test/check_macros.hpp
+++ b/test/check_macros.hpp
@@ -30,6 +30,38 @@
         ); \
     }
 
+template <typename Left, typename Right, typename ToleranceBaseType>
+inline void
+equal_close_impl(Left left_begin,
+                 Left left_end,
+                 Right right_begin,
+                 Right right_end,
+                 ToleranceBaseType tolerance)
+{
+    for(; left_begin != (left_end); ++left_begin, ++right_begin) {
+        BOOST_CHECK_CLOSE(*left_begin, *right_begin, tolerance); \
+    }
+}
+
+#define BOOST_COMPUTE_TEST_CHECK_CLOSE_COLLECTIONS(L_begin, L_end, R_begin, R_end, tolerance) \
+    { \
+        equal_close_impl(L_begin, L_end, R_begin, R_end, tolerance); \
+    }
+
+#define CHECK_RANGE_CLOSE(type, size, actual, expected, tolerance) \
+    { \
+        type _actual[size]; \
+        boost::compute::copy( \
+            actual.begin(), actual.begin()+size, _actual, queue \
+        ); \
+        const type _expected[size] = { \
+            BOOST_PP_REPEAT(size, LIST_ARRAY_VALUES, (size, expected)) \
+        }; \
+        BOOST_COMPUTE_TEST_CHECK_CLOSE_COLLECTIONS( \
+            _actual, _actual + size, _expected, _expected + size, tolerance \
+        ); \
+    }
+
 #define CHECK_HOST_RANGE_EQUAL(type, size, actual, expected) \
     { \
         const type _expected[size] = { \

--- a/test/quirks.hpp
+++ b/test/quirks.hpp
@@ -83,6 +83,16 @@ inline bool supports_image_samplers(const boost::compute::device &device)
     return true;
 }
 
+// returns true if the device has remquo() built-in OpenCL function implementation
+inline bool has_remquo_func(const boost::compute::device &device)
+{
+    // POCL does not have it
+    if(is_pocl_device(device)){
+        return false;
+    }
+    return true;
+}
+
 // returns true if the device supports clSetMemObjectDestructorCallback
 inline bool supports_destructor_callback(const boost::compute::device &device)
 {


### PR DESCRIPTION
Hello,
The problem with OpenCL is that there is no complete library compared to cuda where all libraries like cufft and cublas are installed by default,  but with OpenCL  we have to search equivalent libraries and try to figure out a way to link them with other libraries we may use in the same program. I think that compute boost is a good apportunity  to create a full library cuda-like. Libraries like Arrayfire are not standard and dont give full control as in native OpenCL c/c++ program without lose of performance.
So can please you add wrapper "boost-like" of those libraries clfft clblas clsparse , clrand and maybe cl deep learning if that exist, where the programming is a kind unified under the boost model.
sorry for my english and thank you if you still red till here 