### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,6 @@ target_link_libraries(boost_compute
     Boost::proto
     Boost::range
     Boost::smart_ptr
-    Boost::static_assert
     Boost::thread
     Boost::throw_exception
     Boost::tuple

--- a/build.jam
+++ b/build.jam
@@ -26,7 +26,6 @@ constant boost_dependencies :
     /boost/proto//boost_proto
     /boost/range//boost_range
     /boost/smart_ptr//boost_smart_ptr
-    /boost/static_assert//boost_static_assert
     /boost/thread//boost_thread
     /boost/throw_exception//boost_throw_exception
     /boost/tuple//boost_tuple


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.