### PR TITLE
Check opencl availability on test.

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -6,6 +6,9 @@ import testing ;
 
 lib boost_unit_test_framework ;
 
+compile check/has_opencl.cpp : : has_opencl ;
+explicit has_opencl ;
+
 project
     : source-location .
     : requirements
@@ -19,6 +22,8 @@ project
         <toolset>msvc:<cxxflags>/wd4800 # Warning C4800: 'uint32_t' : forcing value to bool 'true' or 'false' (performance warning)
         <toolset>msvc:<cxxflags>/wd4838 # Warning C4838: conversion from 'double' to 'float' requires a narrowing conversion
         <library>/boost/test//boost_unit_test_framework
+
+        [ check-target-builds has_opencl "OpenCL" : : <build>no ]
     ;
 
 rule test_all

--- a/test/check/has_opencl.cpp
+++ b/test/check/has_opencl.cpp
@@ -1,0 +1,11 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2017 Kohei Takahashi
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#include <boost/compute/cl.hpp>


### PR DESCRIPTION
This change avoids massive of test failure that's caused by no opencl env.