### PR TITLE
Support for set_arg on macOS

### DIFF
--- a/include/boost/compute/core.hpp
+++ b/include/boost/compute/core.hpp
@@ -22,6 +22,7 @@
 #include <boost/compute/device.hpp>
 #include <boost/compute/event.hpp>
 #include <boost/compute/kernel.hpp>
+#include <boost/compute/types.hpp>
 #include <boost/compute/memory_object.hpp>
 #include <boost/compute/platform.hpp>
 #include <boost/compute/program.hpp>

--- a/include/boost/compute/kernel.hpp
+++ b/include/boost/compute/kernel.hpp
@@ -23,6 +23,7 @@
 #include <boost/compute/exception.hpp>
 #include <boost/compute/program.hpp>
 #include <boost/compute/platform.hpp>
+#include <boost/compute/types.hpp>
 #include <boost/compute/type_traits/is_fundamental.hpp>
 #include <boost/compute/detail/diagnostic.hpp>
 #include <boost/compute/detail/get_object_info.hpp>

--- a/include/boost/compute/kernel.hpp
+++ b/include/boost/compute/kernel.hpp
@@ -23,7 +23,6 @@
 #include <boost/compute/exception.hpp>
 #include <boost/compute/program.hpp>
 #include <boost/compute/platform.hpp>
-#include <boost/compute/types.hpp>
 #include <boost/compute/type_traits/is_fundamental.hpp>
 #include <boost/compute/detail/diagnostic.hpp>
 #include <boost/compute/detail/get_object_info.hpp>

--- a/test/test_kernel.cpp
+++ b/test/test_kernel.cpp
@@ -13,6 +13,7 @@
 
 #include <boost/compute/buffer.hpp>
 #include <boost/compute/kernel.hpp>
+#include <boost/compute/types.hpp>
 #include <boost/compute/system.hpp>
 #include <boost/compute/utility/source.hpp>
 

--- a/test/test_kernel.cpp
+++ b/test/test_kernel.cpp
@@ -113,6 +113,21 @@ BOOST_AUTO_TEST_CASE(kernel_set_args)
 }
 #endif // BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 
+// Originally failed to compile on macOS (several types are resolved differently)
+BOOST_AUTO_TEST_CASE(kernel_set_args_mac)
+{
+    compute::kernel k = compute::kernel::create_with_source(
+        "__kernel void test(unsigned int a, unsigned long b) { }", "test", context
+    );
+
+    unsigned int a;
+    unsigned long b;
+
+    k.set_arg(0, a);
+    k.set_arg(1, b);
+}
+
+
 #ifdef BOOST_COMPUTE_CL_VERSION_1_2
 BOOST_AUTO_TEST_CASE(get_arg_info)
 {


### PR DESCRIPTION
Currently, macOS does not support set_arg with some datatypes. This was partially fixed in #737, but it does not work if the user does not manually specify the `<boost/compute/types.hpp>` header manually.

This PR is expected to fail to build on macOS on the first build. It will then need to be fixed. 


See ddemidov/vexcl#227 for more info.