### PR TITLE
program::build() method throws a failure exception that contains a build log

### DIFF
--- a/include/boost/compute/exception/program_build_failure.hpp
+++ b/include/boost/compute/exception/program_build_failure.hpp
@@ -1,0 +1,44 @@
+#ifndef BOOST_COMPUTE_EXCEPTION_PROGRAM_BUILD_FAILURE_HPP
+#define BOOST_COMPUTE_EXCEPTION_PROGRAM_BUILD_FAILURE_HPP
+
+#include <string>
+
+#include <boost/compute/exception/opencl_error.hpp>
+
+namespace boost {
+namespace compute {
+
+/// \class program_build_failure
+/// \brief A failure when building OpenCL program
+///
+/// Instances of this class are thrown when OpenCL program build fails.
+/// Extends opencl_error by saving a program build log so it can be used
+/// for testing, debugging, or logging purposes.
+///
+/// \see opencl_error
+class program_build_failure : public opencl_error
+{
+public:
+    /// Creates a new program_build_failure exception object for \p error
+    /// and \p build_log.
+    explicit program_build_failure(cl_int error, const std::string& build_log)
+        throw()
+        : opencl_error(error),
+          m_build_log(build_log)
+    {
+    }
+
+    /// Retrieve the log of a failed program build.
+    std::string build_log() const throw()
+    {
+        return m_build_log;
+    }
+
+private:
+    std::string m_build_log;
+};
+
+} // end compute namespace
+} // end boost namespace
+
+#endif // BOOST_COMPUTE_EXCEPTION_PROGRAM_BUILD_FAILURE_HPP

--- a/include/boost/compute/exception/program_build_failure.hpp
+++ b/include/boost/compute/exception/program_build_failure.hpp
@@ -1,3 +1,12 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2017 Kristian Popov <kristian.popov@outlook.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
 #ifndef BOOST_COMPUTE_EXCEPTION_PROGRAM_BUILD_FAILURE_HPP
 #define BOOST_COMPUTE_EXCEPTION_PROGRAM_BUILD_FAILURE_HPP
 

--- a/include/boost/compute/exception/program_build_failure.hpp
+++ b/include/boost/compute/exception/program_build_failure.hpp
@@ -37,6 +37,11 @@ public:
     {
     }
 
+    /// Destroys the program_build_failure object.
+    ~program_build_failure() throw()
+    {
+    }
+
     /// Retrieve the log of a failed program build.
     std::string build_log() const throw()
     {

--- a/include/boost/compute/program.hpp
+++ b/include/boost/compute/program.hpp
@@ -23,6 +23,7 @@
 #include <boost/compute/config.hpp>
 #include <boost/compute/context.hpp>
 #include <boost/compute/exception.hpp>
+#include <boost/compute/exception/program_build_failure.hpp>
 #include <boost/compute/detail/assert_cl_success.hpp>
 
 #ifdef BOOST_COMPUTE_USE_OFFLINE_CACHE
@@ -276,7 +277,7 @@ public:
         #endif
 
         if(ret != CL_SUCCESS){
-            BOOST_THROW_EXCEPTION(opencl_error(ret));
+            BOOST_THROW_EXCEPTION(program_build_failure(ret, build_log()));
         }
     }
 

