### PR TITLE
use _WIN32 instead of WIN32

### DIFF
--- a/include/boost/compute/detail/path.hpp
+++ b/include/boost/compute/detail/path.hpp
@@ -30,7 +30,7 @@ static const std::string& path_delim()
 // Path to appdata folder.
 inline const std::string& appdata_path()
 {
-    #ifdef WIN32
+    #ifdef _WIN32
     static const std::string appdata = detail::getenv("APPDATA")
         + path_delim() + "boost_compute";
     #else

--- a/include/boost/compute/interop/opengl/context.hpp
+++ b/include/boost/compute/interop/opengl/context.hpp
@@ -96,7 +96,7 @@ inline context opengl_create_shared_context()
         #if defined(__linux__)
             CL_GL_CONTEXT_KHR, (cl_context_properties) glXGetCurrentContext(),
             CL_GLX_DISPLAY_KHR, (cl_context_properties) glXGetCurrentDisplay(),
-        #elif defined(WIN32)
+        #elif defined(_WIN32)
             CL_GL_CONTEXT_KHR, (cl_context_properties) wglGetCurrentContext(),
             CL_WGL_HDC_KHR, (cl_context_properties) wglGetCurrentDC(), 
         #endif


### PR DESCRIPTION
In two places of Boost.Compute, the macro WIN32 is used to detect Windows environment.
However, this macro is undefined on g++ when C++11 or C++0x is used. This can cause a crash in detail/path.hpp, because the incorrect path will be used.

There are some discussions on the Internet regarding this issue:

https://github.com/RcppCore/Rcpp/issues/360
https://sourceforge.net/p/mingw-w64/discussion/723798/thread/4ce97145/

I tried to compile the following code in MinGW, with GCC 6.3.0
```
#ifndef WIN32
        #error Define WIN32 is missing!
#endif
#ifndef _WIN32
        #error Define _WIN32 is missing!
#endif
int
main()
{
        return 0;
}
```

And when c++11 or c++0x is used, WIN32 will not be defined:

```
D:\github_repos>g++ -o test test.cpp

D:\github_repos>g++ -std=c++11 -o test test.cpp
test.cpp:2:10: error: #error Define WIN32 is missing!
         #error Define WIN32 is missing!
          ^~~~~

D:\github_repos>g++ -std=c++0x -o test test.cpp
test.cpp:2:10: error: #error Define WIN32 is missing!
         #error Define WIN32 is missing!
          ^~~~~
```
