### PR TITLE
Fix strided_iterator tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
        - LINUX_DIST=trusty
        - OPENCL_LIB=pocl
        - OPENCL_HEADERS_VER="21"
-       - ENV_CXX_FLAGS="-DBOOST_COMPUTE_MAX_CL_VERSION=100"
+       - ENV_CXX_FLAGS="-Wno-unused-local-typedef -DBOOST_COMPUTE_MAX_CL_VERSION=100"
        - ENV_CMAKE_OPTIONS="-DOpenCL_LIBRARY=${OPENCL_ROOT}/pocl/lib/libOpenCL.so -DOpenCL_INCLUDE_DIR=${OPENCL_ROOT}/include"
     - os: linux
       dist: trusty
@@ -87,7 +87,7 @@ matrix:
        - LINUX_DIST=trusty
        - OPENCL_LIB=pocl
        - OPENCL_HEADERS_VER="21"
-       - ENV_CXX_FLAGS="-DBOOST_COMPUTE_MAX_CL_VERSION=100"
+       - ENV_CXX_FLAGS="-Wno-unused-local-typedef -DBOOST_COMPUTE_MAX_CL_VERSION=100"
        - ENV_CMAKE_OPTIONS="-DOpenCL_LIBRARY=${OPENCL_ROOT}/pocl/lib/libOpenCL.so -DOpenCL_INCLUDE_DIR=${OPENCL_ROOT}/include"
     # Trusty, OpenCL 1.1
     - os: linux
@@ -102,7 +102,7 @@ matrix:
        - LINUX_DIST=trusty
        - OPENCL_LIB=pocl
        - OPENCL_HEADERS_VER="21"
-       - ENV_CXX_FLAGS="-DBOOST_COMPUTE_MAX_CL_VERSION=101"
+       - ENV_CXX_FLAGS="-Wno-unused-local-typedef -DBOOST_COMPUTE_MAX_CL_VERSION=101"
        - ENV_CMAKE_OPTIONS="-DOpenCL_LIBRARY=${OPENCL_ROOT}/pocl/lib/libOpenCL.so -DOpenCL_INCLUDE_DIR=${OPENCL_ROOT}/include"
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -300,7 +300,7 @@ matrix:
         - ENV_CMAKE_OPTIONS="-DOpenCL_INCLUDE_DIR=${OPENCL_ROOT}/include -DBOOST_COMPUTE_ENABLE_COVERAGE=ON -DBOOST_COMPUTE_USE_CPP11=ON"
         - COVERAGE=true
 
-    # Latest Boost library builds (currently 1.64)
+    # Latest Boost library builds (currently 1.65.1)
     # Precise, AMD APP SDK v2.9.1, Travis CI container-based infrastructure
     - os: linux
       sudo: false
@@ -323,8 +323,8 @@ matrix:
         - OPENCL_LIB=amdappsdk
         - OPENCL_HEADERS_VER="21"
         - AMDAPPSDK_VERSION=291 # OpenCL 1.2
-        - BOOST_VERSION="1_64_0" # Boost 1.64
-        - BOOST_URL="http://sourceforge.net/projects/boost/files/boost/1.64.0/boost_1_64_0.tar.gz"
+        - BOOST_VERSION="1_65_1" # Boost 1.65.1
+        - BOOST_URL="http://sourceforge.net/projects/boost/files/boost/1.65.1/boost_1_65_1.tar.gz"
         - ENV_CXX_FLAGS="-DBOOST_COMPUTE_MAX_CL_VERSION=102"
         - ENV_CMAKE_OPTIONS="-DOpenCL_INCLUDE_DIR=${OPENCL_ROOT}/include -DBOOST_COMPUTE_USE_CPP11=ON"
     - os: linux
@@ -342,8 +342,8 @@ matrix:
         - OPENCL_LIB=amdappsdk
         - OPENCL_HEADERS_VER="21"
         - AMDAPPSDK_VERSION=291 # OpenCL 1.2
