### PR TITLE
const correct get_context() in svm_ptr

### DIFF
--- a/include/boost/compute/memory/svm_ptr.hpp
+++ b/include/boost/compute/memory/svm_ptr.hpp
@@ -126,7 +126,7 @@ public:
         return m_ptr - other.m_ptr;
     }
 
-    context& get_context() const
+    const context& get_context() const
     {
         return m_context;
     }


### PR DESCRIPTION
gcc 8.1 now considers this an error.