### PR TITLE
Allow manually setting default command queue via `default_queue()`

### DIFF
--- a/doc/reference.qbk
+++ b/doc/reference.qbk
@@ -149,6 +149,8 @@ Header: `<boost/compute/exception.hpp>`
 * [classref boost::compute::no_device_found no_device_found]
 * [classref boost::compute::opencl_error opencl_error]
 * [classref boost::compute::unsupported_extension_error unsupported_extension_error]
+* [classref boost::compute::program_build_failure program_build_failure]
+* [classref boost::compute::set_default_queue_error set_default_queue_error]
 
 [h3 Iterators]
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -37,6 +37,11 @@ set(EXAMPLES
 # boost library link dependencies
 set(EXAMPLE_BOOST_COMPONENTS program_options)
 
+if(${BOOST_COMPUTE_USE_CPP11})
+  # allow examples to use C++11 features
+  add_definitions(-DBOOST_COMPUTE_USE_CPP11)
+endif()
+
 if (${BOOST_COMPUTE_USE_OFFLINE_CACHE})
   set(EXAMPLE_BOOST_COMPONENTS ${EXAMPLE_BOOST_COMPONENTS} system filesystem)
 endif()

--- a/include/boost/compute/context.hpp
+++ b/include/boost/compute/context.hpp
@@ -18,6 +18,7 @@
 #include <boost/compute/config.hpp>
 #include <boost/compute/device.hpp>
 #include <boost/compute/exception/opencl_error.hpp>
+#include <boost/compute/exception/set_default_queue_error.hpp>
 #include <boost/compute/detail/assert_cl_success.hpp>
 
 namespace boost {

--- a/include/boost/compute/exception/set_default_queue_error.hpp
+++ b/include/boost/compute/exception/set_default_queue_error.hpp
@@ -1,0 +1,47 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2019 Anthony Chang <ac.chang@outlook.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#ifndef BOOST_COMPUTE_EXCEPTION_SET_DEFAULT_QUEUE_ERROR_HPP
+#define BOOST_COMPUTE_EXCEPTION_SET_DEFAULT_QUEUE_ERROR_HPP
+
+#include <exception>
+
+namespace boost {
+namespace compute {
+
+/// \class set_default_queue_error
+/// \brief Exception thrown when failure to set default command queue 
+///
+/// This exception is thrown when Boost.Compute fails to set up user-provided 
+/// default command queue for the system. 
+class set_default_queue_error : public std::exception
+{
+public:
+    /// Creates a new set_default_queue_error exception object.
+    set_default_queue_error() throw()
+    {
+    }
+
+    /// Destroys the set_default_queue_error object.
+    ~set_default_queue_error() throw()
+    {
+    }
+
+    /// Returns a string with a description of the error.
+    const char* what() const throw()
+    {
+        return "User command queue mismatches default device and/or context";
+    }
+};
+
+} // end compute namespace
+} // end boost namespace
+
+#endif // BOOST_COMPUTE_EXCEPTION_SET_DEFAULT_QUEUE_ERROR_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,6 +83,8 @@ add_compute_test("core.program" test_program.cpp)
 add_compute_test("core.system" test_system.cpp)
 add_compute_test("core.type_traits" test_type_traits.cpp)
 add_compute_test("core.user_event" test_user_event.cpp)
+add_compute_test("core.attach_user_queue_error" test_attach_user_queue_error.cpp)
+add_compute_test("core.attach_user_queue_thread_safety" test_attach_user_queue_thread_safety.cpp)
 
 add_compute_test("utility.extents" test_extents.cpp)
 add_compute_test("utility.invoke" test_invoke.cpp)

--- a/test/test_attach_user_queue_error.cpp
+++ b/test/test_attach_user_queue_error.cpp
@@ -20,24 +20,17 @@ namespace compute = boost::compute;
 // For correct usage of setting up global default queue, see test_system.cpp
 BOOST_AUTO_TEST_CASE(user_context_device_mismatch)
 {
+//! [queue_mismatch]
     compute::device user_device = compute::system::devices().front();
     compute::context user_context(user_device);
     compute::command_queue user_queue(user_context, user_device);
 
     // Don't call default_device() or default_context() before calling 
-    // default_queue(command_queue* = 0) if you wish to attach your command queue
-    compute::system::default_device(); 
+    // default_queue() if you wish to attach your command queue
+    compute::system::default_context();
 
-    try 
-    {
-        compute::system::default_queue(&user_queue); 
-    }
-    catch (boost::compute::context_error& e) 
-    {
-        BOOST_CHECK_EQUAL(
-            std::string(e.what()), 
-            std::string("Error: User command queue mismatches default device and/or context")
-        );
-        return;
-    }
+    BOOST_CHECK_THROW(
+        compute::system::default_queue(user_queue),
+        compute::set_default_queue_error);
+//! [queue_mismatch]
 }

--- a/test/test_attach_user_queue_error.cpp
+++ b/test/test_attach_user_queue_error.cpp
@@ -1,0 +1,43 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2019 Anthony Chang <ac.chang@outlook.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE TestAttachUserQueueError
+#include <boost/test/unit_test.hpp>
+
+#include <boost/compute/context.hpp>
+#include <boost/compute/device.hpp>
+#include <boost/compute/system.hpp>
+
+namespace compute = boost::compute;
+
+// For correct usage of setting up global default queue, see test_system.cpp
+BOOST_AUTO_TEST_CASE(user_context_device_mismatch)
+{
+    compute::device user_device = compute::system::devices().front();
+    compute::context user_context(user_device);
+    compute::command_queue user_queue(user_context, user_device);
+
+    // Don't call default_device() or default_context() before calling 
+    // default_queue(command_queue* = 0) if you wish to attach your command queue
+    compute::system::default_device(); 
+
+    try 
+    {
+        compute::system::default_queue(&user_queue); 
+    }
+    catch (boost::compute::context_error& e) 
+    {
+        BOOST_CHECK_EQUAL(
+            std::string(e.what()), 
+            std::string("Error: User command queue mismatches default device and/or context")
+        );
+        return;
+    }
+}

--- a/test/test_attach_user_queue_thread_safety.cpp
+++ b/test/test_attach_user_queue_thread_safety.cpp
@@ -1,0 +1,74 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2019 Anthony Chang <ac.chang@outlook.com>
+//
+// Distributed under the Boost Software License, Version 1.0
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+// See http://boostorg.github.com/compute for more information.
+//---------------------------------------------------------------------------//
+
+#define BOOST_TEST_MODULE TestAttachUserQueueThreadSafety
+
+#ifdef BOOST_COMPUTE_USE_CPP11
+  #include <thread>
+  using std::thread;
+#else
+  #include <boost/thread.hpp>
+  using boost::thread;
+#endif 
+
+#include <boost/test/unit_test.hpp>
+
+#include <boost/compute/context.hpp>
+#include <boost/compute/device.hpp>
+#include <boost/compute/system.hpp>
+
+namespace compute = boost::compute;
+
+void attach_user_queue_worker_threads(
+    int id,
+    const compute::context& user_context,
+    const compute::device& user_device,
+    compute::command_queue* queues)
+{
+    compute::command_queue user_queue(user_context, user_device);
+    queues[id] = compute::system::default_queue(&user_queue);
+}
+
+BOOST_AUTO_TEST_CASE(user_default_context_thread_safety)
+{
+#ifdef BOOST_COMPUTE_THREAD_SAFE
+    const int num_threads = 16;
+
+    compute::command_queue queues[num_threads];
+    thread* threads[num_threads];
+    
+    compute::device user_device = compute::system::devices().front();
+    compute::context user_context(user_device);
+
+    for (int i = 0; i < num_threads; i++)
+    {
+        threads[i] = new thread(
+            attach_user_queue_worker_threads,
+            i, 
+            user_context, 
+            user_device,
+            queues
+        );
+    }
+
+    for (int i = 0; i < num_threads; i++)
+    {
+        threads[i]->join();
+        delete threads[i];
+    }
+
+    BOOST_CHECK_EQUAL(compute::system::default_context().get(), user_context.get());
+    BOOST_CHECK_EQUAL(compute::system::default_device().get(), user_device.get());
+    for (int i = 1; i < num_threads; i++)
+    {
+        BOOST_CHECK_EQUAL(queues[0].get(), queues[i].get());
+    }
+#endif
+}

--- a/test/test_attach_user_queue_thread_safety.cpp
+++ b/test/test_attach_user_queue_thread_safety.cpp
@@ -33,7 +33,7 @@ void attach_user_queue_worker_threads(
     compute::command_queue* queues)
 {
     compute::command_queue user_queue(user_context, user_device);
-    queues[id] = compute::system::default_queue(&user_queue);
+    queues[id] = compute::system::default_queue(user_queue);
 }
 
 BOOST_AUTO_TEST_CASE(user_default_context_thread_safety)

--- a/test/test_attach_user_queue_thread_safety.cpp
+++ b/test/test_attach_user_queue_thread_safety.cpp
@@ -38,7 +38,7 @@ void attach_user_queue_worker_threads(
 
 BOOST_AUTO_TEST_CASE(user_default_context_thread_safety)
 {
-#ifdef BOOST_COMPUTE_THREAD_SAFE
+#if defined(BOOST_COMPUTE_THREAD_SAFE) && defined(NDEBUG)
     const int num_threads = 16;
 
     compute::command_queue queues[num_threads];
@@ -70,5 +70,5 @@ BOOST_AUTO_TEST_CASE(user_default_context_thread_safety)
     {
         BOOST_CHECK_EQUAL(queues[0].get(), queues[i].get());
     }
-#endif
+#endif // defined(BOOST_COMPUTE_THREAD_SAFE) && defined(NDEBUG)
 }

--- a/test/test_system.cpp
+++ b/test/test_system.cpp
@@ -14,25 +14,46 @@
 #include <boost/compute/device.hpp>
 #include <boost/compute/system.hpp>
 
+namespace compute = boost::compute;
+
 BOOST_AUTO_TEST_CASE(platform_count)
 {
-    BOOST_CHECK(boost::compute::system::platform_count() >= 1);
+    BOOST_CHECK(compute::system::platform_count() >= 1);
 }
 
 BOOST_AUTO_TEST_CASE(device_count)
 {
-    BOOST_CHECK(boost::compute::system::device_count() >= 1);
+    BOOST_CHECK(compute::system::device_count() >= 1);
 }
 
 BOOST_AUTO_TEST_CASE(default_device)
 {
-    boost::compute::device device = boost::compute::system::default_device();
+    compute::device device = compute::system::default_device();
     BOOST_CHECK(device.id() != cl_device_id());
 }
 
+BOOST_AUTO_TEST_CASE(user_default_queue)
+{
+    compute::device device = compute::system::default_device();
+    compute::context context = compute::context(device);
+
+    compute::command_queue queue1(context, device);
+    {
+        compute::system::default_queue(&queue1);
+        compute::command_queue default_queue = compute::system::default_queue();
+        BOOST_ASSERT(queue1 == default_queue);
+    }
+    compute::command_queue queue2(context, device);
+    {
+        compute::system::default_queue(&queue2); // no longer settable after first initialization
+        compute::command_queue default_queue = compute::system::default_queue();
+        BOOST_ASSERT(queue2 != default_queue);
+        BOOST_ASSERT(queue1 == default_queue);
+    }
+}
 BOOST_AUTO_TEST_CASE(find_device)
 {
-    boost::compute::device device = boost::compute::system::default_device();
+    compute::device device = compute::system::default_device();
     const std::string &name = device.name();
-    BOOST_CHECK(boost::compute::system::find_device(name).name() == device.name());
+    BOOST_CHECK(compute::system::find_device(name).name() == device.name());
 }

--- a/test/test_system.cpp
+++ b/test/test_system.cpp
@@ -39,20 +39,21 @@ BOOST_AUTO_TEST_CASE(user_default_queue)
 
     compute::command_queue queue1(context, device);
     {
-        compute::system::default_queue(&queue1);
+        compute::system::default_queue(queue1);
         compute::command_queue default_queue = compute::system::default_queue();
-        BOOST_ASSERT(queue1 == default_queue);
+        BOOST_CHECK(queue1 == default_queue);
     }
 #ifdef NDEBUG
     compute::command_queue queue2(context, device);
     {
-        compute::system::default_queue(&queue2); // no longer settable after first initialization
+        compute::system::default_queue(queue2); // no longer settable after first initialization
         compute::command_queue default_queue = compute::system::default_queue();
-        BOOST_ASSERT(queue2 != default_queue);
-        BOOST_ASSERT(queue1 == default_queue);
+        BOOST_CHECK(queue2 != default_queue);
+        BOOST_CHECK(queue1 == default_queue);
     }
 #endif
 }
+
 BOOST_AUTO_TEST_CASE(find_device)
 {
     compute::device device = compute::system::default_device();

--- a/test/test_system.cpp
+++ b/test/test_system.cpp
@@ -43,6 +43,7 @@ BOOST_AUTO_TEST_CASE(user_default_queue)
         compute::command_queue default_queue = compute::system::default_queue();
         BOOST_ASSERT(queue1 == default_queue);
     }
+#ifdef NDEBUG
     compute::command_queue queue2(context, device);
     {
         compute::system::default_queue(&queue2); // no longer settable after first initialization
@@ -50,6 +51,7 @@ BOOST_AUTO_TEST_CASE(user_default_queue)
         BOOST_ASSERT(queue2 != default_queue);
         BOOST_ASSERT(queue1 == default_queue);
     }
+#endif
 }
 BOOST_AUTO_TEST_CASE(find_device)
 {


### PR DESCRIPTION
By doing so, the associated default device and context will automatically match the user-provided command queue. It

Guarantees unique default queue/device/context is returned when calling from multiple threads (requires config macro BOOST_COMPUTE_THREAD_SAFE)

Resolves issue #827