-        - BOOST_VERSION="1_64_0" # Boost 1.64
-        - BOOST_URL="http://sourceforge.net/projects/boost/files/boost/1.64.0/boost_1_64_0.tar.gz"
+        - BOOST_VERSION="1_65_1" # Boost 1.65.1
+        - BOOST_URL="http://sourceforge.net/projects/boost/files/boost/1.65.1/boost_1_65_1.tar.gz"
         - ENV_CXX_FLAGS="-DBOOST_COMPUTE_MAX_CL_VERSION=102"
         - ENV_CMAKE_OPTIONS="-DOpenCL_INCLUDE_DIR=${OPENCL_ROOT}/include -DBOOST_COMPUTE_USE_CPP11=ON"
 

--- a/.travis/amd_sdk.sh
+++ b/.travis/amd_sdk.sh
@@ -3,7 +3,7 @@
 # Original script from https://github.com/gregvw/amd_sdk/
 
 # Location from which get nonce and file name from
-URL="http://developer.amd.com/tools-and-sdks/opencl-zone/opencl-tools-sdks/amd-accelerated-parallel-processing-app-sdk/"
+URL="http://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/"
 URLDOWN="http://developer.amd.com/amd-license-agreement-appsdk/"
 
 NONCE1_STRING='name="amd_developer_central_downloads_page_nonce"'

--- a/include/boost/compute/iterator/strided_iterator.hpp
+++ b/include/boost/compute/iterator/strided_iterator.hpp
@@ -42,7 +42,9 @@ class strided_iterator_base
 public:
     typedef ::boost::iterator_adaptor<
         ::boost::compute::strided_iterator<Iterator>,
-        Iterator
+        Iterator,
+        typename std::iterator_traits<Iterator>::value_type,
+        typename std::iterator_traits<Iterator>::iterator_category
     > type;
 };
 

--- a/test/test_strided_iterator.cpp
+++ b/test/test_strided_iterator.cpp
@@ -18,10 +18,13 @@
 
 #include <boost/compute/algorithm/copy.hpp>
 #include <boost/compute/container/vector.hpp>
+#include <boost/compute/iterator/buffer_iterator.hpp>
 #include <boost/compute/iterator/strided_iterator.hpp>
 
 #include "check_macros.hpp"
 #include "context_setup.hpp"
+
+namespace bc = boost::compute;
 
 BOOST_AUTO_TEST_CASE(value_type)
 {
@@ -155,6 +158,37 @@ BOOST_AUTO_TEST_CASE(make_strided_iterator_end)
         queue
     );
     CHECK_RANGE_EQUAL(boost::compute::int_, 4, result, (2, 4, 6, 8));
+}
+
+BOOST_AUTO_TEST_CASE(iterator_tag)
+{
+    typedef bc::buffer_iterator<bc::float_> i_type;
+
+    BOOST_STATIC_ASSERT((
+        boost::is_same<
+            std::iterator_traits<
+                i_type
+            >::iterator_category,
+            std::iterator_traits<
+                bc::strided_iterator<i_type>
+            >::iterator_category
+        >::value
+    ));
+}
+
+BOOST_AUTO_TEST_CASE(std_distance)
+{
+    bc::vector<bc::float_> vec(
+        size_t(300),
+        bc::float_(1.1f),
+        queue
+    );
+
+    bc::strided_iterator<bc::buffer_iterator<bc::float_> > begin(vec.begin(), 1);
+    bc::strided_iterator<bc::buffer_iterator<bc::float_> > end(vec.end(), 1);
+
+    BOOST_CHECK_EQUAL(std::distance(begin, end),  300);
+    BOOST_CHECK_EQUAL(std::distance(end, begin), -300);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Using `std::iterator_traits<>` to get `iterator_catagory` prevents from converting STL iterator tag to Boost tag.

Fixes #741 