### PR TITLE
Various fixes

### DIFF
--- a/include/boost/compute/container/detail/scalar.hpp
+++ b/include/boost/compute/container/detail/scalar.hpp
@@ -12,6 +12,7 @@
 #define BOOST_COMPUTE_CONTAINER_DETAIL_SCALAR_HPP
 
 #include <boost/compute/buffer.hpp>
+#include <boost/compute/event.hpp>
 #include <boost/compute/detail/read_write_single_value.hpp>
 
 namespace boost {
@@ -40,9 +41,9 @@ public:
         return read_single_value<T>(m_buffer, 0, queue);
     }
 
-    void write(const T &value, command_queue &queue)
+    event write(const T &value, command_queue &queue)
     {
-        write_single_value<T>(value, m_buffer, 0, queue);
+        return write_single_value<T>(value, m_buffer, 0, queue);
     }
 
     const buffer& get_buffer() const

--- a/include/boost/compute/detail/buffer_value.hpp
+++ b/include/boost/compute/detail/buffer_value.hpp
@@ -124,7 +124,9 @@ public:
             const context &context = m_buffer.get_context();
             command_queue queue(context, context.get_device());
 
-            detail::write_single_value<T>(value, m_buffer, m_index / sizeof(T), queue);
+            detail::write_single_value<T>(
+                value, m_buffer, m_index / sizeof(T), queue
+            ).wait();
 
             return *this;
         }

--- a/include/boost/compute/detail/read_write_single_value.hpp
+++ b/include/boost/compute/detail/read_write_single_value.hpp
@@ -14,6 +14,7 @@
 #include <boost/throw_exception.hpp>
 
 #include <boost/compute/buffer.hpp>
+#include <boost/compute/event.hpp>
 #include <boost/compute/exception.hpp>
 #include <boost/compute/command_queue.hpp>
 
@@ -47,18 +48,18 @@ inline T read_single_value(const buffer &buffer, command_queue &queue)
 
 // writes a single value at index to the buffer
 template<class T>
-inline void write_single_value(const T &value,
-                               const buffer &buffer,
-                               size_t index,
-                               command_queue &queue)
+inline event write_single_value(const T &value,
+                                const buffer &buffer,
+                                size_t index,
+                                command_queue &queue)
 {
     BOOST_ASSERT(index < buffer.size() / sizeof(T));
     BOOST_ASSERT(buffer.get_context() == queue.get_context());
 
-    queue.enqueue_write_buffer(buffer,
-                               index * sizeof(T),
-                               sizeof(T),
-                               &value);
+    return queue.enqueue_write_buffer(buffer,
+                                      index * sizeof(T),
+                                      sizeof(T),
+                                      &value);
 }
 
 // writes value to the first location in buffer

--- a/include/boost/compute/function.hpp
+++ b/include/boost/compute/function.hpp
@@ -164,6 +164,19 @@ public:
         m_definitions[name] = value;
     }
 
+    bool operator==(const function<Signature>& other) const
+    {
+        return
+            (m_name == other.m_name)
+                && (m_definitions == other.m_definitions)
+                && (m_source == other.m_source);
+    }
+
+    bool operator!=(const function<Signature>& other) const
+    {
+        return !(*this == other);
+    }
+
     /// \internal_
     detail::invoked_function<result_type, boost::tuple<> >
     operator()() const

--- a/include/boost/compute/memory/svm_ptr.hpp
+++ b/include/boost/compute/memory/svm_ptr.hpp
@@ -131,6 +131,16 @@ public:
         return m_context;
     }
 
+    bool operator==(const svm_ptr<T>& other) const
+    {
+        return (other.m_context == m_context) && (m_ptr == other.m_ptr);
+    }
+
+    bool operator!=(const svm_ptr<T>& other) const
+    {
+        return (other.m_context != m_context) || (m_ptr != other.m_ptr);
+    }
+
     // svm functions require OpenCL 2.0
     #if defined(BOOST_COMPUTE_CL_VERSION_2_0) || defined(BOOST_COMPUTE_DOXYGEN_INVOKED)
     /// \internal_

--- a/include/boost/compute/program.hpp
+++ b/include/boost/compute/program.hpp
@@ -310,7 +310,7 @@ public:
                 0,
                 0,
                 options_string,
