### PR TITLE
add const to return type of get_context (fixes #778)

### DIFF
--- a/include/boost/compute/memory/svm_ptr.hpp
+++ b/include/boost/compute/memory/svm_ptr.hpp
@@ -126,7 +126,7 @@ public:
         return m_ptr - other.m_ptr;
     }
 
-    context& get_context() const
+    const context& get_context() const
     {
         return m_context;
     }


### PR DESCRIPTION
see https://github.com/boostorg/compute/issues/778 for background.  this commit fixes the compilation error observed with GCC 8.1.0.