### PR TITLE
use std::shuffle for post-C++11

### DIFF
--- a/include/boost/compute/algorithm/random_shuffle.hpp
+++ b/include/boost/compute/algorithm/random_shuffle.hpp
@@ -52,7 +52,7 @@ inline void random_shuffle(Iterator first,
     boost::iota(random_indices, 0);
 #ifdef BOOST_COMPUTE_USE_CPP11
     std::random_device nondeterministic_randomness;
-    std::default_random_engine random_engine(nondeterministic_randomness);
+    std::default_random_engine random_engine(nondeterministic_randomness());
     std::shuffle(random_indices.begin(), random_indices.end(), random_engine);
 #else
     std::random_shuffle(random_indices.begin(), random_indices.end());

--- a/include/boost/compute/algorithm/random_shuffle.hpp
+++ b/include/boost/compute/algorithm/random_shuffle.hpp
@@ -51,7 +51,8 @@ inline void random_shuffle(Iterator first,
     std::vector<cl_uint> random_indices(count);
     boost::iota(random_indices, 0);
 #ifdef BOOST_COMPUTE_USE_CPP11
-    std::default_random_engine random_engine;
+    std::random_device nondeterministic_randomness;
+    std::default_random_engine random_engine(nondeterministic_randomness);
     std::shuffle(random_indices.begin(), random_indices.end(), random_engine);
 #else
     std::random_shuffle(random_indices.begin(), random_indices.end());

--- a/include/boost/compute/algorithm/random_shuffle.hpp
+++ b/include/boost/compute/algorithm/random_shuffle.hpp
@@ -14,6 +14,10 @@
 #include <vector>
 #include <algorithm>
 
+#ifdef BOOST_COMPUTE_USE_CPP11
+#include <random>
+#endif
+
 #include <boost/range/algorithm_ext/iota.hpp>
 
 #include <boost/compute/system.hpp>
@@ -46,7 +50,12 @@ inline void random_shuffle(Iterator first,
     // generate shuffled indices on the host
     std::vector<cl_uint> random_indices(count);
     boost::iota(random_indices, 0);
+#ifdef BOOST_COMPUTE_USE_CPP11
+    std::default_random_engine random_engine;
+    std::shuffle(random_indices.begin(), random_indices.end(), random_engine);
+#else
     std::random_shuffle(random_indices.begin(), random_indices.end());
+#endif
 
     // copy random indices to the device
     const context &context = queue.get_context();


### PR DESCRIPTION
`std::random_shuffle` was deprecated in C++14 and deleted in C++17.  `std::shuffle` was added in C++11.  using it fixes build issues with clang+libc++ when compiling with `-std=c++1z`.

fixes issue #760

This is my first attempt at contributing.

I do not consider this trivial change to be worthy of copyright, but I work for Intel and will get the open-source contribution paperwork approved ASAP.