-                headers.size(),
+                static_cast<cl_uint>(headers.size()),
                 header_programs.data(),
                 header_names.data(),
                 0,

--- a/test/test_device.cpp
+++ b/test/test_device.cpp
@@ -111,10 +111,10 @@ BOOST_AUTO_TEST_CASE(partition_device_equally)
     // ensure device is not a sub-device
     BOOST_CHECK(device.is_subdevice() == false);
 
-    // partition default device into sub-devices with two compute units each
+    // partition default device into sub-devices with one compute unit each
     std::vector<boost::compute::device>
-        sub_devices = device.partition_equally(2);
-    BOOST_CHECK_EQUAL(sub_devices.size(), size_t(device.compute_units() / 2));
+        sub_devices = device.partition_equally(1);
+    BOOST_CHECK_EQUAL(sub_devices.size(), size_t(device.compute_units()));
 
     // verify each of the sub-devices
     for(size_t i = 0; i < sub_devices.size(); i++){
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(partition_device_equally)
         BOOST_CHECK(sub_device.is_subdevice() == true);
 
         // check number of compute units
-        BOOST_CHECK_EQUAL(sub_device.compute_units(), size_t(2));
+        BOOST_CHECK_EQUAL(sub_device.compute_units(), size_t(1));
     }
 }
 

--- a/test/test_flat_set.cpp
+++ b/test/test_flat_set.cpp
@@ -37,27 +37,32 @@ BOOST_AUTO_TEST_CASE(insert)
     bc::flat_set<int> set(context);
     typedef bc::flat_set<int>::iterator iterator;
     std::pair<iterator, bool> location = set.insert(12, queue);
+    queue.finish();
     BOOST_CHECK(location.first == set.begin());
     BOOST_CHECK(location.second == true);
     BOOST_CHECK_EQUAL(*location.first, 12);
     BOOST_CHECK_EQUAL(set.size(), size_t(1));
 
     location = set.insert(12, queue);
+    queue.finish();
     BOOST_CHECK(location.first == set.begin());
     BOOST_CHECK(location.second == false);
     BOOST_CHECK_EQUAL(set.size(), size_t(1));
 
     location = set.insert(4, queue);
+    queue.finish();
     BOOST_CHECK(location.first == set.begin());
     BOOST_CHECK(location.second == true);
     BOOST_CHECK_EQUAL(set.size(), size_t(2));
 
     location = set.insert(12, queue);
+    queue.finish();
     BOOST_CHECK(location.first == set.begin() + 1);
     BOOST_CHECK(location.second == false);
     BOOST_CHECK_EQUAL(set.size(), size_t(2));
 
     location = set.insert(9, queue);
+    queue.finish();
     BOOST_CHECK(location.first == set.begin() + 1);
     BOOST_CHECK(location.second == true);
     BOOST_CHECK_EQUAL(set.size(), size_t(3));
@@ -72,6 +77,7 @@ BOOST_AUTO_TEST_CASE(erase)
     set.insert(3, queue);
     set.insert(4, queue);
     set.insert(5, queue);
+    queue.finish();
     BOOST_CHECK_EQUAL(set.size(), size_t(5));
 
     iterator i = set.erase(set.begin(), queue);

