### PR TITLE
fix SHA1 hash in build_with_source()

### DIFF
--- a/include/boost/compute/program.hpp
+++ b/include/boost/compute/program.hpp
@@ -543,10 +543,11 @@ public:
             .process( options     )
             .process( source      )
             ;
+        std::string hash_string = hash;
 
         // Try to get cached program binaries:
         try {
-            boost::optional<program> prog = load_program_binary(hash, context);
+            boost::optional<program> prog = load_program_binary(hash_string, context);
 
             if (prog) {
                 prog->build(options);
@@ -575,7 +576,7 @@ public:
 
 #ifdef BOOST_COMPUTE_USE_OFFLINE_CACHE
         // Save program binaries for future reuse.
-        save_program_binary(hash, prog);
+        save_program_binary(hash_string, prog);
 #endif
 
         return prog;


### PR DESCRIPTION
In build_with_source(), when BOOST_COMPUTE_USE_OFFLINE_CACHE is set, we use boost::uuids::detail::sha1 to compute the SHA1 of the program source, options, etc, and use it as the unique key to manage cached objects.

When the hash is converted to a string and passed to load_program_binary() and save_program_binary(), the conversion function of object detail::sha1 is called, which then calls  boost::uuids::detail::sha1::get_digest(). If you take a look at http://www.boost.org/doc/libs/1_63_0/boost/uuid/sha1.hpp, the sha1::get_digest() function actually appends some bytes to the string each time called. Thus, each time when we call get_digest() we get a different SHA1. 

Thus, the hash string used as the parameter to load_program_binary() and save_program_binary() are always different, because the string conversion function is called twice. This effectively disables the offline cache as the two hashes are always different.

My patch fixes this issue by converting the SHA1 to string only once, and use the same string for  load_program_binary() and save_program_binary().
