### PR TITLE
Fix min-max extrema kernel code

### DIFF
--- a/include/boost/compute/algorithm/detail/find_extrema_on_cpu.hpp
+++ b/include/boost/compute/algorithm/detail/find_extrema_on_cpu.hpp
@@ -72,9 +72,8 @@ inline InputIterator find_extrema_on_cpu(InputIterator first,
         k.add_arg<uint_ *>(memory_object::global_memory, "output_idx");
 
     k <<
-        "uint block = " <<
-            "(uint)ceil(((float)count)/get_global_size(0));\n" <<
-        "uint index = get_global_id(0) * block;\n" <<
+        "uint block = (uint)ceil(((float)count)/get_global_size(0));\n" <<
+        "uint index = min(count - 1, (uint)get_global_id(0) * block);\n" <<
         "uint end = min(count, index + block);\n" <<
 
         "uint value_index = index;\n" <<

--- a/test/test_extrema.cpp
+++ b/test/test_extrema.cpp
@@ -158,6 +158,21 @@ BOOST_AUTO_TEST_CASE(int_min_max)
     BOOST_CHECK_EQUAL(max_iter.read(queue), 513);
 }
 
+BOOST_AUTO_TEST_CASE(int_unhandy_max)
+{
+    boost::compute::vector<int> vector(device.compute_units() * 10, context);
+
+    // fill with 0 -> 10 * device.compute_units()
+    boost::compute::iota(vector.begin(), vector.end(), 0, queue);
+    // Last compute unit may hit out of range if initial index isn't handled well
+    int unhandy = 2 * device.compute_units() + 1;
+
+    boost::compute::vector<int>::iterator max_iter =
+        boost::compute::max_element(vector.begin(), vector.begin() + unhandy, queue);
+    BOOST_CHECK(max_iter == (vector.begin() + unhandy - 1));
+    BOOST_CHECK_EQUAL(*max_iter, unhandy - 1);
+}
+
 BOOST_AUTO_TEST_CASE(int2_min_max_custom_comparision_function)
 {
     using boost::compute::int2_;


### PR DESCRIPTION
Due to ceiling a size of block, the index may be out of bounds. As index is always used, we must have it valid regardless `while (index < end)` condition.