### PR TITLE
Handle errors from clFlush and clFinish

### DIFF
--- a/include/boost/compute/command_queue.hpp
+++ b/include/boost/compute/command_queue.hpp
@@ -1511,7 +1511,12 @@ public:
     {
         BOOST_ASSERT(m_queue != 0);
 
-        clFlush(m_queue);
+        cl_int ret = CL_SUCCESS;
+        ret = clFlush(m_queue);
+
+        if (ret != CL_SUCCESS) {
+            BOOST_THROW_EXCEPTION(opencl_error(ret));
+        }
     }
 
     /// Blocks until all outstanding commands in the queue have finished.
@@ -1521,7 +1526,12 @@ public:
     {
         BOOST_ASSERT(m_queue != 0);
 
-        clFinish(m_queue);
+        cl_int ret = CL_SUCCESS;
+        ret = clFinish(m_queue);
+
+        if (ret != CL_SUCCESS) {
+            BOOST_THROW_EXCEPTION(opencl_error(ret));
+        }
     }
 
     /// Enqueues a barrier in the queue.


### PR DESCRIPTION
This functions can return errors such CL_INVALID_COMMAND_QUEUE and CL_OUT_OF_RESOURCES.