### PR TITLE
Include Boost's static_assert header in fundamental.hpp

### DIFF
--- a/include/boost/compute/types/fundamental.hpp
+++ b/include/boost/compute/types/fundamental.hpp
@@ -14,6 +14,8 @@
 #include <cstring>
 #include <ostream>
 
+#include <boost/static_assert.hpp>
+
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/comma.hpp>
 #include <boost/preprocessor/repetition.hpp>


### PR DESCRIPTION
Include static_assert.hpp header in <fundamental.hpp>, required since commit 6c6a1089