### PR TITLE
Fix: unsigned long is not fundamental type on Win64

### DIFF
--- a/test/test_kernel.cpp
+++ b/test/test_kernel.cpp
@@ -121,8 +121,8 @@ BOOST_AUTO_TEST_CASE(kernel_set_args_mac)
         "__kernel void test(unsigned int a, unsigned long b) { }", "test", context
     );
 
-    unsigned int a;
-    unsigned long b;
+    compute::uint_  a;
+    compute::ulong_ b;
 
     k.set_arg(0, a);
     k.set_arg(1, b);


### PR DESCRIPTION
On Windows 64 unsigned long has 4 bytes like unsigned int, but it does not seem to be a simple alias for unsigned int. Because of that unsigned long is not OpenCL fundamental type.