### PR TITLE
add support to set kernel argument as NULL; fixes issue #828

### DIFF
--- a/include/boost/compute/kernel.hpp
+++ b/include/boost/compute/kernel.hpp
@@ -363,6 +363,11 @@ public:
     /// // set argument to a local buffer with storage for 32 float's
     /// kernel.set_arg(0, local_buffer<float>(32));
     /// \endcode
+    ///
+    /// For setting NULL to global and constant memory arguments (C++11):
+    /// \code
+    /// kernel.set_arg(0, nullptr);
+    /// \endcode
     template<class T>
     void set_arg(size_t index, const T &value)
     {
@@ -370,6 +375,14 @@ public:
         // attempted to set a kernel argument from an invalid type.
         detail::set_kernel_arg<T>()(*this, index, value);
     }
+
+    #ifdef BOOST_COMPUTE_USE_CPP11
+    /// \overload
+    void set_arg(size_t index, std::nullptr_t nul)
+    {
+        set_arg(index, sizeof(cl_mem), NULL);
+    }
+    #endif
 
     /// \internal_
     void set_arg(size_t index, const cl_mem mem)

--- a/include/boost/compute/kernel.hpp
+++ b/include/boost/compute/kernel.hpp
@@ -376,13 +376,13 @@ public:
         detail::set_kernel_arg<T>()(*this, index, value);
     }
 
-    #ifdef BOOST_COMPUTE_USE_CPP11
+    #ifndef BOOST_NO_CXX11_NULLPTR
     /// \overload
     void set_arg(size_t index, std::nullptr_t nul)
     {
         set_arg(index, sizeof(cl_mem), NULL);
     }
-    #endif
+    #endif // BOOST_NO_CXX11_NULLPTR
 
     /// \internal_
     void set_arg(size_t index, const cl_mem mem)

--- a/include/boost/compute/memory/local_buffer.hpp
+++ b/include/boost/compute/memory/local_buffer.hpp
@@ -88,4 +88,4 @@ struct set_kernel_arg<local_buffer<T> >
 } // end compute namespace
 } // end boost namespace
 
-#endif // BOOST_COMPUTE_MEMORY_SVM_PTR_HPP
+#endif // BOOST_COMPUTE_MEMORY_LOCAL_BUFFER_HPP

--- a/test/test_kernel.cpp
+++ b/test/test_kernel.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(arity)
 BOOST_AUTO_TEST_CASE(set_buffer_arg)
 {
     const char source[] = BOOST_COMPUTE_STRINGIZE_SOURCE(
-        __kernel void foo(__global int *x, __global int *y)
+        __kernel void foo(__global int *x, __global int *y, __global int *z)
         {
             x[get_global_id(0)] = -y[get_global_id(0)];
         }
@@ -70,6 +70,11 @@ BOOST_AUTO_TEST_CASE(set_buffer_arg)
 
     foo.set_arg(0, x);
     foo.set_arg(1, y.get());
+#ifdef BOOST_COMPUTE_USE_CPP11
+    foo.set_arg(2, nullptr);
+#else
+    foo.set_arg(2, sizeof(cl_mem), 0);
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(get_work_group_info)
@@ -107,10 +112,10 @@ BOOST_AUTO_TEST_CASE(get_work_group_info)
 BOOST_AUTO_TEST_CASE(kernel_set_args)
 {
     compute::kernel k = compute::kernel::create_with_source(
-        "__kernel void test(int x, float y, char z) { }", "test", context
+        "__kernel void test(int x, float y, char z, __global int* w) { }", "test", context
     );
 
-    k.set_args(4, 2.4f, 'a');
+    k.set_args(4, 2.4f, 'a', nullptr);
 }
 #endif // BOOST_COMPUTE_NO_VARIADIC_TEMPLATES
 

--- a/test/test_kernel.cpp
+++ b/test/test_kernel.cpp
@@ -70,11 +70,11 @@ BOOST_AUTO_TEST_CASE(set_buffer_arg)
 
     foo.set_arg(0, x);
     foo.set_arg(1, y.get());
-#ifdef BOOST_COMPUTE_USE_CPP11
+#ifndef BOOST_NO_CXX11_NULLPTR
     foo.set_arg(2, nullptr);
 #else
     foo.set_arg(2, sizeof(cl_mem), 0);
-#endif
+#endif // BOOST_NO_CXX11_NULLPTR
 }
 
 BOOST_AUTO_TEST_CASE(get_work_group_info)


### PR DESCRIPTION
Per Khronos OpenCL spec:
>If the argument is declared to be a pointer of a built-in scalar or vector type, or a user defined structure type in the global or constant address space, the memory object specified as argument value must be a buffer object (or NULL).

But the following call causes error:
```c++
some_kernel.set_arg(0, NULL);
```
One way as suggested in #828 is to use
```c++
some_kernel.set_arg(0, sizeof(cl_mem), NULL);
```
Now it's just
```c++
some_kernel.set_arg(0, nullptr);
```
