### PR TITLE
Output digest[i] as an integer, rather than a character, in sha1.hpp

### DIFF
--- a/include/boost/compute/detail/sha1.hpp
+++ b/include/boost/compute/detail/sha1.hpp
@@ -48,7 +48,7 @@ class sha1 {
             std::ostringstream buf;
             #if BOOST_VERSION >= 108600
             for(int i = 0; i < 20; ++i)
-                buf << std::hex << std::setfill('0') << std::setw(2) << digest[i];
+                buf << std::hex << std::setfill('0') << std::setw(2) << +digest[i];
             #else
             for(int i = 0; i < 5; ++i)
                 buf << std::hex << std::setfill('0') << std::setw(8) << digest[i];


### PR DESCRIPTION
The fix in https://github.com/boostorg/compute/pull/887 is slightly incorrect, because `digest[i]` is `unsigned char` and is output as a character to `buf`. This changes it to be output as an integer, as intended.

It makes the test added in https://github.com/boostorg/compute/pull/892 pass.