### PR TITLE
Work around incomplete closure input arguments on some platforms

### DIFF
--- a/include/boost/compute/closure.hpp
+++ b/include/boost/compute/closure.hpp
@@ -216,7 +216,7 @@ struct closure_signature_argument_inserter
         BOOST_ASSERT(capture_string[0] == '(' &&
                      capture_string[capture_string_length-1] == ')');
         std::string capture_string_(capture_string + 1, capture_string_length - 2);
-        boost::split(m_capture_names, capture_string_ , boost::is_any_of(","));
+        boost::split(m_capture_names, capture_string_ , boost::is_any_of(", "), boost::algorithm::token_compress_on);
     }
 
     template<class T>
@@ -226,9 +226,6 @@ struct closure_signature_argument_inserter
 
         // get captured variable name
         std::string variable_name = m_capture_names[n];
-
-        // remove leading and trailing whitespace from variable name
-        boost::trim(variable_name);
 
         s << capture_traits<T>::type_name() << " " << variable_name;
         if(n+1 < m_last){


### PR DESCRIPTION
This fixes all the kernel compile errors I encountered when running `test_closure`, one example:

```
--- build log ---
BC-src-code:6:75: error: use of undeclared identifier 'pi'
 inline float add_two_and_pi(float x, int two, float  p){ return x + two + pi; }
                                                                           ^
1 diagnostic(s) generated.
```

I encountered this curious case when cross-compiling with the standalone toolchain generated from [android NDK](https://developer.android.com/ndk/guides/standalone_toolchain). Most tests pass. But closure is among one of the few that fails. It seems like boost::trim() from the main boost library somehow cuts off more character than it should and also leaves a leading whitespace. 

```log
two, pi          // original string   
[two,  pi]       // vector after split()

two              // after trim()
int two          // capture_traits<T>::type_name() << " " << variable_name

 p               // after trim(), there is a leading space before 'pi' and 'i' is cut off 
float  p         // capture_traits<T>::type_name() << " " << variable_name
```