### PR TITLE
svmmemcpy tests are ignored on Intel GPUs

### DIFF
--- a/include/boost/compute/detail/vendor.hpp
+++ b/include/boost/compute/detail/vendor.hpp
@@ -43,6 +43,12 @@ inline bool is_apple_platform_device(const device &device)
     return is_apple_platform(device.platform());
 }
 
+// returns true if the device is an Intel GPU
+inline bool is_intel_gpu(const device& device)
+{
+    return device.name().find("Intel(R) HD Graphics") != std::string::npos;
+}
+
 } // end detail namespace
 } // end compute namespace
 } // end boost namespace

--- a/test/quirks.hpp
+++ b/test/quirks.hpp
@@ -42,14 +42,18 @@ inline bool bug_in_struct_assignment(const boost::compute::device &device)
 
 // clEnqueueSVMMemcpy() operation does not work on AMD devices. This affects
 // copy() algorithm. This bug was fixed in AMD drivers for Windows.
+// Also it doesn't work on Intel GPUs
+// (returns INVALID_VALUE for valid parameters).
 //
 // see: https://community.amd.com/thread/190585
+// also: https://github.com/boostorg/compute/issues/818
 inline bool bug_in_svmmemcpy(const boost::compute::device &device)
 {
     #ifdef _WIN32
-    return false;
+    return boost::compute::detail::is_intel_gpu(device);
     #else
-    return boost::compute::detail::is_amd_device(device);
+    return boost::compute::detail::is_amd_device(device) ||
+        boost::compute::detail::is_intel_gpu(device);
     #endif
 }
 


### PR DESCRIPTION
Tests related to svmmemcpy are ignored when running Intel GPUs (in addition to AMD devices on non-Windows OS's).
Fixes issue #818