### PR TITLE
boost/uuid/sha1.hpp is deprecated since v1.66

### DIFF
--- a/include/boost/compute/detail/sha1.hpp
+++ b/include/boost/compute/detail/sha1.hpp
@@ -13,7 +13,12 @@
 
 #include <sstream>
 #include <iomanip>
-#include <boost/uuid/sha1.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 106600
+#  include <boost/uuid/detail/sha1.hpp>
+#else
+#  include <boost/uuid/sha1.hpp>
+#endif
 
 namespace boost {
 namespace compute {


### PR DESCRIPTION
This suppresses the warning at
https://github.com/boostorg/uuid/blob/boost-1.66.0/include/boost/uuid/sha1.hpp#L13