### PR TITLE
Various fixes

### DIFF
--- a/include/boost/compute/detail/meta_kernel.hpp
+++ b/include/boost/compute/detail/meta_kernel.hpp
@@ -1072,7 +1072,7 @@ inline meta_kernel& operator<<(meta_kernel &kernel,
     BOOST_STATIC_ASSERT(N < 16);
 
     if(N < 10){
-        return kernel << expr.m_arg << ".s" << uint_(N);
+        return kernel << expr.m_arg << ".s" << int_(N);
     }
     else if(N < 16){
 #ifdef _MSC_VER

--- a/include/boost/compute/lambda/context.hpp
+++ b/include/boost/compute/lambda/context.hpp
@@ -78,6 +78,41 @@ struct context : proto::callable_context<context<Args> >
         stream << stream.lit(x);
     }
 
+    void operator()(proto::tag::terminal, const uchar_ &x)
+    {
+        stream << "(uchar)(" << stream.lit(uint_(x)) << "u)";
+    } 
+
+    void operator()(proto::tag::terminal, const char_ &x)
+    {
+        stream << "(char)(" << stream.lit(int_(x)) << ")";
+    } 
+
+    void operator()(proto::tag::terminal, const ushort_ &x)
+    {
+        stream << "(ushort)(" << stream.lit(x) << "u)";
+    } 
+
+    void operator()(proto::tag::terminal, const short_ &x)
+    {
+        stream << "(short)(" << stream.lit(x) << ")";
+    } 
+
+    void operator()(proto::tag::terminal, const uint_ &x)
+    {
+        stream << "(" << stream.lit(x) << "u)";
+    } 
+
+    void operator()(proto::tag::terminal, const ulong_ &x)
+    {
+        stream << "(" << stream.lit(x) << "ul)";
+    } 
+
+    void operator()(proto::tag::terminal, const long_ &x)
+    {
+        stream << "(" << stream.lit(x) << "l)";
+    } 
+
     // handle placeholders
     template<int I>
     void operator()(proto::tag::terminal, placeholder<I>)

--- a/include/boost/compute/types/tuple.hpp
+++ b/include/boost/compute/types/tuple.hpp
@@ -206,7 +206,7 @@ inline meta_kernel& operator<<(meta_kernel &kernel,                            \
     typedef typename boost::tuple<BOOST_PP_ENUM_PARAMS(n, T)> T;               \
     BOOST_STATIC_ASSERT(N < size_t(boost::tuples::length<T>::value));          \
     kernel.inject_type<T>();                                                   \
-    return kernel << expr.m_arg << ".v" << uint_(N);                           \
+    return kernel << expr.m_arg << ".v" << int_(N);                           \
 }
 
 BOOST_PP_REPEAT_FROM_TO(1, BOOST_COMPUTE_MAX_ARITY, BOOST_COMPUTE_GET_N, ~)

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -109,15 +109,20 @@ BOOST_AUTO_TEST_CASE(clone_buffer)
     BOOST_CHECK(buffer1.get_memory_flags() == buffer2.get_memory_flags());
 }
 
+#ifdef BOOST_COMPUTE_USE_CPP11
 #ifdef CL_VERSION_1_1
+std::mutex callback_mutex;
+std::condition_variable callback_condition_variable;
+
 static void BOOST_COMPUTE_CL_CALLBACK
-destructor_callback_function(cl_mem memobj, void *user_data)
+destructor_callback_function(cl_mem, void *user_data)
 {
-    (void) memobj;
+    std::lock_guard<std::mutex> lock(callback_mutex);
 
     bool *flag = static_cast<bool *>(user_data);
-
     *flag = true;
+
+    callback_condition_variable.notify_one();
 }
 
 BOOST_AUTO_TEST_CASE(destructor_callback)
@@ -134,13 +139,13 @@ BOOST_AUTO_TEST_CASE(destructor_callback)
         boost::compute::buffer buf(context, 128);
         buf.set_destructor_callback(destructor_callback_function, &invoked);
     }
