### PR TITLE
Use 'obj' rule instead of 'compile' in opencl availability test.

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -6,7 +6,7 @@ import testing ;
 
 lib boost_unit_test_framework ;
 
-compile check/has_opencl.cpp : : has_opencl ;
+obj has_opencl : check/has_opencl.cpp ;
 explicit has_opencl ;
 
 project


### PR DESCRIPTION
The use of 'compile' rule interferes with --dump-tests option of b2 and prevents correct running of tests in some of the other Boost libraries.

See discussion: http://boost.2283326.n4.nabble.com/build-geometry-regression-Geometry-develop-regression-tests-are-blank-td4693186.html