### PR TITLE
Default device queue

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -1,6 +1,6 @@
 # ---------------------------------------------------------------------------
 #  Copyright (c) 2013 Kyle Lutz <kyle.r.lutz@gmail.com>
-# 
+#
 #  Distributed under the Boost Software License, Version 1.0
 #  See accompanying file LICENSE_1_0.txt or copy at
 #  http://www.boost.org/LICENSE_1_0.txt
@@ -95,6 +95,8 @@ doxygen autodoc
       see_opencl_ref{1}=\"See the documentation for \\opencl_ref{\\1} for more information.\" \\
       opencl2_ref{1}=\"<a href=\"http://www.khronos.org/registry/cl/sdk/2.0/docs/man/xhtml/\\1.html\">\\1()</a>\" \\
       see_opencl2_ref{1}=\"See the documentation for \\opencl2_ref{\\1} for more information.\" \\
+      opencl21_ref{1}=\"<a href=\"http://www.khronos.org/registry/cl/sdk/2.1/docs/man/xhtml/\\1.html\">\\1()</a>\" \\
+      see_opencl21_ref{1}=\"See the documentation for \\opencl21_ref{\\1} for more information.\" \\
       opencl_version_warning{2}=\"\\warning This method is only available if the OpenCL version is \\1.\\2 or later.\" \\
       "
     <xsl:param>"boost.doxygen.reftitle=Header Reference"

--- a/include/boost/compute/command_queue.hpp
+++ b/include/boost/compute/command_queue.hpp
@@ -253,6 +253,35 @@ public:
         return get_info<cl_command_queue_properties>(CL_QUEUE_PROPERTIES);
     }
 
+    #if defined(BOOST_COMPUTE_CL_VERSION_2_1) || defined(BOOST_COMPUTE_DOXYGEN_INVOKED)
+    /// Returns the current default device command queue for the underlying device.
+    ///
+    /// \opencl_version_warning{2,1}
+    command_queue get_default_device_queue() const
+    {
+        return command_queue(get_info<cl_command_queue>(CL_QUEUE_DEVICE_DEFAULT));
+    }
+
+    /// Replaces the default device command queue for the underlying device
+    /// with this command queue. Command queue must have been created
+    /// with CL_QUEUE_ON_DEVICE flag.
+    ///
+    /// \see_opencl21_ref{clSetDefaultDeviceCommandQueue}
+    ///
+    /// \opencl_version_warning{2,1}
+    void set_as_default_device_queue() const
+    {
+        cl_int ret = clSetDefaultDeviceCommandQueue(
+            this->get_context().get(),
+            this->get_device().get(),
+            m_queue
+        );
+        if(ret != CL_SUCCESS){
+            BOOST_THROW_EXCEPTION(opencl_error(ret));
+        }
+    }
+    #endif // BOOST_COMPUTE_CL_VERSION_2_1
+
     /// Enqueues a command to read data from \p buffer to host memory.
     ///
     /// \see_opencl_ref{clEnqueueReadBuffer}
@@ -1885,6 +1914,12 @@ BOOST_COMPUTE_DETAIL_DEFINE_GET_INFO_SPECIALIZATIONS(command_queue,
     ((uint_, CL_QUEUE_REFERENCE_COUNT))
     ((cl_command_queue_properties, CL_QUEUE_PROPERTIES))
 )
+
+#ifdef BOOST_COMPUTE_CL_VERSION_2_1
+BOOST_COMPUTE_DETAIL_DEFINE_GET_INFO_SPECIALIZATIONS(command_queue,
+    ((cl_command_queue, CL_QUEUE_DEVICE_DEFAULT))
+)
+#endif // BOOST_COMPUTE_CL_VERSION_2_1
 
 } // end compute namespace
 } // end boost namespace

--- a/include/boost/compute/device.hpp
+++ b/include/boost/compute/device.hpp
@@ -400,7 +400,7 @@ public:
     /// Returns the current value of the host clock as seen by device
     /// in nanoseconds.
     ///
-    /// \see_opencl_ref{clGetHostTimer}
+    /// \see_opencl21_ref{clGetHostTimer}
     ///
     /// \opencl_version_warning{2,1}
     ulong_ get_host_timer() const
@@ -417,7 +417,7 @@ public:
     /// and the host timer as seen by device in nanoseconds. The first of returned
     /// std::pair is a device timer timestamp, the second is a host timer timestamp.
     ///
-    /// \see_opencl_ref{clGetDeviceAndHostTimer}
+    /// \see_opencl21_ref{clGetDeviceAndHostTimer}
     ///
     /// \opencl_version_warning{2,1}
     std::pair<ulong_, ulong_> get_device_and_host_timer() const