--- a/test/data/invalid_program.cl
+++ b/test/data/invalid_program.cl
@@ -1,0 +1,1 @@
+__kernel void foo(__global int *input) { !@#$%^&*() }

--- a/test/data/invalid_program.cl
+++ b/test/data/invalid_program.cl
@@ -1,1 +1,10 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2017 Kristian Popov <kristian.popov@outlook.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
 __kernel void foo(__global int *input) { !@#$%^&*() }

--- a/test/quirks.hpp
+++ b/test/quirks.hpp
@@ -118,4 +118,11 @@ inline bool supports_link_program(const boost::compute::device &device)
     return !is_pocl_device(device);
 }
 
+// See https://github.com/pocl/pocl/issues/577, POCL fails when a program
+// with incorrect code is built for the 2nd time
+inline bool pocl_bug_issue_577(const boost::compute::device &device)
+{
+    return is_pocl_device(device);
+}
+
 #endif // BOOST_COMPUTE_TEST_QUIRKS_HPP

--- a/test/test_program.cpp
+++ b/test/test_program.cpp
@@ -357,6 +357,12 @@ BOOST_AUTO_TEST_CASE(program_build_exception)
                       compute::program_build_failure);
 
     try {
+        // POCL bug: https://github.com/pocl/pocl/issues/577
+        if(pocl_bug_issue_577(device))
+        {
+            invalid_program =
+                compute::program::create_with_source(invalid_source, context);
+        }
         invalid_program.build();
 
         // should not get here

--- a/test/test_program.cpp
+++ b/test/test_program.cpp
@@ -372,4 +372,20 @@ BOOST_AUTO_TEST_CASE(program_build_exception)
     }
 }
 
+BOOST_AUTO_TEST_CASE(build_with_source_exception)
+{
+    const char invalid_source[] =
+        "__kernel void foo(__global int *input) { !@#$%^&*() }";
+
+    BOOST_CHECK_THROW(compute::program::build_with_source(invalid_source, context),
+        compute::program_build_failure);
+}
+
+BOOST_AUTO_TEST_CASE(build_with_source_file_exception)
+{
+    std::string file_path(BOOST_COMPUTE_TEST_DATA_PATH "/invalid_program.cl");
+    BOOST_CHECK_THROW(compute::program::build_with_source_file(file_path, context),
+        compute::program_build_failure);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_program.cpp
+++ b/test/test_program.cpp
@@ -158,6 +158,8 @@ BOOST_AUTO_TEST_CASE(create_with_il)
 
 BOOST_AUTO_TEST_CASE(get_program_il_binary)
 {
+    REQUIRES_OPENCL_VERSION(2, 1);
+
     size_t device_address_space_size = device.address_bits();
     std::string file_path(BOOST_COMPUTE_TEST_DATA_PATH);
     if(device_address_space_size == 64)
@@ -193,6 +195,8 @@ BOOST_AUTO_TEST_CASE(get_program_il_binary)
 
 BOOST_AUTO_TEST_CASE(get_program_il_binary_empty)
 {
+    REQUIRES_OPENCL_VERSION(2, 1);
+
     boost::compute::program program;
     BOOST_CHECK_NO_THROW(
         program = boost::compute::program::create_with_source(source, context)

--- a/test/test_program.cpp
+++ b/test/test_program.cpp
@@ -16,6 +16,7 @@
 // thrown when invalid kernel code is passed to program::build().
 #undef BOOST_COMPUTE_DEBUG_KERNEL_COMPILATION
 
+#include <boost/compute/exception/program_build_failure.hpp>
 #include <boost/compute/kernel.hpp>
 #include <boost/compute/system.hpp>
 #include <boost/compute/program.hpp>
@@ -341,6 +342,33 @@ BOOST_AUTO_TEST_CASE(build_log)
     catch(compute::opencl_error&){
         std::string log = invalid_program.build_log();
         BOOST_CHECK(!log.empty());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(program_build_exception)
+{
+    const char invalid_source[] =
+        "__kernel void foo(__global int *input) { !@#$%^&*() }";
+
+    compute::program invalid_program =
+        compute::program::create_with_source(invalid_source, context);
+
+    BOOST_CHECK_THROW(invalid_program.build(),
+                      compute::program_build_failure);
+
+    try {
+        invalid_program.build();
+
+        // should not get here
+        BOOST_CHECK(false);
+    }
+    catch(compute::program_build_failure& e){
+        BOOST_CHECK(e.build_log() == invalid_program.build_log());
+    }
+    catch(...)
+    {
+        // should not get here
+        BOOST_CHECK(false);
     }
 }
 


### PR DESCRIPTION
Good day!
I've prepared changes to change an exception type thrown by program::build() when program build fails (discussion can be found [here](https://github.com/boostorg/compute/issues/750))
There's one question left - whom should I mention in copyright notices in new files?

Thanks for your time,
Kristian Popov