### PR TITLE
Implement vector::shrink_to_fit()

### DIFF
--- a/include/boost/compute/algorithm/copy.hpp
+++ b/include/boost/compute/algorithm/copy.hpp
@@ -227,8 +227,8 @@ dispatch_copy(InputIterator first,
     boost::shared_ptr<parameter_cache> parameters =
         detail::parameter_cache::get_global_cache(device);
 
-    size_t map_copy_threshold;
-    size_t direct_copy_threshold;
+    uint_ map_copy_threshold;
+    uint_ direct_copy_threshold;
 
     // calculate default values of thresholds
     if (device.type() & device::gpu) {
@@ -310,8 +310,8 @@ dispatch_copy(InputIterator first,
     boost::shared_ptr<parameter_cache> parameters =
         detail::parameter_cache::get_global_cache(device);
 
-    size_t map_copy_threshold;
-    size_t direct_copy_threshold;
+    uint_ map_copy_threshold;
+    uint_ direct_copy_threshold;
 
     // calculate default values of thresholds
     if (device.type() & device::gpu) {
@@ -505,8 +505,8 @@ dispatch_copy(InputIterator first,
     boost::shared_ptr<parameter_cache> parameters =
         detail::parameter_cache::get_global_cache(device);
 
-    size_t map_copy_threshold;
-    size_t direct_copy_threshold;
+    uint_ map_copy_threshold;
+    uint_ direct_copy_threshold;
 
     // calculate default values of thresholds
     if (device.type() & device::gpu) {
@@ -587,8 +587,8 @@ dispatch_copy(InputIterator first,
     boost::shared_ptr<parameter_cache> parameters =
         detail::parameter_cache::get_global_cache(device);
 
-    size_t map_copy_threshold;
-    size_t direct_copy_threshold;
+    uint_ map_copy_threshold;
+    uint_ direct_copy_threshold;
 
     // calculate default values of thresholds
     if (device.type() & device::gpu) {

--- a/include/boost/compute/container/vector.hpp
+++ b/include/boost/compute/container/vector.hpp
@@ -477,7 +477,22 @@ public:
 
     void shrink_to_fit(command_queue &queue)
     {
-        (void) queue;
+        pointer old_data = m_data;
+        m_data = pointer(); // null pointer
+        if(m_size > 0)
+        {
+            // allocate new buffer
+            m_data = m_allocator.allocate(m_size);
+
+            // copy old values to the new buffer
+            ::boost::compute::copy(old_data, old_data + m_size, m_data, queue);
+        }
+
+        if(capacity() > 0)
+        {
+            // free old memory
+            m_allocator.deallocate(old_data, capacity());
+        }
     }
 
     void shrink_to_fit()

--- a/include/boost/compute/container/vector.hpp
+++ b/include/boost/compute/container/vector.hpp
@@ -293,8 +293,8 @@ public:
     /// Move-assigns the data from \p other to \c *this.
     vector& operator=(vector&& other)
     {
-        if(m_size){
-            m_allocator.deallocate(m_data, m_size);
+        if(capacity() > 0){
+            m_allocator.deallocate(m_data, capacity());
         }
 
         m_data = std::move(other.m_data);
@@ -310,8 +310,8 @@ public:
     /// Destroys the vector object.
     ~vector()
     {
-        if(m_size){
-            m_allocator.deallocate(m_data, m_size);
+        if(capacity() > 0){
+            m_allocator.deallocate(m_data, capacity());
         }
     }
 
@@ -401,11 +401,14 @@ public:
                     )
                 );
 
-            // copy old values to the new buffer
-            ::boost::compute::copy(m_data, m_data + m_size, new_data, queue);
+            if(capacity() > 0)
+            {
+                // copy old values to the new buffer
+                ::boost::compute::copy(m_data, m_data + m_size, new_data, queue);
 
-            // free old memory
-            m_allocator.deallocate(m_data, m_size);
+                // free old memory
+                m_allocator.deallocate(m_data, capacity());
+            }
 
             // set new data and size
             m_data = new_data;
@@ -430,6 +433,10 @@ public:
     /// Returns the capacity of the vector.
     size_type capacity() const
     {
+        if(m_data == pointer()) // null pointer check
+        {
+            return 0;
+        }
         return m_data.get_buffer().size() / sizeof(T);
     }
 
@@ -447,11 +454,14 @@ public:
                     )
                 );
 
-            // copy old values to the new buffer
-            ::boost::compute::copy(m_data, m_data + m_size, new_data, queue);
+            if(capacity() > 0)
+            {
+                // copy old values to the new buffer
+                ::boost::compute::copy(m_data, m_data + m_size, new_data, queue);
 
-            // free old memory
-            m_allocator.deallocate(m_data, m_size);
+                // free old memory
+                m_allocator.deallocate(m_data, capacity());
+            }
 
             // set new data
             m_data = new_data;

--- a/test/test_vector.cpp
+++ b/test/test_vector.cpp
@@ -472,4 +472,31 @@ BOOST_AUTO_TEST_CASE(swap_ctor_custom_alloc)
     CHECK_RANGE_EQUAL(int, 4, b, (11, 12, 13, 14));
 }
 
+BOOST_AUTO_TEST_CASE(shrink_to_fit)
+{
+    bc::vector<bc::int_> int_vector(5, context);
+    BOOST_CHECK_EQUAL(int_vector.size(), 5);
+    BOOST_CHECK(int_vector.capacity() >= 5);
+
+    int_vector.reserve(15);
+    BOOST_CHECK_EQUAL(int_vector.size(), 5);
+    BOOST_CHECK(int_vector.capacity() >= 15);
+
+    int_vector.shrink_to_fit();
+    BOOST_CHECK_EQUAL(int_vector.size(), 5);
+    BOOST_CHECK_EQUAL(int_vector.capacity(), 5);
+
+    int_vector.clear();
+    BOOST_CHECK_EQUAL(int_vector.size(), 0);
+    BOOST_CHECK_EQUAL(int_vector.capacity(), 5);
+
+    int_vector.shrink_to_fit();
+    BOOST_CHECK_EQUAL(int_vector.size(), 0);
+    BOOST_CHECK_EQUAL(int_vector.capacity(), 0);
+
+    int_vector.reserve(15);
+    BOOST_CHECK_EQUAL(int_vector.size(), 0);
+    BOOST_CHECK(int_vector.capacity() >= 15);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This pull-request:

* fixes warning referenced in #730,
* implements `boost::compute::vector::shrink_to_fit()` (which resolves #732), and
* fixes memory management issue in `boost::compute::vector`: memory deallocation should depend on `vector`'s capacity, not on its `m_size`.