### PR TITLE
Added wait_list parameter to "copy" functions

### DIFF
--- a/include/boost/compute/algorithm/copy_n.hpp
+++ b/include/boost/compute/algorithm/copy_n.hpp
@@ -37,14 +37,16 @@ template<class InputIterator, class Size, class OutputIterator>
 inline OutputIterator copy_n(InputIterator first,
                              Size count,
                              OutputIterator result,
-                             command_queue &queue = system::default_queue())
+                             command_queue &queue = system::default_queue(),
+                             const wait_list &events = wait_list())
 {
     typedef typename std::iterator_traits<InputIterator>::difference_type difference_type;
 
     return ::boost::compute::copy(first,
                                   first + static_cast<difference_type>(count),
                                   result,
-                                  queue);
+                                  queue,
+                                  events);
 }
 
 } // end compute namespace

--- a/include/boost/compute/detail/meta_kernel.hpp
+++ b/include/boost/compute/detail/meta_kernel.hpp
@@ -665,7 +665,8 @@ public:
 
     event exec_1d(command_queue &queue,
                   size_t global_work_offset,
-                  size_t global_work_size)
+                  size_t global_work_size,
+                  const wait_list &events = wait_list())
     {
         const context &context = queue.get_context();
 
@@ -675,14 +676,16 @@ public:
                    kernel,
                    global_work_offset,
                    global_work_size,
-                   0
+                   0,
+                   events
                );
     }
 
     event exec_1d(command_queue &queue,
                  size_t global_work_offset,
                  size_t global_work_size,
-                 size_t local_work_size)
+                 size_t local_work_size,
+                 const wait_list &events = wait_list())
     {
         const context &context = queue.get_context();
 
@@ -692,7 +695,8 @@ public:
                    kernel,
                    global_work_offset,
                    global_work_size,
-                   local_work_size
+                   local_work_size,
+                   events
                );
     }
 


### PR DESCRIPTION
It's not possible to use current "copy" functions with CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE option in command queue, because wait_list parameter is missing.