--- a/test/test_is_permutation.cpp
+++ b/test/test_is_permutation.cpp
@@ -24,10 +24,10 @@ namespace bc = boost::compute;
 
 BOOST_AUTO_TEST_CASE(is_permutation_int)
 {
-    int dataset1[] = {1, 3, 1, 2, 5};
+    bc::int_ dataset1[] = {1, 3, 1, 2, 5};
     bc::vector<bc::int_> vector1(dataset1, dataset1 + 5, queue);
 
-    int dataset2[] = {3, 1, 5, 1, 2};
+    bc::int_ dataset2[] = {3, 1, 5, 1, 2};
     bc::vector<bc::int_> vector2(dataset2, dataset2 + 5, queue);
 
     bool result =
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(is_permutation_int)
 
     BOOST_VERIFY(result == true);
 
-    vector2[0] = 1;
+    vector2.begin().write(bc::int_(1), queue);
 
     result = bc::is_permutation(vector1.begin(), vector1.begin() + 5,
                                 vector2.begin(), vector2.begin() + 5,
@@ -47,10 +47,10 @@ BOOST_AUTO_TEST_CASE(is_permutation_int)
 
 BOOST_AUTO_TEST_CASE(is_permutation_string)
 {
-    char dataset1[] = "abade";
+    bc::char_ dataset1[] = "abade";
     bc::vector<bc::char_> vector1(dataset1, dataset1 + 5, queue);
 
-    char dataset2[] = "aadeb";
+    bc::char_ dataset2[] = "aadeb";
     bc::vector<bc::char_> vector2(dataset2, dataset2 + 5, queue);
 
     bool result =
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(is_permutation_string)
 
     BOOST_VERIFY(result == true);
 
-    vector2[0] = 'b';
+    vector2.begin().write(bc::char_('b'), queue);
 
     result = bc::is_permutation(vector1.begin(), vector1.begin() + 5,
                                 vector2.begin(), vector2.begin() + 5,

--- a/test/test_pair.cpp
+++ b/test/test_pair.cpp
@@ -32,6 +32,7 @@ BOOST_AUTO_TEST_CASE(vector_pair_int_float)
     vector.push_back(std::make_pair(1, 1.1f), queue);
     vector.push_back(std::make_pair(2, 2.2f), queue);
     vector.push_back(std::make_pair(3, 3.3f), queue);
+    queue.finish();
     BOOST_CHECK_EQUAL(vector.size(), size_t(3));
     BOOST_CHECK(vector[0] == std::make_pair(1, 1.1f));
     BOOST_CHECK(vector[1] == std::make_pair(2, 2.2f));
@@ -45,6 +46,7 @@ BOOST_AUTO_TEST_CASE(copy_pair_vector)
     input.push_back(std::make_pair(3, 4.0f), queue);
     input.push_back(std::make_pair(5, 6.0f), queue);
     input.push_back(std::make_pair(7, 8.0f), queue);
+    queue.finish();
     BOOST_CHECK_EQUAL(input.size(), size_t(4));
 
     boost::compute::vector<std::pair<int, float> > output(4, context);
@@ -98,6 +100,7 @@ BOOST_AUTO_TEST_CASE(transform_pair_get)
     input.push_back(std::make_pair(3, 4.0f), queue);
     input.push_back(std::make_pair(5, 6.0f), queue);
     input.push_back(std::make_pair(7, 8.0f), queue);
+    queue.finish();
 
     boost::compute::vector<int> first_output(4, context);
     boost::compute::transform(

--- a/test/test_random_shuffle.cpp
+++ b/test/test_random_shuffle.cpp
@@ -30,6 +30,7 @@ BOOST_AUTO_TEST_CASE(shuffle_int_vector)
     vector.push_back(9, queue);
     vector.push_back(19, queue);
     vector.push_back(29, queue);
+    queue.finish();
 
     std::set<int> original_values;
     for(size_t i = 0; i < vector.size(); i++){


### PR DESCRIPTION
https://github.com/boostorg/compute/commit/2a6995581432ab602459aff81a1ecee6e175b732 is the most interesting bug-fix. `clEnqueueWriteBuffer` is not "100% blocking". OpenCL specification only promises that for `clEnqueueWriteBuffer`:

>if blocking_write is `CL_TRUE`, the OpenCL implementation copies the data referred to by `ptr` and enqueues the write operation in the command-queue. The memory pointed to by `ptr` can be reused by the application after the `clEnqueueWriteBuffer` call returns.

Which means that blocking `clEnqueueWriteBuffer` can return after it copies memory pointer by `ptr` to some temporary memory (on host), and it doesn't have to wait for the write to the buffer to be completed. (To be honest OpenCL specification is not 100% clear about that.) Anyway, in case of the Intel implementation for CPU, `clEnqueueWriteBuffer` does not wait for the data to be written into the buffer. Every other platform waits (AMD, NVIDIA, pocl), but the fact is that Intel implementation is in line with the specification. (See also https://software.intel.com/en-us/forums/opencl/topic/731519.)

That caused random errors when writing and reading using `[]` operator, because each call of `[]` operator creates it's own temporary command queue (so calls were not ordered). Long story short: It was possible to do `vector[0] = 3;` and right after that `vector[0] == 3` could be `false`.