### PR TITLE
Link to OpenCL under Windows as well in test/Jamfile.v2

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -40,6 +40,7 @@ rule test_all
             <host-os>linux:<linkflags>"-lOpenCL"
             <host-os>darwin:<linkflags>"-framework OpenCL"
             <host-os>freebsd:<linkflags>"-lOpenCL"
+            <host-os>windows:<linkflags>"OpenCL.lib"
         ] ;
     }
 


### PR DESCRIPTION
This is necessary to make the tests link under Windows when b2 is used to run them.