### PR TITLE
Fix for #484

### DIFF
--- a/test/test_command_queue.cpp
+++ b/test/test_command_queue.cpp
@@ -261,6 +261,7 @@ BOOST_AUTO_TEST_CASE(copy_with_wait_list)
     CHECK_HOST_RANGE_EQUAL(int, 4, data2, (1, 3, 5, 7));
 }
 
+#ifndef BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
 BOOST_AUTO_TEST_CASE(enqueue_kernel_with_extents)
 {
     using boost::compute::dim;
@@ -311,5 +312,6 @@ BOOST_AUTO_TEST_CASE(enqueue_kernel_with_extents)
     CHECK_RANGE_EQUAL(int, 4, output1, (0, 1, 0, 1));
     CHECK_RANGE_EQUAL(int, 4, output2, (0, 1, 0, 1));
 }
+#endif // BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_extents.cpp
+++ b/test/test_extents.cpp
@@ -21,6 +21,7 @@
 
 namespace compute = boost::compute;
 
+#ifndef BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
 BOOST_AUTO_TEST_CASE(initialize)
 {
     compute::extents<1> one(1);
@@ -31,6 +32,7 @@ BOOST_AUTO_TEST_CASE(initialize)
     BOOST_CHECK_EQUAL(xyz[1], size_t(2));
     BOOST_CHECK_EQUAL(xyz[2], size_t(3));
 }
+#endif
 
 BOOST_AUTO_TEST_CASE(size)
 {
@@ -54,6 +56,7 @@ BOOST_AUTO_TEST_CASE(subscript_operator)
     BOOST_CHECK_EQUAL(xyz[2], size_t(30));
 }
 
+#ifndef BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
 BOOST_AUTO_TEST_CASE(data)
 {
     compute::extents<3> xyz = compute::dim(5, 6, 7);
@@ -92,5 +95,6 @@ BOOST_AUTO_TEST_CASE(copy_to_vector)
     BOOST_CHECK_EQUAL(vec[1], size_t(5));
     BOOST_CHECK_EQUAL(vec[2], size_t(6));
 }
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -214,6 +214,7 @@ BOOST_AUTO_TEST_CASE(move_ctor_custom_alloc)
 #endif // BOOST_COMPUTE_NO_RVALUE_REFERENCES
 
 #ifdef BOOST_COMPUTE_USE_CPP11
+#ifndef BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
 BOOST_AUTO_TEST_CASE(initializer_list_ctor)
 {
     // ctor with std::initializer_list<T> always uses
@@ -225,6 +226,7 @@ BOOST_AUTO_TEST_CASE(initializer_list_ctor)
     BOOST_CHECK_EQUAL(vector[2], 6);
     BOOST_CHECK_EQUAL(vector[3], 8);
 }
+#endif // BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
 #endif // BOOST_COMPUTE_USE_CPP11
 
 BOOST_AUTO_TEST_CASE(vector_double)


### PR DESCRIPTION
Some tests should not be run if macro `BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST` is defined.