### PR TITLE
Update sha1.hpp for breaking interface change in Boost.UUID

### DIFF
--- a/include/boost/compute/detail/sha1.hpp
+++ b/include/boost/compute/detail/sha1.hpp
@@ -37,12 +37,12 @@ class sha1 {
         }
 
         operator std::string() {
-            unsigned int digest[5];
+            unsigned char digest[20];
             h.get_digest(digest);
 
             std::ostringstream buf;
-            for(int i = 0; i < 5; ++i)
-                buf << std::hex << std::setfill('0') << std::setw(8) << digest[i];
+            for(int i = 0; i < 20; ++i)
+                buf << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(digest[i]);
 
             return buf.str();
         }


### PR DESCRIPTION
see https://github.com/boostorg/uuid/commit/0f843137a1a479797004f195ec615fdc6ac1c219

The interface is in detail namespace, so the breakage is not on the Boost.UUID maintainers