### PR TITLE
remove the redundant copy when move item to the front of the lru list in lru_cache.hpp

### DIFF
--- a/include/boost/compute/detail/lru_cache.hpp
+++ b/include/boost/compute/detail/lru_cache.hpp
@@ -93,16 +93,9 @@ public:
         typename list_type::iterator j = i->second.second;
         if(j != m_list.begin()){
             // move item to the front of the most recently used list
-            m_list.erase(j);
-            m_list.push_front(key);
-
-            // update iterator in map
-            j = m_list.begin();
-            const value_type &value = i->second.first;
-            m_map[key] = std::make_pair(value, j);
-
+            m_list.splice(m_list.begin(), m_list, j, std::next(j));
             // return the value
-            return value;
+            return i->second.first;
         }
         else {
             // the item is already at the front of the most recently


### PR DESCRIPTION
std::list<T,Allocator>::splice is the helper for to move list element in constant complexity.


Complexity
1-2) Constant.
3) Constant if other refers to the same object as *this, otherwise linear in std::distance(first, last).

Ref: https://en.cppreference.com/w/cpp/container/list/splice