### PR TITLE
Fix out of bound access in local_scan kernel

### DIFF
--- a/include/boost/compute/algorithm/detail/scan_on_gpu.hpp
+++ b/include/boost/compute/algorithm/detail/scan_on_gpu.hpp
@@ -108,7 +108,7 @@ public:
         // store sum for the block
         if(exclusive){
             *this <<
-                "if(lid == block_size - 1){\n" <<
+                "if(lid == block_size - 1 && gid < count) {\n" <<
                 "    block_sums[get_group_id(0)] = " <<
                        op(first[expr<cl_uint>("gid")], var<T>("scratch[lid]")) <<
                        ";\n" <<


### PR DESCRIPTION
The `local_scan` kernel was accessing the first buffer using the global id without checking if it was within the bounds.