### PR TITLE
fixes radix sort error

### DIFF
--- a/include/boost/compute/algorithm/detail/radix_sort.hpp
+++ b/include/boost/compute/algorithm/detail/radix_sort.hpp
@@ -176,8 +176,10 @@ const char radix_sort_source[] =
 "    uint sum = 0;\n"
 "    for(uint i = 0; i < K2_BITS; i++){\n"
 "        uint x = global_offsets[i] + last_block_offsets[i];\n"
+"        mem_fence(CLK_GLOBAL_MEM_FENCE);\n" // work around the RX 500/Vega bug, see #811
 "        global_offsets[i] = sum;\n"
 "        sum += x;\n"
+"        mem_fence(CLK_GLOBAL_MEM_FENCE);\n" // work around the RX Vega bug, see #811
 "    }\n"
 "}\n"
 


### PR DESCRIPTION
insert memory fence to avoid AMD OpenCL compiler reordering the read/writes; fixes issue #811

CTest log for Vega56

```
99% tests passed, 2 tests failed out of 169
 
Total Test time (real) =  85.07 sec

The following tests FAILED:
 	143 - misc.amd_cpp_kernel_language (Failed)
 	148 - example.amd_cpp_kernel (Exit code 0xc0000409)
Errors while running CTest
```