@@ -445,7 +445,7 @@ public:
     /// std::cout << device.get_host_timer<std::chrono::milliseconds>().count() << " ms";
     /// \endcode
     ///
-    /// \see_opencl_ref{clGetHostTimer}
+    /// \see_opencl21_ref{clGetHostTimer}
     ///
     /// \opencl_version_warning{2,1}
     template<class Duration>
@@ -460,7 +460,7 @@ public:
     /// The first of returned std::pair is a device timer timestamp, the second is
     /// a host timer timestamp.
     ///
-    /// \see_opencl_ref{clGetDeviceAndHostTimer}
+    /// \see_opencl21_ref{clGetDeviceAndHostTimer}
     ///
     /// \opencl_version_warning{2,1}
     template<class Duration>

--- a/include/boost/compute/kernel.hpp
+++ b/include/boost/compute/kernel.hpp
@@ -134,7 +134,7 @@ public:
     ///
     /// \opencl_version_warning{2,1}
     ///
-    /// \see_opencl_ref{clCloneKernel}
+    /// \see_opencl21_ref{clCloneKernel}
     kernel clone()
     {
         cl_int ret = 0;
@@ -233,7 +233,8 @@ public:
     /// for cl_khr_subgroups extension.
     ///
     /// \opencl_version_warning{2,1}
-    /// \see_opencl_ref{clGetKernelSubGroupInfo}
+    /// \see_opencl21_ref{clGetKernelSubGroupInfo}
+    /// \see_opencl2_ref{clGetKernelSubGroupInfoKHR}
     template<class T>
     boost::optional<T> get_sub_group_info(const device &device, cl_kernel_sub_group_info info,
                                           const size_t input_size, const void * input) const
@@ -288,7 +289,7 @@ public:
     /// optional if cl_khr_subgroups extension is not supported by \p device.
     ///
     /// \opencl_version_warning{2,0}
-    /// \see_opencl_ref{clGetKernelSubGroupInfoKHR}
+    /// \see_opencl2_ref{clGetKernelSubGroupInfoKHR}
     template<class T>
     boost::optional<T> get_sub_group_info(const device &device, cl_kernel_sub_group_info info,
                                           const size_t input_size, const void * input) const

--- a/include/boost/compute/program.hpp
+++ b/include/boost/compute/program.hpp
@@ -587,7 +587,7 @@ public:
     ///
     /// \opencl_version_warning{2,1}
     ///
-    /// \see_opencl_ref{clCreateProgramWithIL}
+    /// \see_opencl21_ref{clCreateProgramWithIL}
     static program create_with_il(const void * il_binary,
                                   const size_t il_size,
                                   const context &context)

--- a/test/test_command_queue.cpp
+++ b/test/test_command_queue.cpp
@@ -314,4 +314,39 @@ BOOST_AUTO_TEST_CASE(enqueue_kernel_with_extents)
 }
 #endif // BOOST_COMPUTE_NO_HDR_INITIALIZER_LIST
 
+#ifdef BOOST_COMPUTE_CL_VERSION_2_1
+BOOST_AUTO_TEST_CASE(get_default_device_queue)
+{
+    REQUIRES_OPENCL_VERSION(2, 1);
+
+    boost::compute::command_queue default_device_queue(
+        context, device,
+        boost::compute::command_queue::on_device |
+        boost::compute::command_queue::on_device_default |
+        boost::compute::command_queue::enable_out_of_order_execution
+    );
+    BOOST_CHECK_NO_THROW(queue.get_info<CL_QUEUE_DEVICE_DEFAULT>());
+    BOOST_CHECK_EQUAL(
+        queue.get_default_device_queue(),
+        default_device_queue
+    );
+}
+
+BOOST_AUTO_TEST_CASE(set_as_default_device_queue)
+{
+    REQUIRES_OPENCL_VERSION(2, 1);
+
+    boost::compute::command_queue new_default_device_queue(
+        context, device,
+        boost::compute::command_queue::on_device |
+        boost::compute::command_queue::enable_out_of_order_execution
+    );
+    new_default_device_queue.set_as_default_device_queue();
+    BOOST_CHECK_EQUAL(
+         queue.get_default_device_queue(),
+         new_default_device_queue
+    );
+}
+#endif
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Adds `set_as_default_device_queue()` (wrapper for `clSetDefaultDeviceCommandQueue`) and ` get_default_device_queue()` methods to `command_queue` class.