### PR TITLE
Fix copy construction of LRU cache

### DIFF
--- a/include/boost/compute/detail/lru_cache.hpp
+++ b/include/boost/compute/detail/lru_cache.hpp
@@ -39,6 +39,28 @@ public:
     {
     }
 
+    // in case of default copying list iterators would be invalidated
+    lru_cache(const lru_cache& other)
+        : m_list(other.m_list),
+          m_capacity(other.m_capacity)
+    {
+        for(typename list_type::iterator i = m_list.begin(); i != m_list.end(); ++i){
+            m_map[*i] = std::make_pair(other.m_map.at(*i).first, i);
+        }
+    }
+
+    lru_cache& operator=(const lru_cache& other)
+    {
+        if(this != &other){
+            m_list = other.m_list;
+            m_capacity = other.m_capacity;
+            for(typename list_type::iterator i = m_list.begin(); i != m_list.end(); ++i){
+                m_map[*i] = std::make_pair(other.m_map.at(*i).first, i);
+            }
+        }
+        return *this;
+    }
+
     ~lru_cache()
     {
     }

--- a/include/boost/compute/detail/lru_cache.hpp
+++ b/include/boost/compute/detail/lru_cache.hpp
@@ -41,12 +41,8 @@ public:
 
     // in case of default copying list iterators would be invalidated
     lru_cache(const lru_cache& other)
-        : m_list(other.m_list),
-          m_capacity(other.m_capacity)
     {
-        for(typename list_type::iterator i = m_list.begin(); i != m_list.end(); ++i){
-            m_map[*i] = std::make_pair(other.m_map.at(*i).first, i);
-        }
+        lru_cache::operator=(other);
     }
 
     lru_cache& operator=(const lru_cache& other)
@@ -57,6 +53,21 @@ public:
             for(typename list_type::iterator i = m_list.begin(); i != m_list.end(); ++i){
                 m_map[*i] = std::make_pair(other.m_map.at(*i).first, i);
             }
+        }
+        return *this;
+    }
+
+    lru_cache(const lru_cache&& other) BOOST_NOEXCEPT
+    {
+        lru_cache::operator=(std::move(other));
+    }
+
+    lru_cache& operator==(lru_cache&& other) BOOST_NOEXCEPT
+    {
+        if(this != &other){
+            m_map = std::move(other.m_map);
+            m_list = std::move(other.m_list);
+            m_capacity = other.m_capacity;
         }
         return *this;
     }


### PR DESCRIPTION
The copy constructor of `boost::compute::detail::lru_cache` does not seem to work properly: the new map holds invalidated `std::list` iterators after its copying. I believe that the copy constructor should be deleted there at all (seems reasonable for this class), or iterators should be restored from the new list, that's done in this PR. 