### PR TITLE
Fix valarray copy ctor

### DIFF
--- a/include/boost/compute/container/valarray.hpp
+++ b/include/boost/compute/container/valarray.hpp
@@ -67,6 +67,7 @@ public:
     valarray(const valarray<T> &other)
         : m_buffer(other.m_buffer.get_context(), other.size() * sizeof(T))
     {
+        copy(other.begin(), other.end(), begin());
     }
 
     valarray(const std::valarray<T> &valarray,


### PR DESCRIPTION
This fixes `valarray(const valarray<T> &other)` copy ctor.