+
+    std::unique_lock<std::mutex> lock(callback_mutex);
+    callback_condition_variable.wait_for(
+        lock, std::chrono::seconds(1), [&](){ return invoked; }
+    );
     BOOST_CHECK(invoked == true);
 }
-
-#ifdef BOOST_COMPUTE_USE_CPP11
-
-std::mutex callback_mutex;
-std::condition_variable callback_condition_variable;
 
 static void BOOST_COMPUTE_CL_CALLBACK
 destructor_templated_callback_function(bool *flag)

--- a/test/test_lambda.cpp
+++ b/test/test_lambda.cpp
@@ -546,4 +546,72 @@ BOOST_AUTO_TEST_CASE(bind_lambda_function)
     CHECK_RANGE_EQUAL(int, 4, vector, (2, 4, 6, 8));
 }
 
+BOOST_AUTO_TEST_CASE(lambda_function_with_uint_args)
+{
+  compute::uint_ host_data[] = { 1, 3, 5, 7, 9 };
+  compute::vector<compute::uint_> device_vector(host_data, host_data + 5, queue);
+
+  using boost::compute::lambda::clamp;
+  using compute::lambda::_1;
+
+  compute::transform(
+    device_vector.begin(), device_vector.end(),
+    device_vector.begin(),
+    clamp(_1, compute::uint_(4), compute::uint_(6)),
+    queue
+  );
+  CHECK_RANGE_EQUAL(compute::uint_, 5, device_vector, (4, 4, 5, 6, 6));
+}
+
+BOOST_AUTO_TEST_CASE(lambda_function_with_short_args)
+{
+  compute::short_ host_data[] = { 1, 3, 5, 7, 9 };
+  compute::vector<compute::short_> device_vector(host_data, host_data + 5, queue);
+
+  using boost::compute::lambda::clamp;
+  using compute::lambda::_1;
+
+  compute::transform(
+    device_vector.begin(), device_vector.end(),
+    device_vector.begin(),
+    clamp(_1, compute::short_(4), compute::short_(6)),
+    queue
+  );
+  CHECK_RANGE_EQUAL(compute::short_, 5, device_vector, (4, 4, 5, 6, 6));
+}
+
+BOOST_AUTO_TEST_CASE(lambda_function_with_uchar_args)
+{
+  compute::uchar_ host_data[] = { 1, 3, 5, 7, 9 };
+  compute::vector<compute::uchar_> device_vector(host_data, host_data + 5, queue);
+
+  using boost::compute::lambda::clamp;
+  using compute::lambda::_1;
+
+  compute::transform(
+    device_vector.begin(), device_vector.end(),
+    device_vector.begin(),
+    clamp(_1, compute::uchar_(4), compute::uchar_(6)),
+    queue
+  );
+  CHECK_RANGE_EQUAL(compute::uchar_, 5, device_vector, (4, 4, 5, 6, 6));
+}
+
+BOOST_AUTO_TEST_CASE(lambda_function_with_char_args)
+{
+  compute::char_ host_data[] = { 1, 3, 5, 7, 9 };
+  compute::vector<compute::char_> device_vector(host_data, host_data + 5, queue);
+
+  using boost::compute::lambda::clamp;
+  using compute::lambda::_1;
+
+  compute::transform(
+    device_vector.begin(), device_vector.end(),
+    device_vector.begin(),
+    clamp(_1, compute::char_(4), compute::char_(6)),
+    queue
+  );
+  CHECK_RANGE_EQUAL(compute::char_, 5, device_vector, (4, 4, 5, 6, 6));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
* Fixes https://github.com/boostorg/compute/issues/683 - variable type is kept when using it in `boost::compute::lambda`. I decided that for now it's better not to change `operator<<` operators for `detail::meta_kernel` as was proposed in https://github.com/boostorg/compute/pull/684. Instead, I specialised `void operator()(proto::tag::terminal, const T &x)` in `lambda::context`.
* Remove race conditions from test in `test_async_wait_guard.cpp` and from test `destructor_callback` in `test_buffer.hpp`